### PR TITLE
docs(contributing): document the issue claim protocol

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Issues are worked first-come, first-served — by humans and automated agents al
 2. Self-assign the issue (or ask a maintainer to assign you).
 3. A maintainer will apply the `contributor-claimed` label.
 
-A claimed issue is off-limits to everyone else, including this repository's automated maintenance agents; they check labels, assignees, and comments before picking issues and again before opening or merging any PR. If your PR references a claimed issue (`Fixes #<n>`), maintainers will hold it for your review before merging anything else against it.
+If a PR from someone other than the claimant references a claimed issue (`Fixes #<n>`), maintainers must not merge it while the claim is active. The claimant must release the claim, or a maintainer must follow the stale-claim process, before another PR is merged against the issue.
 
 If you stop working on a claimed issue, comment to release it so someone else can pick it up. Stale claims (no activity for ~30 days) may be released by a maintainer after a ping.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,18 @@ Thanks for contributing. Issues and pull requests are welcome from humans and AI
 2. For non-trivial changes, open an issue first and propose the approach and scope.
 3. Keep PRs narrow: one subsystem group per PR. If work spans schema/surface contracts, storage/serialization, and retrieval behavior, split it before review.
 
+## Claiming an issue
+
+Issues are worked first-come, first-served — by humans and automated agents alike. To reserve an issue:
+
+1. Comment on the issue stating you are taking it.
+2. Self-assign the issue (or ask a maintainer to assign you).
+3. A maintainer will apply the `contributor-claimed` label.
+
+A claimed issue is off-limits to everyone else, including this repository's automated maintenance agents; they check labels, assignees, and comments before picking issues and again before opening or merging any PR. If your PR references a claimed issue (`Fixes #<n>`), maintainers will hold it for your review before merging anything else against it.
+
+If you stop working on a claimed issue, comment to release it so someone else can pick it up. Stale claims (no activity for ~30 days) may be released by a maintainer after a ping.
+
 ## Development setup
 
 Requires Node.js `>=22.12.0` and [pnpm](https://pnpm.io/).


### PR DESCRIPTION
Follow-up to #2712: an external contributor claimed an issue, the automated loop implemented it anyway, and the PR merged before the reservation was seen.

- Adds a **Claiming an issue** section: comment + self-assign + `contributor-claimed` label.
- States that claims are binding for automated agents, who re-check labels/assignees/comments before picking, before opening, and before merging a PR.
- Defines claim release (comment to release; maintainer ping after ~30 days idle).

Paired with: `contributor-claimed`, `meta-loop-excluded`, and `agent-working` labels now on the repo, and the loop prompt updated to run a live claim gate three times per issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for claiming issues, identifying active claims, and releasing or expiring stale claims.
  * Clarified when pull requests from non-claimants may be merged while an issue claim remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->