### PR TITLE
feat(activity): add assertBeginEndPair helper

### DIFF
--- a/.changeset/1985-vault-region-pair.md
+++ b/.changeset/1985-vault-region-pair.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": minor
+---
+
+Add `assertBeginEndPair` to check a managed-region begin/end name pair. Empty names throw. A mismatch is `name_mismatch`. Part of #1985.

--- a/packages/remnic-core/src/activity/vault-region-pair.test.ts
+++ b/packages/remnic-core/src/activity/vault-region-pair.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertBeginEndPair } from "./vault-region-pair.js";
+
+test("assertBeginEndPair accepts a matching pair", () => {
+  assert.deepEqual(assertBeginEndPair({ beginName: "timeline", endName: "timeline" }), { ok: true });
+  assert.deepEqual(assertBeginEndPair({ beginName: "  timeline  ", endName: "timeline" }), {
+    ok: true,
+  });
+});
+
+test("assertBeginEndPair rejects a name mismatch", () => {
+  assert.deepEqual(assertBeginEndPair({ beginName: "timeline", endName: "weekly" }), {
+    ok: false,
+    error: "name_mismatch",
+  });
+});
+
+test("assertBeginEndPair throws on an empty name", () => {
+  assert.throws(() => assertBeginEndPair({ beginName: "", endName: "timeline" }), /empty/i);
+  assert.throws(() => assertBeginEndPair({ beginName: "timeline", endName: "   " }), /empty/i);
+});

--- a/packages/remnic-core/src/activity/vault-region-pair.test.ts
+++ b/packages/remnic-core/src/activity/vault-region-pair.test.ts
@@ -8,6 +8,9 @@ test("assertBeginEndPair accepts a matching pair", () => {
   assert.deepEqual(assertBeginEndPair({ beginName: "  timeline  ", endName: "timeline" }), {
     ok: true,
   });
+  assert.deepEqual(assertBeginEndPair({ beginName: "timeline", endName: "  timeline  " }), {
+    ok: true,
+  });
 });
 
 test("assertBeginEndPair rejects a name mismatch", () => {

--- a/packages/remnic-core/src/activity/vault-region-pair.ts
+++ b/packages/remnic-core/src/activity/vault-region-pair.ts
@@ -1,0 +1,24 @@
+/**
+ * Assert a managed-region begin/end name pair (issue #1985).
+ *
+ * Trim both names. Empty throws. Mismatch is name_mismatch. Else ok.
+ */
+
+export type BeginEndPairInput = {
+  beginName: string;
+  endName: string;
+};
+
+export type BeginEndPairResult = { ok: true } | { ok: false; error: "name_mismatch" };
+
+export function assertBeginEndPair({ beginName, endName }: BeginEndPairInput): BeginEndPairResult {
+  const begin = beginName.trim();
+  const end = endName.trim();
+  if (begin.length === 0 || end.length === 0) {
+    throw new RangeError("Region name must be non-empty.");
+  }
+  if (begin !== end) {
+    return { ok: false, error: "name_mismatch" };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Part of #1985

## Change
assertBeginEndPair. Trim both names. Mismatch fails. Empty throws.

## Test
packages/remnic-core/src/activity/vault-region-pair.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for matching begin and end region names.
  * Names are trimmed before comparison, allowing surrounding whitespace.
  * Matching names are accepted, while mismatches return a clear validation result.
* **Bug Fixes**
  * Empty or whitespace-only region names now produce an explicit validation error.
* **Tests**
  * Added coverage for matching, mismatched, whitespace-padded, and empty names.
* **Release**
  * Included a minor release update for the validation enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->