### PR TITLE
Potential fix for code scanning alert no. 227: Clear-text logging of sensitive information

### DIFF
--- a/packages/remnic-cli/src/commands/export-okf.ts
+++ b/packages/remnic-cli/src/commands/export-okf.ts
@@ -34,22 +34,10 @@ export async function runExportOkfBinaryCommand(rest: string[]): Promise<void> {
     try {
       const rawConfig = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
       config = parseConfig(resolveRemnicConfigRecord(rawConfig));
-    } catch (err) {
-      // parseConfig error strings embed raw config values — an unresolved
-      // ${...} placeholder is the key's own text — so err.message must not
-      // reach console output (CodeQL js/clear-text-logging).
-      //
-      // Nothing derived from the config is logged either. Three earlier
-      // attempts each failed: redacting the parsed object (taint analysis
-      // cannot see through a generic redactor, and a key deny-list is only as
-      // complete as its last edit), describing its shape (still reads every
-      // value), and scanning the file text for key names (CodeQL treats the
-      // text as sensitive once a credential is parsed out of it, and a
-      // malformed file repeatedly let a value be read as a key). The only
-      // amount of config-derived logging that is safe is none.
-      console.error(
-        `export-okf: failed to load config at ${configPath} (${err instanceof Error ? err.name : "unknown error"})`,
-      );
+    } catch {
+      // parseConfig error strings can embed raw config values (including
+      // resolved secrets), so this path must only emit fixed text.
+      console.error("export-okf: failed to load config");
       console.error("  config values are never printed; inspect the file directly");
       process.exitCode = 1;
       return;
@@ -71,8 +59,8 @@ export async function runExportOkfBinaryCommand(rest: string[]): Promise<void> {
     });
     if (result.plaintextWarning) console.log("PLAINTEXT EXPORT: the OKF bundle is unencrypted.");
     console.log(`OKF export: ${result.exported} concepts, ${result.excluded} excluded`);
-  } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+  } catch {
+    console.error("export-okf: command failed");
     process.exitCode = 1;
   } finally {
     orchestrator?.abortDeferredInit();


### PR DESCRIPTION
Potential fix for [https://github.com/joshuaswarren/remnic/security/code-scanning/227](https://github.com/joshuaswarren/remnic/security/code-scanning/227)

Best fix: stop logging exception-derived free text (`err.message`, `String(err)`, and tainted interpolation context) in this command, and replace with fixed, non-sensitive messages plus optional non-sensitive error type classification.

In `packages/remnic-cli/src/commands/export-okf.ts`:
- In the inner `catch (err)` (config load/parse), replace the current interpolated message (line 51) with a constant message that does **not** include `configPath` or any `err` data.
- In the outer `catch (err)`, replace `console.error(err instanceof Error ? err.message : String(err));` with a constant message (or constant + safe code), so no exception payload is emitted.
- Keep existing exit behavior unchanged (`process.exitCode = 1; return;`) so functionality remains the same except for safer logs.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export command error handling by displaying consistent, non-sensitive messages when configuration loading or command execution fails.
  * Preserved existing exit codes and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->