### PR TITLE
Potential fix for code scanning alert no. 226: Clear-text logging of sensitive information

### DIFF
--- a/packages/remnic-cli/src/commands/codegraph.ts
+++ b/packages/remnic-cli/src/commands/codegraph.ts
@@ -53,9 +53,7 @@ export async function runCodegraphBinaryCommand(rest: string[]): Promise<void> {
       // text as sensitive once a credential is parsed out of it, and a
       // malformed file repeatedly let a value be read as a key). The only
       // amount of config-derived logging that is safe is none.
-      console.error(
-        `codegraph export-okf: failed to load config at ${configPath} (${err instanceof Error ? err.name : "unknown error"})`,
-      );
+      console.error(`codegraph export-okf: failed to load config at ${configPath}`);
       console.error("  config values are never printed; inspect the file directly");
       process.exitCode = 1;
       return;
@@ -78,8 +76,8 @@ export async function runCodegraphBinaryCommand(rest: string[]): Promise<void> {
       `OKF codegraph export: ${result.moduleConcepts} modules, ${result.decisions} decisions` +
         (result.truncated ? " (truncated)" : ""),
     );
-  } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
+  } catch (_err) {
+    console.error("codegraph export-okf: command failed");
     process.exitCode = 1;
   } finally {
     orchestrator?.abortDeferredInit();


### PR DESCRIPTION
Potential fix for [https://github.com/joshuaswarren/remnic/security/code-scanning/226](https://github.com/joshuaswarren/remnic/security/code-scanning/226)

General fix: avoid logging exception messages or any values derived from parsed config/env secrets; log only fixed, non-sensitive diagnostic text.

Best minimal fix (without changing functionality): in `packages/remnic-cli/src/commands/codegraph.ts`, replace both vulnerable error logs with constant/sanitized messages:
1. In the inner `catch` around config parse, remove interpolation of `err` (including `err.name`) and keep a static failure message.
2. In the outer `catch`, stop printing `err.message` and print a static generic command-failure message.

This preserves behavior (command still fails with exit code 1 and gives operator guidance) while removing clear-text secret exposure paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line error handling by replacing detailed failure messages with clear, generic safety notices.
  * Prevented configuration and command errors from exposing internal exception details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->