### PR TITLE
fix(observe): persist observe-derived turns to the transcript store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- The daemon's observe path now persists observe-derived turns to the transcript store (with bounded re-POST dedupe), and `memory_summarize_hourly` reports counts plus an explicit warning when the store is empty or stale instead of an unconditional bare ok — delegate-mode gateways no longer silently starve the hourly summarizer (`#2783`).
+
 ## [v9.69.16] — 2026-08-22
 
 ### Added

--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -408,7 +408,16 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     elapsedMs: T_NUMBER,
     skippedReason: T_STRING,
   }),
-  memory_summarize_hourly: objectSchema({ ok: T_BOOLEAN, message: T_STRING }),
+  memory_summarize_hourly: objectSchema({
+    ok: T_BOOLEAN,
+    message: T_STRING,
+    sessionsConsidered: T_NUMBER,
+    sessionsWithEntries: T_NUMBER,
+    summariesWritten: T_NUMBER,
+    staleStore: T_BOOLEAN,
+    newestEntryTimestamp: T_NULLABLE_STRING,
+    warning: T_STRING,
+  }),
   conversation_index_update: objectSchema({
     enabled: T_BOOLEAN,
     sessions: T_NUMBER,

--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -18,7 +18,7 @@ const T_NULLABLE_STRING = { type: ["string", "null"] } as const;
 /** Build a JSON Schema object type with the given properties. */
 function objectSchema(
   properties: Record<string, Readonly<Record<string, unknown>>>,
-  required?: readonly string[],
+  required?: readonly string[]
 ): Record<string, unknown> {
   return {
     type: "object",
@@ -82,8 +82,20 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     skipped: T_NUMBER,
     removed: T_ARRAY,
   }),
-  deep_recall: objectSchema({ ok: T_BOOLEAN, error: T_NULLABLE_STRING, entries: T_ARRAY, trace: T_ARRAY, rendered: T_STRING }, ["entries", "trace"]),
-  standup: objectSchema({ date: T_STRING, yesterday: T_STRING, today: T_STRING, highlights: T_ARRAY, priorities: T_ARRAY, blockers: T_ARRAY, activityGrid: T_STRING, markdown: T_STRING }),
+  deep_recall: objectSchema(
+    { ok: T_BOOLEAN, error: T_NULLABLE_STRING, entries: T_ARRAY, trace: T_ARRAY, rendered: T_STRING },
+    ["entries", "trace"]
+  ),
+  standup: objectSchema({
+    date: T_STRING,
+    yesterday: T_STRING,
+    today: T_STRING,
+    highlights: T_ARRAY,
+    priorities: T_ARRAY,
+    blockers: T_ARRAY,
+    activityGrid: T_STRING,
+    markdown: T_STRING,
+  }),
   action_confidence: objectSchema({
     schemaVersion: T_NUMBER,
     decision: T_STRING,
@@ -176,6 +188,7 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     effectiveNamespace: T_STRING,
     lcmArchived: T_BOOLEAN,
     extractionQueued: T_BOOLEAN,
+    transcriptPersisted: T_BOOLEAN,
   }),
   lcm_search: objectSchema({
     query: T_STRING,
@@ -274,42 +287,45 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     guidelineVersion: { type: ["number", "null"] } as const,
   }),
   memory_search: objectSchema({ query: T_STRING, results: T_ARRAY, count: T_NUMBER }),
-  external_wiki_search: objectSchema({
-    query: T_STRING,
-    hits: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          wikiId: T_STRING,
-          title: T_STRING,
-          path: T_STRING,
-          snippet: T_STRING,
-          score: T_NUMBER,
-          rank: T_NUMBER,
-          citations: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                path: T_STRING,
-                lineStart: T_NUMBER,
-                lineEnd: T_NUMBER,
-                note: T_STRING,
+  external_wiki_search: objectSchema(
+    {
+      query: T_STRING,
+      hits: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            wikiId: T_STRING,
+            title: T_STRING,
+            path: T_STRING,
+            snippet: T_STRING,
+            score: T_NUMBER,
+            rank: T_NUMBER,
+            citations: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  path: T_STRING,
+                  lineStart: T_NUMBER,
+                  lineEnd: T_NUMBER,
+                  note: T_STRING,
+                },
+                required: ["path", "lineStart", "lineEnd", "note"],
+                additionalProperties: false,
               },
-              required: ["path", "lineStart", "lineEnd", "note"],
-              additionalProperties: false,
             },
+            indexBlurb: T_STRING,
           },
-          indexBlurb: T_STRING,
+          required: ["wikiId", "title", "path", "snippet", "score", "rank", "citations"],
+          additionalProperties: false,
         },
-        required: ["wikiId", "title", "path", "snippet", "score", "rank", "citations"],
-        additionalProperties: false,
       },
+      count: T_NUMBER,
+      degradedWikiIds: T_ARRAY,
     },
-    count: T_NUMBER,
-    degradedWikiIds: T_ARRAY,
-  }, ["query", "hits", "count", "degradedWikiIds"]),
+    ["query", "hits", "count", "degradedWikiIds"]
+  ),
   memory_profile: objectSchema({ profile: T_STRING }),
   memory_entities_list: objectSchema({ entities: T_ARRAY, count: T_NUMBER }),
   memory_questions: objectSchema({ questions: T_ARRAY, count: T_NUMBER }),
@@ -416,6 +432,7 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     summariesWritten: T_NUMBER,
     staleStore: T_BOOLEAN,
     newestEntryTimestamp: T_NULLABLE_STRING,
+    scanFailed: T_BOOLEAN,
     warning: T_STRING,
   }),
   conversation_index_update: objectSchema({

--- a/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
+++ b/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
@@ -231,3 +231,22 @@ test("skip-listed channel types report transcriptPersisted=false, not a silent s
     assert.equal(entries.length, 0);
   });
 });
+
+test("overlapping identical observes do not double-append the same turn (#2783 review)", async () => {
+  await withTempDir(async (dir) => {
+    const { service } = makeService(dir, true);
+    const [a, b] = await Promise.all([
+      service.observe({
+        sessionKey: "agent:overlap:s1",
+        messages: [{ role: "user", content: "the same turn submitted concurrently by a retrying client" }],
+      }),
+      service.observe({
+        sessionKey: "agent:overlap:s1",
+        messages: [{ role: "user", content: "the same turn submitted concurrently by a retrying client" }],
+      }),
+    ]);
+    const entries = await readAllTranscriptLines(dir);
+    assert.equal(entries.length, 1);
+    assert.equal(a.transcriptPersisted !== b.transcriptPersisted, true);
+  });
+});

--- a/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
+++ b/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
@@ -28,12 +28,13 @@ interface StubOrchestrator {
 
 function makeService(
   memoryDir: string,
-  transcriptEnabled: boolean
+  transcriptEnabled: boolean,
+  transcriptSkipChannelTypes: string[] = []
 ): { service: EngramAccessService; orchestrator: StubOrchestrator } {
   const config = {
     memoryDir,
     transcriptEnabled,
-    transcriptSkipChannelTypes: [],
+    transcriptSkipChannelTypes,
     namespacesEnabled: false,
     defaultNamespace: "default",
   } as unknown as PluginConfig;
@@ -214,4 +215,19 @@ test("observeTranscriptSessionKey scopes transcripts to the effective write name
   // A default-store write keeps the raw key (single-store deployments
   // unchanged, mirroring the LCM archive key rules).
   assert.equal(observeTranscriptSessionKey("agent:shared-key:s1", "generalist", config), "agent:shared-key:s1");
+});
+
+test("skip-listed channel types report transcriptPersisted=false, not a silent success (#2783 review)", async () => {
+  await withTempDir(async (dir) => {
+    // cron is in the default skip list; a session whose channel type
+    // resolves to it must not report persisted=true for a no-op append.
+    const { service } = makeService(dir, true, ["cron"]);
+    const response = await service.observe({
+      sessionKey: "agent:nightly:cron:job-1",
+      messages: [{ role: "user", content: "this nightly cron turn must not claim transcript persistence" }],
+    });
+    assert.equal(response.transcriptPersisted, false);
+    const entries = await readAllTranscriptLines(dir);
+    assert.equal(entries.length, 0);
+  });
 });

--- a/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
+++ b/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Issue #2783: the daemon's observe path must persist observe-derived turns
+ * into the transcript store, and `memory_summarize_hourly` must report an
+ * empty/stale transcript store distinctly instead of a bare unconditional
+ * ok. Delegate-mode gateways (and any observe-only client) starve the
+ * hourly summarizer otherwise — 11 days of silent empty runs in the field.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import { HourlySummarizer } from "./summarizer.js";
+import { Orchestrator } from "./orchestrator.js";
+import { TranscriptManager } from "./transcript.js";
+import type { CodingContext, PluginConfig } from "./types.js";
+
+interface StubOrchestrator {
+  config: PluginConfig;
+  transcript: TranscriptManager;
+  summarizer: HourlySummarizer;
+  lcmEngine?: undefined;
+  ingestReplayBatch: () => Promise<unknown[]>;
+  _codingContextBySession: Map<string, CodingContext>;
+}
+
+function makeService(memoryDir: string, transcriptEnabled: boolean): { service: EngramAccessService; orchestrator: StubOrchestrator } {
+  const config = {
+    memoryDir,
+    transcriptEnabled,
+    transcriptSkipChannelTypes: [],
+    namespacesEnabled: false,
+    defaultNamespace: "default",
+  } as unknown as PluginConfig;
+  const orch = Object.create(Orchestrator.prototype) as Orchestrator;
+  const stub: StubOrchestrator = {
+    config,
+    transcript: new TranscriptManager(config),
+    summarizer: new HourlySummarizer(config),
+    lcmEngine: undefined,
+    ingestReplayBatch: async () => [],
+    _codingContextBySession: new Map<string, CodingContext>(),
+  };
+  Object.assign(orch as unknown as Record<string, unknown>, stub);
+  return { service: new EngramAccessService(orch), orchestrator: stub };
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-2783-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function readAllTranscriptLines(dir: string): Promise<Array<Record<string, unknown>>> {
+  const root = path.join(dir, "transcripts");
+  const entries: Array<Record<string, unknown>> = [];
+  const typeDirs = await readdir(root, { withFileTypes: true }).catch(() => []);
+  for (const typeEnt of typeDirs) {
+    if (!typeEnt.isDirectory()) continue;
+    const idDirs = await readdir(path.join(root, typeEnt.name), { withFileTypes: true });
+    for (const idEnt of idDirs) {
+      if (!idEnt.isDirectory()) continue;
+      const files = await readdir(path.join(root, typeEnt.name, idEnt.name));
+      for (const file of files) {
+        if (!file.endsWith(".jsonl")) continue;
+        const raw = await readFile(path.join(root, typeEnt.name, idEnt.name, file), "utf-8");
+        for (const line of raw.split("\n")) {
+          if (line.trim().length === 0) continue;
+          entries.push(JSON.parse(line) as Record<string, unknown>);
+        }
+      }
+    }
+  }
+  return entries;
+}
+
+const USER_TURN = "please summarize the replication topology for the fleet";
+const ASSISTANT_TURN = "the fleet uses one primary daemon with a replicated failover copy";
+
+test("observe persists user and assistant turns into the transcript store (#2783)", async () => {
+  await withTempDir(async (dir) => {
+    const { service } = makeService(dir, true);
+    const response = await service.observe({
+      sessionKey: "agent:delegate-test:session-1",
+      messages: [
+        { role: "user", content: USER_TURN },
+        { role: "assistant", content: ASSISTANT_TURN },
+      ],
+    });
+    assert.equal(response.transcriptPersisted, true);
+    const entries = await readAllTranscriptLines(dir);
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0]?.role, "user");
+    assert.equal(entries[0]?.content, USER_TURN);
+    assert.equal(entries[0]?.sessionKey, "agent:delegate-test:session-1");
+    assert.equal(entries[1]?.role, "assistant");
+    assert.equal(entries[1]?.content, ASSISTANT_TURN);
+    assert.equal(typeof entries[0]?.turnId, "string");
+    assert.equal(typeof entries[0]?.timestamp, "string");
+  });
+});
+
+test("observe filters short messages below the embedded parity noise floor (#2783)", async () => {
+  await withTempDir(async (dir) => {
+    const { service } = makeService(dir, true);
+    const response = await service.observe({
+      sessionKey: "agent:delegate-test:session-2",
+      messages: [
+        { role: "user", content: "ok" },
+        { role: "assistant", content: ASSISTANT_TURN },
+      ],
+    });
+    assert.equal(response.transcriptPersisted, true);
+    const entries = await readAllTranscriptLines(dir);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.role, "assistant");
+  });
+});
+
+test("a re-POST of the same user turn is deduped; new turns still append (#2783)", async () => {
+  await withTempDir(async (dir) => {
+    const { service } = makeService(dir, true);
+    await service.observe({
+      sessionKey: "agent:delegate-test:session-3",
+      messages: [
+        { role: "user", content: USER_TURN },
+        { role: "assistant", content: ASSISTANT_TURN },
+      ],
+    });
+    // Un-keyed client retry of the SAME turn (no idempotencyKey).
+    await service.observe({
+      sessionKey: "agent:delegate-test:session-3",
+      messages: [
+        { role: "user", content: USER_TURN },
+        { role: "assistant", content: ASSISTANT_TURN },
+      ],
+    });
+    const afterRetry = await readAllTranscriptLines(dir);
+    assert.equal(afterRetry.length, 2);
+
+    // A genuinely new turn still appends.
+    await service.observe({
+      sessionKey: "agent:delegate-test:session-3",
+      messages: [{ role: "user", content: "now check the failover read path end to end please" }],
+    });
+    const afterNew = await readAllTranscriptLines(dir);
+    assert.equal(afterNew.length, 3);
+  });
+});
+
+test("transcript persistence is gated on the transcriptEnabled capability (#2783)", async () => {
+  await withTempDir(async (dir) => {
+    const { service } = makeService(dir, false);
+    const response = await service.observe({
+      sessionKey: "agent:delegate-test:session-4",
+      messages: [{ role: "user", content: USER_TURN }],
+    });
+    assert.equal(response.transcriptPersisted, false);
+    const entries = await readAllTranscriptLines(dir);
+    assert.equal(entries.length, 0);
+  });
+});
+
+test("memory_summarize_hourly warns distinctly when the transcript store is empty (#2783)", async () => {
+  await withTempDir(async (dir) => {
+    const { service } = makeService(dir, true);
+    const result = await service.memorySummarizeHourly();
+    assert.equal(result.ok, true);
+    assert.equal(result.sessionsConsidered, 0);
+    assert.equal(result.warning, "transcript store is empty");
+    assert.match(result.message, /transcript store is empty/);
+  });
+});
+
+test("memory_summarize_hourly warns distinctly when the store is stale and the hour was idle (#2783)", async () => {
+  await withTempDir(async (dir) => {
+    const { service, orchestrator } = makeService(dir, true);
+    // Seed one transcript entry far in the past: the store is non-empty but
+    // stale, and the target hour has no entries.
+    await orchestrator.transcript.append({
+      timestamp: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
+      role: "user",
+      content: "an old turn from a much earlier hour",
+      sessionKey: "agent:delegate-test:session-5",
+      turnId: "seed-turn",
+    });
+    const result = await service.memorySummarizeHourly();
+    assert.equal(result.ok, true);
+    assert.ok(result.sessionsConsidered > 0);
+    assert.equal(result.sessionsWithEntries, 0);
+    assert.equal(result.staleStore, true);
+    assert.equal(result.warning, "no transcript entries for the target hour and no new entries recently");
+  });
+});

--- a/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
+++ b/packages/remnic-core/src/access-observe-transcript-persistence.test.ts
@@ -26,7 +26,10 @@ interface StubOrchestrator {
   _codingContextBySession: Map<string, CodingContext>;
 }
 
-function makeService(memoryDir: string, transcriptEnabled: boolean): { service: EngramAccessService; orchestrator: StubOrchestrator } {
+function makeService(
+  memoryDir: string,
+  transcriptEnabled: boolean
+): { service: EngramAccessService; orchestrator: StubOrchestrator } {
   const config = {
     memoryDir,
     transcriptEnabled,
@@ -196,4 +199,19 @@ test("memory_summarize_hourly warns distinctly when the store is stale and the h
     assert.equal(result.staleStore, true);
     assert.equal(result.warning, "no transcript entries for the target hour and no new entries recently");
   });
+});
+
+test("observeTranscriptSessionKey scopes transcripts to the effective write namespace (#2783 review)", async () => {
+  const { observeTranscriptSessionKey } = await import("./access-observe-transcript.js");
+  const config = { defaultNamespace: "generalist" } as { defaultNamespace: string };
+  // Same client-controlled sessionKey from two principals in different
+  // namespaces must not share one transcript identity.
+  const a = observeTranscriptSessionKey("agent:shared-key:s1", "project-origin-aaa", config);
+  const b = observeTranscriptSessionKey("agent:shared-key:s1", "project-origin-bbb", config);
+  assert.notEqual(a, b);
+  assert.ok(a.includes("project-origin-aaa"));
+  assert.ok(b.includes("project-origin-bbb"));
+  // A default-store write keeps the raw key (single-store deployments
+  // unchanged, mirroring the LCM archive key rules).
+  assert.equal(observeTranscriptSessionKey("agent:shared-key:s1", "generalist", config), "agent:shared-key:s1");
 });

--- a/packages/remnic-core/src/access-observe-transcript.ts
+++ b/packages/remnic-core/src/access-observe-transcript.ts
@@ -24,6 +24,14 @@ import type { TranscriptEntry } from "./types.js";
 
 const OBSERVE_TRANSCRIPT_DEDUPE_MAX_ENTRIES = 8192;
 const OBSERVE_TRANSCRIPT_MIN_CONTENT_CHARS = 10;
+/**
+ * A fingerprint only suppresses re-POSTs inside this window. A client retry
+ * lands seconds later; a session LEGITIMATELY repeating the same >10-char
+ * turn usually does so minutes or hours later, and that repeat is a real
+ * conversation event the transcripts must keep (review: preserve legitimate
+ * repeated turns).
+ */
+const OBSERVE_TRANSCRIPT_DEDUPE_TTL_MS = 10 * 60 * 1000;
 
 /**
  * The transcript-side session identity for an observe payload (issue #2783
@@ -46,7 +54,7 @@ export function observeTranscriptSessionKey(
 
 /** Bounded FIFO of seen fingerprints; insertion order is the eviction order. */
 export class ObserveTranscriptPersister {
-  private readonly seenFingerprints = new Set<string>();
+  private readonly seenFingerprintsAt = new Map<string, number>();
 
   /**
    * Append every eligible message of an observe payload to the per-session
@@ -59,6 +67,13 @@ export class ObserveTranscriptPersister {
     messages: ReadonlyArray<{ role: string; content: string }>
   ): Promise<boolean> {
     let persisted = false;
+    // TranscriptManager.append silently no-ops for skip-listed channel types
+    // (cron by default) — check BEFORE appending so the response's
+    // transcriptPersisted stays truthful (review: report skipped appends).
+    const { channelType } = orchestrator.transcript.getTranscriptPath(sessionKey);
+    if (orchestrator.config.transcriptSkipChannelTypes.includes(channelType)) {
+      return false;
+    }
     for (const message of messages) {
       if (message.content.length < OBSERVE_TRANSCRIPT_MIN_CONTENT_CHARS) continue;
       // Fixed-size digest, never the raw content: 8192 retained entries of
@@ -67,7 +82,10 @@ export class ObserveTranscriptPersister {
       const fingerprint = createHash("sha256")
         .update(`${sessionKey}\0${message.role}\0${message.content}`)
         .digest("hex");
-      if (this.seenFingerprints.has(fingerprint)) continue;
+      const nowMs = Date.now();
+      const seenAt = this.seenFingerprintsAt.get(fingerprint);
+      if (seenAt !== undefined && nowMs - seenAt < OBSERVE_TRANSCRIPT_DEDUPE_TTL_MS) continue;
+      this.seenFingerprintsAt.delete(fingerprint);
       const entry: TranscriptEntry = {
         timestamp: new Date().toISOString(),
         role: message.role as TranscriptEntry["role"],
@@ -92,10 +110,10 @@ export class ObserveTranscriptPersister {
   }
 
   private remember(fingerprint: string): void {
-    this.seenFingerprints.add(fingerprint);
-    if (this.seenFingerprints.size > OBSERVE_TRANSCRIPT_DEDUPE_MAX_ENTRIES) {
-      const oldest = this.seenFingerprints.keys().next().value;
-      if (typeof oldest === "string") this.seenFingerprints.delete(oldest);
+    this.seenFingerprintsAt.set(fingerprint, Date.now());
+    if (this.seenFingerprintsAt.size > OBSERVE_TRANSCRIPT_DEDUPE_MAX_ENTRIES) {
+      const oldest = this.seenFingerprintsAt.keys().next().value;
+      if (typeof oldest === "string") this.seenFingerprintsAt.delete(oldest);
     }
   }
 }

--- a/packages/remnic-core/src/access-observe-transcript.ts
+++ b/packages/remnic-core/src/access-observe-transcript.ts
@@ -55,6 +55,8 @@ export function observeTranscriptSessionKey(
 /** Bounded FIFO of seen fingerprints; insertion order is the eviction order. */
 export class ObserveTranscriptPersister {
   private readonly seenFingerprintsAt = new Map<string, number>();
+  /** In-flight appends by fingerprint: an overlapping identical observe waits for the first append instead of double-writing. */
+  private readonly inflightAppends = new Map<string, Promise<void>>();
 
   /**
    * Append every eligible message of an observe payload to the per-session
@@ -85,7 +87,18 @@ export class ObserveTranscriptPersister {
       const nowMs = Date.now();
       const seenAt = this.seenFingerprintsAt.get(fingerprint);
       if (seenAt !== undefined && nowMs - seenAt < OBSERVE_TRANSCRIPT_DEDUPE_TTL_MS) continue;
-      this.seenFingerprintsAt.delete(fingerprint);
+      // Two identical observes can overlap before either records its
+      // fingerprint; both would then append and the transcript would carry
+      // the turn twice. Serialize per fingerprint: the second caller waits
+      // for the first append, re-checks the completed set, and skips.
+      const inflight = this.inflightAppends.get(fingerprint);
+      if (inflight) {
+        await inflight;
+        const seenAfter = this.seenFingerprintsAt.get(fingerprint);
+        if (seenAfter !== undefined && Date.now() - seenAfter < OBSERVE_TRANSCRIPT_DEDUPE_TTL_MS) {
+          continue;
+        }
+      }
       const entry: TranscriptEntry = {
         timestamp: new Date().toISOString(),
         role: message.role as TranscriptEntry["role"],
@@ -93,18 +106,28 @@ export class ObserveTranscriptPersister {
         sessionKey,
         turnId: randomUUID(),
       };
-      try {
-        await orchestrator.transcript.append(entry);
-        // Remember only after a successful append: a transient failure must
-        // not permanently swallow the turn — the client's retry has to be
-        // able to re-append it (review round 2).
-        this.remember(fingerprint);
-        persisted = true;
-      } catch (err) {
-        // Same policy as the LCM enqueue in the observe path: transcript
-        // persistence must never fail the observe itself.
-        log.error(`access-observe transcript append failed: ${err}`);
-      }
+      // Register BEFORE awaiting: the check-then-register sequence above has
+      // no await between its steps, so exactly one overlapping caller starts
+      // the append; the others wait on the inflight promise and re-check.
+      const appendPromise = orchestrator.transcript
+        .append(entry)
+        .then(() => {
+          // Remember only after a successful append: a transient failure must
+          // not permanently swallow the turn — the client's retry has to be
+          // able to re-append it (review round 2).
+          this.remember(fingerprint);
+          persisted = true;
+        })
+        .catch((err) => {
+          // Same policy as the LCM enqueue in the observe path: transcript
+          // persistence must never fail the observe itself.
+          log.error(`access-observe transcript append failed: ${err}`);
+        })
+        .finally(() => {
+          this.inflightAppends.delete(fingerprint);
+        });
+      this.inflightAppends.set(fingerprint, appendPromise);
+      await appendPromise;
     }
     return persisted;
   }

--- a/packages/remnic-core/src/access-observe-transcript.ts
+++ b/packages/remnic-core/src/access-observe-transcript.ts
@@ -44,7 +44,7 @@ export class ObserveTranscriptPersister {
         role: message.role as TranscriptEntry["role"],
         content: message.content,
         sessionKey,
-        turnId: crypto.randomUUID(),
+        turnId: randomUUID(),
       };
       try {
         await orchestrator.transcript.append(entry);

--- a/packages/remnic-core/src/access-observe-transcript.ts
+++ b/packages/remnic-core/src/access-observe-transcript.ts
@@ -1,0 +1,68 @@
+/**
+ * Observe-derived transcript persistence (issue #2783).
+ *
+ * Delegate-mode gateways POST every turn to `/observe`; without a transcript
+ * append in the daemon's observe path the transcript store never grows and
+ * the hourly summarizer starves silently while every run reports ok. This
+ * module is that append: it mirrors the embedded runtime's `agent_end`
+ * handler (src/index.ts) — same `TranscriptManager`, same entry shape, same
+ * `transcriptEnabled` presentation gate, same 10-char noise floor.
+ *
+ * Turns are deduped against a bounded process-lifetime (session, role,
+ * content) fingerprint — the daemon-side equivalent of the embedded
+ * runtime's `observedInboundContentFingerprints`, extended to both roles
+ * because an un-keyed client re-POST always carries the whole turn — so a
+ * retry cannot double-write it.
+ */
+
+import { randomUUID } from "node:crypto";
+import { log } from "./logger.js";
+import type { Orchestrator } from "./orchestrator.js";
+import type { TranscriptEntry } from "./types.js";
+
+const OBSERVE_TRANSCRIPT_DEDUPE_MAX_ENTRIES = 8192;
+const OBSERVE_TRANSCRIPT_MIN_CONTENT_CHARS = 10;
+
+/** Bounded FIFO of seen fingerprints; insertion order is the eviction order. */
+export class ObserveTranscriptPersister {
+  private readonly seenFingerprints = new Set<string>();
+
+  /**
+   * Append every eligible message of an observe payload to the per-session
+   * transcript store. Best-effort: a failing append logs and does not fail
+   * the observe. Returns true when at least one turn was appended.
+   */
+  async persist(orchestrator: Orchestrator, sessionKey: string, messages: ReadonlyArray<{ role: string; content: string }>): Promise<boolean> {
+    let persisted = false;
+    for (const message of messages) {
+      if (message.content.length < OBSERVE_TRANSCRIPT_MIN_CONTENT_CHARS) continue;
+      const fingerprint = `${sessionKey}\0${message.role}\0${message.content}`;
+      if (this.seenFingerprints.has(fingerprint)) continue;
+      this.remember(fingerprint);
+      const entry: TranscriptEntry = {
+        timestamp: new Date().toISOString(),
+        role: message.role as TranscriptEntry["role"],
+        content: message.content,
+        sessionKey,
+        turnId: crypto.randomUUID(),
+      };
+      try {
+        await orchestrator.transcript.append(entry);
+        persisted = true;
+      } catch (err) {
+        // Same policy as the LCM enqueue in the observe path: transcript
+        // persistence must never fail the observe itself.
+        log.error(`access-observe transcript append failed: ${err}`);
+      }
+    }
+    return persisted;
+  }
+
+  private remember(fingerprint: string): void {
+    this.seenFingerprints.add(fingerprint);
+    if (this.seenFingerprints.size > OBSERVE_TRANSCRIPT_DEDUPE_MAX_ENTRIES) {
+      const oldest = this.seenFingerprints.keys().next().value;
+      if (typeof oldest === "string") this.seenFingerprints.delete(oldest);
+    }
+  }
+}

--- a/packages/remnic-core/src/access-observe-transcript.ts
+++ b/packages/remnic-core/src/access-observe-transcript.ts
@@ -66,13 +66,18 @@ export class ObserveTranscriptPersister {
   async persist(
     orchestrator: Orchestrator,
     sessionKey: string,
-    messages: ReadonlyArray<{ role: string; content: string }>
+    messages: ReadonlyArray<{ role: string; content: string }>,
+    rawSessionKey?: string
   ): Promise<boolean> {
     let persisted = false;
     // TranscriptManager.append silently no-ops for skip-listed channel types
     // (cron by default) — check BEFORE appending so the response's
     // transcriptPersisted stays truthful (review: report skipped appends).
-    const { channelType } = orchestrator.transcript.getTranscriptPath(sessionKey);
+    // The channel identity must derive from the RAW session key: the legacy
+    // parser requires the key to start with "agent:", so a namespace-prefixed
+    // transcript identity would always classify as "session" and the skip
+    // list would silently not apply to namespaced cron sessions (review r4).
+    const { channelType } = orchestrator.transcript.getTranscriptPath(rawSessionKey ?? sessionKey);
     if (orchestrator.config.transcriptSkipChannelTypes.includes(channelType)) {
       return false;
     }
@@ -84,55 +89,61 @@ export class ObserveTranscriptPersister {
       const fingerprint = createHash("sha256")
         .update(`${sessionKey}\0${message.role}\0${message.content}`)
         .digest("hex");
-      const nowMs = Date.now();
-      const seenAt = this.seenFingerprintsAt.get(fingerprint);
-      if (seenAt !== undefined && nowMs - seenAt < OBSERVE_TRANSCRIPT_DEDUPE_TTL_MS) continue;
       // Two identical observes can overlap before either records its
       // fingerprint; both would then append and the transcript would carry
-      // the turn twice. Serialize per fingerprint: the second caller waits
-      // for the first append, re-checks the completed set, and skips.
-      const inflight = this.inflightAppends.get(fingerprint);
-      if (inflight) {
-        await inflight;
-        const seenAfter = this.seenFingerprintsAt.get(fingerprint);
-        if (seenAfter !== undefined && Date.now() - seenAfter < OBSERVE_TRANSCRIPT_DEDUPE_TTL_MS) {
-          continue;
+      // the turn twice. The attempt loop serializes per fingerprint: a caller
+      // that finds an in-flight append awaits it and RE-RUNS BOTH checks — on
+      // success the completed-set check skips the message; on failure (no
+      // fingerprint recorded) exactly ONE waiter proceeds to retry, because
+      // the check-then-register sequence has no await between its steps and
+      // is therefore atomic on the event loop (review r4).
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const seenAt = this.seenFingerprintsAt.get(fingerprint);
+        if (seenAt !== undefined && Date.now() - seenAt < OBSERVE_TRANSCRIPT_DEDUPE_TTL_MS) {
+          break; // duplicate within the retry window — skip the message
         }
+        const inflight = this.inflightAppends.get(fingerprint);
+        if (inflight) {
+          await inflight;
+          continue; // re-run both checks with the append's outcome visible
+        }
+        const entry: TranscriptEntry = {
+          timestamp: new Date().toISOString(),
+          role: message.role as TranscriptEntry["role"],
+          content: message.content,
+          sessionKey,
+          turnId: randomUUID(),
+        };
+        const appendPromise = orchestrator.transcript
+          .append(entry)
+          .then(() => {
+            // Remember only after a successful append: a transient failure
+            // must not permanently swallow the turn — the client's retry has
+            // to be able to re-append it (review round 2).
+            this.remember(fingerprint);
+            persisted = true;
+          })
+          .catch((err) => {
+            // Same policy as the LCM enqueue in the observe path: transcript
+            // persistence must never fail the observe itself.
+            log.error(`access-observe transcript append failed: ${err}`);
+          })
+          .finally(() => {
+            this.inflightAppends.delete(fingerprint);
+          });
+        this.inflightAppends.set(fingerprint, appendPromise);
+        await appendPromise;
+        break;
       }
-      const entry: TranscriptEntry = {
-        timestamp: new Date().toISOString(),
-        role: message.role as TranscriptEntry["role"],
-        content: message.content,
-        sessionKey,
-        turnId: randomUUID(),
-      };
-      // Register BEFORE awaiting: the check-then-register sequence above has
-      // no await between its steps, so exactly one overlapping caller starts
-      // the append; the others wait on the inflight promise and re-check.
-      const appendPromise = orchestrator.transcript
-        .append(entry)
-        .then(() => {
-          // Remember only after a successful append: a transient failure must
-          // not permanently swallow the turn — the client's retry has to be
-          // able to re-append it (review round 2).
-          this.remember(fingerprint);
-          persisted = true;
-        })
-        .catch((err) => {
-          // Same policy as the LCM enqueue in the observe path: transcript
-          // persistence must never fail the observe itself.
-          log.error(`access-observe transcript append failed: ${err}`);
-        })
-        .finally(() => {
-          this.inflightAppends.delete(fingerprint);
-        });
-      this.inflightAppends.set(fingerprint, appendPromise);
-      await appendPromise;
     }
     return persisted;
   }
 
   private remember(fingerprint: string): void {
+    // Map.set keeps an existing key at its ORIGINAL insertion position, so a
+    // TTL-refreshed fingerprint could still be the FIFO-oldest and get
+    // evicted immediately — delete first to move it to the end (review r4).
+    this.seenFingerprintsAt.delete(fingerprint);
     this.seenFingerprintsAt.set(fingerprint, Date.now());
     if (this.seenFingerprintsAt.size > OBSERVE_TRANSCRIPT_DEDUPE_MAX_ENTRIES) {
       const oldest = this.seenFingerprintsAt.keys().next().value;

--- a/packages/remnic-core/src/access-observe-transcript.ts
+++ b/packages/remnic-core/src/access-observe-transcript.ts
@@ -15,13 +15,34 @@
  * retry cannot double-write it.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { lcmSessionKeyForNamespace } from "./coding/coding-namespace.js";
+import type { PluginConfig } from "./types.js";
 import { log } from "./logger.js";
 import type { Orchestrator } from "./orchestrator.js";
 import type { TranscriptEntry } from "./types.js";
 
 const OBSERVE_TRANSCRIPT_DEDUPE_MAX_ENTRIES = 8192;
 const OBSERVE_TRANSCRIPT_MIN_CONTENT_CHARS = 10;
+
+/**
+ * The transcript-side session identity for an observe payload (issue #2783
+ * review: namespace scoping). Two authenticated principals can submit the
+ * same client-controlled sessionKey while resolving to different effective
+ * write namespaces; persisting through the raw key would let one
+ * principal's transcript-derived summaries surface under the other's
+ * session. Mirror the LCM archive's answer (rule 42 parity): prefix the
+ * key with the effective write namespace whenever it diverges from the
+ * default store. The summarizer lists sessions from the store itself, so
+ * reads self-consistently follow the same prefixed keys.
+ */
+export function observeTranscriptSessionKey(
+  sessionKey: string,
+  writeNamespace: string,
+  config: Pick<PluginConfig, "defaultNamespace">
+): string {
+  return lcmSessionKeyForNamespace(writeNamespace, sessionKey, config.defaultNamespace) ?? sessionKey;
+}
 
 /** Bounded FIFO of seen fingerprints; insertion order is the eviction order. */
 export class ObserveTranscriptPersister {
@@ -32,13 +53,21 @@ export class ObserveTranscriptPersister {
    * transcript store. Best-effort: a failing append logs and does not fail
    * the observe. Returns true when at least one turn was appended.
    */
-  async persist(orchestrator: Orchestrator, sessionKey: string, messages: ReadonlyArray<{ role: string; content: string }>): Promise<boolean> {
+  async persist(
+    orchestrator: Orchestrator,
+    sessionKey: string,
+    messages: ReadonlyArray<{ role: string; content: string }>
+  ): Promise<boolean> {
     let persisted = false;
     for (const message of messages) {
       if (message.content.length < OBSERVE_TRANSCRIPT_MIN_CONTENT_CHARS) continue;
-      const fingerprint = `${sessionKey}\0${message.role}\0${message.content}`;
+      // Fixed-size digest, never the raw content: 8192 retained entries of
+      // full turn text is an avoidable heap-exhaustion surface on a daemon
+      // that accepts arbitrary observe payloads (review round 2).
+      const fingerprint = createHash("sha256")
+        .update(`${sessionKey}\0${message.role}\0${message.content}`)
+        .digest("hex");
       if (this.seenFingerprints.has(fingerprint)) continue;
-      this.remember(fingerprint);
       const entry: TranscriptEntry = {
         timestamp: new Date().toISOString(),
         role: message.role as TranscriptEntry["role"],
@@ -48,6 +77,10 @@ export class ObserveTranscriptPersister {
       };
       try {
         await orchestrator.transcript.append(entry);
+        // Remember only after a successful append: a transient failure must
+        // not permanently swallow the turn — the client's retry has to be
+        // able to re-append it (review round 2).
+        this.remember(fingerprint);
         persisted = true;
       } catch (err) {
         // Same policy as the LCM enqueue in the observe path: transcript

--- a/packages/remnic-core/src/access-observe-write-surface.ts
+++ b/packages/remnic-core/src/access-observe-write-surface.ts
@@ -30,11 +30,13 @@ import {
   NamespaceNotWritableError,
 } from "./access-service.js";
 import { extractionForceFlush } from "./access-extraction-force-flush.js";
+import { ObserveTranscriptPersister } from "./access-observe-transcript.js";
 import { FileCalendarSource, buildBriefing, parseBriefingFocus, parseBriefingWindow } from "./briefing.js";
 import {
   resolveCompressionCapabilities,
   resolveNamespaceCapabilities,
   resolveObjectiveStateCapabilities,
+  resolvePresentationCapabilities,
 } from "./capabilities.js";
 import { lcmSessionKeyForNamespace } from "./coding/coding-namespace.js";
 import {
@@ -135,6 +137,7 @@ export interface AccessObserveWriteSurfaceDeps {
 export class AccessObserveWriteSurface {
   private quarantineStoreInstance?: WriteQuarantineStore;
   private readonly pendingObserveExtractions = new PendingObserveExtractionTracker();
+  private readonly observeTranscriptPersister = new ObserveTranscriptPersister();
 
   public cancelPendingObservePreparations(sessionKey: string, scopeHint?: string): void {
     this.pendingObserveExtractions.cancelPreparations(sessionKey, scopeHint);
@@ -784,6 +787,17 @@ export class AccessObserveWriteSurface {
       }
     }
 
+    // 5b. Transcript persistence → the per-session transcript store the
+    // hourly summarizer reads (issue #2783). Best-effort like the LCM
+    // enqueue above: a transcript failure must not fail the observe.
+    const transcriptPersisted = resolvePresentationCapabilities(this.deps.orchestrator.config).transcript
+      ? await this.observeTranscriptPersister.persist(
+          this.deps.orchestrator,
+          request.sessionKey,
+          request.messages,
+        )
+      : false;
+
     // 6. Extraction/replay → effective write namespace for STORAGE, ORIGINAL
     //    sessionKey for IDENTITY (provenance + threading).
     let extractionQueued = false;
@@ -876,7 +890,7 @@ export class AccessObserveWriteSurface {
 
 
     log.info(
-      `access-observe namespace=${namespace} effectiveNamespace=${writeNamespace} sessionKey=${request.sessionKey} messages=${request.messages.length} lcm=${lcmArchived} extraction=${extractionQueued}`
+      `access-observe namespace=${namespace} effectiveNamespace=${writeNamespace} sessionKey=${request.sessionKey} messages=${request.messages.length} lcm=${lcmArchived} extraction=${extractionQueued} transcript=${transcriptPersisted}`
     );
 
     return {
@@ -898,6 +912,7 @@ export class AccessObserveWriteSurface {
       },
       lcmArchived,
       extractionQueued,
+      transcriptPersisted,
     };
     } finally {
       observePreparation.release();

--- a/packages/remnic-core/src/access-observe-write-surface.ts
+++ b/packages/remnic-core/src/access-observe-write-surface.ts
@@ -790,7 +790,8 @@ export class AccessObserveWriteSurface {
         ? await this.observeTranscriptPersister.persist(
             this.deps.orchestrator,
             observeTranscriptSessionKey(request.sessionKey, writeNamespace, this.deps.orchestrator.config),
-            request.messages
+            request.messages,
+            request.sessionKey
           )
         : false;
 

--- a/packages/remnic-core/src/access-observe-write-surface.ts
+++ b/packages/remnic-core/src/access-observe-write-surface.ts
@@ -30,7 +30,7 @@ import {
   NamespaceNotWritableError,
 } from "./access-service.js";
 import { extractionForceFlush } from "./access-extraction-force-flush.js";
-import { ObserveTranscriptPersister } from "./access-observe-transcript.js";
+import { ObserveTranscriptPersister, observeTranscriptSessionKey } from "./access-observe-transcript.js";
 import { FileCalendarSource, buildBriefing, parseBriefingFocus, parseBriefingWindow } from "./briefing.js";
 import {
   resolveCompressionCapabilities,
@@ -112,15 +112,12 @@ export interface AccessObserveWriteSurfaceDeps {
       authenticatedPrincipal?: string;
     }
   ): Promise<MemoryScopePlan>;
-  cancelPendingObservePreparations?(
-    sessionKey: string,
-    scopeHint?: string,
-  ): void;
+  cancelPendingObservePreparations?(sessionKey: string, scopeHint?: string): void;
   cancelPendingObserveExtractions?(
     sessionKey: string,
     principal?: string,
     namespace?: string,
-    scopeHint?: string,
+    scopeHint?: string
   ): void;
   resolveReadableNamespace(namespace: string | undefined, principal?: string): string;
   validateWriteCandidate(
@@ -147,7 +144,7 @@ export class AccessObserveWriteSurface {
     sessionKey: string,
     principal?: string,
     namespace?: string,
-    scopeHint?: string,
+    scopeHint?: string
   ): void {
     this.pendingObserveExtractions.cancel(sessionKey, principal, namespace, scopeHint);
   }
@@ -155,9 +152,7 @@ export class AccessObserveWriteSurface {
 
   private quarantineStore(): WriteQuarantineStore {
     if (!this.quarantineStoreInstance) {
-      this.quarantineStoreInstance = new WriteQuarantineStore(
-        this.deps.orchestrator.config.memoryDir,
-      );
+      this.quarantineStoreInstance = new WriteQuarantineStore(this.deps.orchestrator.config.memoryDir);
     }
     return this.quarantineStoreInstance;
   }
@@ -170,11 +165,7 @@ export class AccessObserveWriteSurface {
    * the caller re-throws. The ACL placement is unchanged; the payload simply
    * stops being destroyed.
    */
-  private async parkRejectedWrite(
-    err: unknown,
-    operation: QuarantineOperation,
-    payload: unknown,
-  ): Promise<void> {
+  private async parkRejectedWrite(err: unknown, operation: QuarantineOperation, payload: unknown): Promise<void> {
     if (!(err instanceof NamespaceNotWritableError)) return;
     try {
       await this.quarantineStore().quarantine({
@@ -184,11 +175,11 @@ export class AccessObserveWriteSurface {
         payload,
       });
       log.warn(
-        `quarantine: parked rejected ${operation} write for principal=${err.principal ?? "-"} attemptedNamespace=${err.attemptedNamespace} (namespace not writable); replay after fixing config`,
+        `quarantine: parked rejected ${operation} write for principal=${err.principal ?? "-"} attemptedNamespace=${err.attemptedNamespace} (namespace not writable); replay after fixing config`
       );
     } catch (quarantineErr) {
       log.warn(
-        `quarantine: failed to park rejected ${operation} write: ${quarantineErr instanceof Error ? quarantineErr.message : String(quarantineErr)}`,
+        `quarantine: failed to park rejected ${operation} write: ${quarantineErr instanceof Error ? quarantineErr.message : String(quarantineErr)}`
       );
     }
   }
@@ -275,14 +266,20 @@ export class AccessObserveWriteSurface {
     if (typeof (qmd as { status?: unknown }).status === "function") {
       try {
         const statusReport = await Promise.race([
-          (qmd as unknown as { status: () => Promise<{ pendingEmbeddings: number | null; oldestPendingAgeMs: number | null }> }).status(),
+          (
+            qmd as unknown as {
+              status: () => Promise<{ pendingEmbeddings: number | null; oldestPendingAgeMs: number | null }>;
+            }
+          ).status(),
           new Promise<null>((resolve) => setTimeout(() => resolve(null), 5_000).unref?.()),
         ]);
         if (statusReport) {
           pendingEmbeddings = statusReport.pendingEmbeddings;
           oldestPendingAgeMs = statusReport.oldestPendingAgeMs;
         }
-      } catch { /* status probe failed — non-fatal */ }
+      } catch {
+        /* status probe failed — non-fatal */
+      }
     }
     if (threshold > 0 && pendingEmbeddings !== null && pendingEmbeddings > threshold) {
       degraded = true;
@@ -685,242 +682,239 @@ export class AccessObserveWriteSurface {
     //    session mutation.
     const observePreparation = this.pendingObserveExtractions.reserve(
       request.sessionKey,
-      pendingObserveScopeHint(request),
+      pendingObserveScopeHint(request)
     );
     try {
-
-    let scope: MemoryScopePlan;
-    try {
-      scope = await this.deps.resolveMemoryScopePlan(request);
-    } catch (err) {
-      // A replay re-submit sets suppressQuarantine so a still-unwritable target
-      // propagates instead of re-parking (#1888); observe has no dryRun path.
-      if (request.suppressQuarantine !== true) {
-        await this.parkRejectedWrite(err, "observe", request);
-      }
-      throw err;
-    }
-    const writeNamespace = scope.writeNamespace;
-    observePreparation.setScope(scope.principal, writeNamespace);
-
-    // Backward-compatible BASE writable namespace (pre-#1495 response semantics)
-    // for the legacy `namespace` response field. DERIVED from the already-resolved
-    // scope plan — NOT a second writable-namespace resolution call
-    // call (#1505 thread jvO). The fresh call re-authorized `undefined ⇒
-    // config.defaultNamespace` a SECOND time; under a restrictive default-namespace
-    // write policy that re-auth could REJECT an otherwise valid project-scoped
-    // observe whose effective self/project write target the scope plan already
-    // authorized (the same target memory_store/suggestion_submit accept). Worse,
-    // that post-plan rejection fired AFTER `resolveMemoryScopePlan` may have seeded
-    // the coding context, leaving an orphaned session binding behind. The plan is
-    // the single authorization point (rule 22 / 39); the legacy field must reuse it
-    // and never re-authorize. Pre-#1495 semantics were exactly
-    // the writable-namespace resolver (overlay-agnostic): the explicit
-    // namespace when supplied, else `config.defaultNamespace` for user-project
-    // coding overlays. Hosted scope-profile layers such as `teamProject` report
-    // their effective profile write namespace because there is no legacy
-    // overlay-compatible base namespace for those writes.
-    const namespace = this.deps.legacyResponseNamespaceForScope(scope);
-    const shouldWriteObjectiveState =
-      resolveObjectiveStateCapabilities(this.deps.orchestrator.config).objectiveStateMemory === true &&
-      resolveObjectiveStateCapabilities(this.deps.orchestrator.config).objectiveStateSnapshotWrites === true;
-
-    // 2. Auto-resolve coding context from cwd/projectTag so a LATER bare recall
-    //    on the same session is project-scoped (rule 42: same namespace layer as
-    //    recall). Done AFTER the scope plan authorized the write, so a rejected
-    //    request never leaves orphaned context on the session.
-    await this.deps.maybeAttachCodingContext(request.sessionKey, {
-      cwd: request.cwd,
-      projectTag: request.projectTag,
-    });
-
-    // Prefix sessionKey with the EFFECTIVE write namespace for LCM archival so
-    // observed turns are scoped to the same namespace project-scoped recall
-    // reads. The SAME `lcmSessionKeyForNamespace` helper is used by the
-    // orchestrator recall readers and by compaction flush/record, so the LCM
-    // write key and every read/flush key agree (#1495, rule 42). Only prefixes
-    // when the namespace diverges from the default store; a single-store
-    // deployment keeps the raw sessionKey unchanged.
-    const lcmSessionKey =
-      lcmSessionKeyForNamespace(writeNamespace, request.sessionKey, this.deps.orchestrator.config.defaultNamespace) ??
-      request.sessionKey;
-
-    // 4. Objective-state snapshots → the scope plan's objective-state namespace.
-    //    For explicit-namespace and coding-overlay writes this equals
-    //    writeNamespace; for an IMPLICIT write it is the principal SELF base
-    //    (#928 contract, already auth-checked inside the scope plan), not the
-    //    general default-store write namespace.
-    if (shouldWriteObjectiveState) {
+      let scope: MemoryScopePlan;
       try {
-        const objectiveStateLocation = await this.deps.objectiveStateStoreLocationForNamespace(
-          scope.objectiveStateNamespace
-        );
-        await recordObjectiveStateSnapshotsFromObservedMessages({
-          memoryDir: objectiveStateLocation.memoryDir,
-          objectiveStateStoreDir: objectiveStateLocation.objectiveStateStoreDir,
-          objectiveStateMemoryEnabled: resolveObjectiveStateCapabilities(this.deps.orchestrator.config)
-            .objectiveStateMemory,
-          objectiveStateSnapshotWritesEnabled: resolveObjectiveStateCapabilities(this.deps.orchestrator.config)
-            .objectiveStateSnapshotWrites,
+        scope = await this.deps.resolveMemoryScopePlan(request);
+      } catch (err) {
+        // A replay re-submit sets suppressQuarantine so a still-unwritable target
+        // propagates instead of re-parking (#1888); observe has no dryRun path.
+        if (request.suppressQuarantine !== true) {
+          await this.parkRejectedWrite(err, "observe", request);
+        }
+        throw err;
+      }
+      const writeNamespace = scope.writeNamespace;
+      observePreparation.setScope(scope.principal, writeNamespace);
+
+      // Backward-compatible BASE writable namespace (pre-#1495 response semantics)
+      // for the legacy `namespace` response field. DERIVED from the already-resolved
+      // scope plan — NOT a second writable-namespace resolution call
+      // call (#1505 thread jvO). The fresh call re-authorized `undefined ⇒
+      // config.defaultNamespace` a SECOND time; under a restrictive default-namespace
+      // write policy that re-auth could REJECT an otherwise valid project-scoped
+      // observe whose effective self/project write target the scope plan already
+      // authorized (the same target memory_store/suggestion_submit accept). Worse,
+      // that post-plan rejection fired AFTER `resolveMemoryScopePlan` may have seeded
+      // the coding context, leaving an orphaned session binding behind. The plan is
+      // the single authorization point (rule 22 / 39); the legacy field must reuse it
+      // and never re-authorize. Pre-#1495 semantics were exactly
+      // the writable-namespace resolver (overlay-agnostic): the explicit
+      // namespace when supplied, else `config.defaultNamespace` for user-project
+      // coding overlays. Hosted scope-profile layers such as `teamProject` report
+      // their effective profile write namespace because there is no legacy
+      // overlay-compatible base namespace for those writes.
+      const namespace = this.deps.legacyResponseNamespaceForScope(scope);
+      const shouldWriteObjectiveState =
+        resolveObjectiveStateCapabilities(this.deps.orchestrator.config).objectiveStateMemory === true &&
+        resolveObjectiveStateCapabilities(this.deps.orchestrator.config).objectiveStateSnapshotWrites === true;
+
+      // 2. Auto-resolve coding context from cwd/projectTag so a LATER bare recall
+      //    on the same session is project-scoped (rule 42: same namespace layer as
+      //    recall). Done AFTER the scope plan authorized the write, so a rejected
+      //    request never leaves orphaned context on the session.
+      await this.deps.maybeAttachCodingContext(request.sessionKey, {
+        cwd: request.cwd,
+        projectTag: request.projectTag,
+      });
+
+      // Prefix sessionKey with the EFFECTIVE write namespace for LCM archival so
+      // observed turns are scoped to the same namespace project-scoped recall
+      // reads. The SAME `lcmSessionKeyForNamespace` helper is used by the
+      // orchestrator recall readers and by compaction flush/record, so the LCM
+      // write key and every read/flush key agree (#1495, rule 42). Only prefixes
+      // when the namespace diverges from the default store; a single-store
+      // deployment keeps the raw sessionKey unchanged.
+      const lcmSessionKey =
+        lcmSessionKeyForNamespace(writeNamespace, request.sessionKey, this.deps.orchestrator.config.defaultNamespace) ??
+        request.sessionKey;
+
+      // 4. Objective-state snapshots → the scope plan's objective-state namespace.
+      //    For explicit-namespace and coding-overlay writes this equals
+      //    writeNamespace; for an IMPLICIT write it is the principal SELF base
+      //    (#928 contract, already auth-checked inside the scope plan), not the
+      //    general default-store write namespace.
+      if (shouldWriteObjectiveState) {
+        try {
+          const objectiveStateLocation = await this.deps.objectiveStateStoreLocationForNamespace(
+            scope.objectiveStateNamespace
+          );
+          await recordObjectiveStateSnapshotsFromObservedMessages({
+            memoryDir: objectiveStateLocation.memoryDir,
+            objectiveStateStoreDir: objectiveStateLocation.objectiveStateStoreDir,
+            objectiveStateMemoryEnabled: resolveObjectiveStateCapabilities(this.deps.orchestrator.config)
+              .objectiveStateMemory,
+            objectiveStateSnapshotWritesEnabled: resolveObjectiveStateCapabilities(this.deps.orchestrator.config)
+              .objectiveStateSnapshotWrites,
+            sessionKey: request.sessionKey,
+            recordedAt: new Date().toISOString(),
+            messages: request.messages,
+          });
+        } catch (err) {
+          log.error(`access-observe objective-state snapshot write failed: ${err}`);
+        }
+      }
+
+      // 5. LCM archival → effective write namespace.
+      // lcmArchived in the response means "LCM archival was queued" (not
+      // "completed"), matching extractionQueued semantics.  Both run async.
+      let lcmArchived = false;
+      if (this.deps.orchestrator.lcmEngine && this.deps.orchestrator.lcmEngine.enabled) {
+        // Fire-and-forget: LCM archival writes to SQLite and builds summary
+        // DAGs, which can take tens of seconds for large sessions.  Don't
+        // block the HTTP response — the caller only needs acknowledgment.
+        try {
+          this.deps.orchestrator.lcmEngine.enqueueObserveMessages(lcmSessionKey, request.messages);
+          lcmArchived = true;
+        } catch (err) {
+          log.error(`access-observe LCM enqueue failed: ${err}`);
+        }
+      }
+
+      // 5b. Transcript persistence → the per-session transcript store the
+      // hourly summarizer reads (issue #2783). Best-effort like the LCM
+      // enqueue above: a transcript failure must not fail the observe.
+      const transcriptPersisted = resolvePresentationCapabilities(this.deps.orchestrator.config).transcript
+        ? await this.observeTranscriptPersister.persist(
+            this.deps.orchestrator,
+            observeTranscriptSessionKey(request.sessionKey, writeNamespace, this.deps.orchestrator.config),
+            request.messages
+          )
+        : false;
+
+      // 6. Extraction/replay → effective write namespace for STORAGE, ORIGINAL
+      //    sessionKey for IDENTITY (provenance + threading).
+      let extractionQueued = false;
+      if (request.skipExtraction !== true) {
+        const turns = request.messages.map((m) => ({
+          source: "openclaw" as const,
+          // Identity-vs-routing separation (#1505 thread 1, cursor): extraction
+          // derives the provenance principal via `resolvePrincipal(turn.sessionKey)`
+          // and threads `turn.sessionKey` into conversation threading. Feeding the
+          // namespace-PREFIXED `lcmSessionKey` here mis-derived the principal to
+          // `default` (a `<ns>:<key>` string matches no prefix/map rule and fails
+          // the `agent:` heuristic). Pass the ORIGINAL sessionKey so identity is
+          // correct; storage routing is pinned separately via
+          // writeNamespaceOverride below, and the authenticated principal is pinned
+          // via principalOverride.
           sessionKey: request.sessionKey,
-          recordedAt: new Date().toISOString(),
-          messages: request.messages,
-        });
-      } catch (err) {
-        log.error(`access-observe objective-state snapshot write failed: ${err}`);
+          role: m.role,
+          content: m.content,
+          parts: m.parts,
+          rawContent: m.rawContent,
+          sourceFormat: m.sourceFormat,
+          timestamp: new Date().toISOString(),
+          ...(request.sourceConnector ? { sourceConnector: request.sourceConnector } : {}),
+        }));
+        // Pin extraction STORAGE to the effective namespace rather than letting the
+        // orchestrator re-derive one from the session key + coding overlay — that
+        // re-derivation would have to reparse identity and could miss the overlay
+        // (the #1495 drift). Passing writeNamespaceOverride makes the extraction
+        // target deterministic and identical to LCM/objective-state (rule 39).
+        //
+        // Pin WHENEVER namespaces are enabled, not only when writeNamespace differs
+        // from the default store (#1505 round 3, codex "Pin default-store extraction
+        // writes too"). For an unqualified/no-overlay observe by a principal that
+        // HAS a self namespace, writeNamespace is `config.defaultNamespace` but an
+        // unpinned `runExtraction` would fall back to
+        // `defaultNamespaceForPrincipal(principal)` = the SELF namespace — diverging
+        // from where LCM/objective-state/response wrote (`default`). Pinning the
+        // resolved writeNamespace forces all side effects onto the one scope-plan
+        // namespace. When namespaces are DISABLED the router collapses every
+        // namespace to one store, so leaving the override undefined preserves the
+        // existing single-store routing byte-for-byte.
+        const writeNamespaceOverride =
+          resolveNamespaceCapabilities(this.deps.orchestrator.config).namespaces === true ? writeNamespace : undefined;
+        // Pin provenance PRINCIPAL to the scope plan's resolved principal (#1505
+        // thread 1). The scope plan already applied auth precedence
+        // (authenticatedPrincipal/principalOverride > resolvePrincipal(original
+        // sessionKey)), so this is the same identity the surface authorized — never
+        // a `default` fallback parsed from a prefixed key. Omitted when no principal
+        // resolved (namespaces-disabled / unauthenticated single-store), preserving
+        // existing behavior.
+        const principalOverride =
+          typeof scope.principal === "string" && scope.principal.length > 0 ? scope.principal : undefined;
+        // Fire-and-forget: queue extraction in the background so the HTTP
+        // response returns immediately. LCM archival (above) is also
+        // enqueue-only; extraction involves LLM calls that can take
+        // minutes under load and should not block the caller.
+        //
+        // Backpressure: the orchestrator's own extraction queue already
+        // limits concurrency (one extraction at a time per session via
+        // queueBufferedExtraction). Fire-and-forget here just decouples
+        // the HTTP response from the queue drain.
+        if (!observePreparation.isCancelled()) {
+          try {
+            const observeAbortController = new AbortController();
+            const extractionPromise = this.deps.orchestrator.ingestReplayBatch(turns, {
+              archiveLcm: false,
+              writeNamespaceOverride,
+              principalOverride,
+              abortSignal: observeAbortController.signal,
+              ...(typeof request.authenticatedPrincipal === "string" && request.authenticatedPrincipal.trim().length > 0
+                ? { sessionOwnerPrincipal: request.authenticatedPrincipal.trim() }
+                : {}),
+            });
+            extractionPromise.catch((err) => {
+              log.error(`access-observe background extraction failed: ${err}`);
+            });
+            this.pendingObserveExtractions.track(
+              this.pendingObserveExtractions.key(request.sessionKey, scope.principal, writeNamespace),
+              extractionPromise,
+              observeAbortController
+            );
+            extractionQueued = true;
+          } catch (err) {
+            // Synchronous enqueue failure (e.g. orchestrator disposed)
+            log.error(`access-observe extraction enqueue failed: ${err}`);
+          }
+        }
       }
-    }
 
-    // 5. LCM archival → effective write namespace.
-    // lcmArchived in the response means "LCM archival was queued" (not
-    // "completed"), matching extractionQueued semantics.  Both run async.
-    let lcmArchived = false;
-    if (this.deps.orchestrator.lcmEngine && this.deps.orchestrator.lcmEngine.enabled) {
-      // Fire-and-forget: LCM archival writes to SQLite and builds summary
-      // DAGs, which can take tens of seconds for large sessions.  Don't
-      // block the HTTP response — the caller only needs acknowledgment.
-      try {
-        this.deps.orchestrator.lcmEngine.enqueueObserveMessages(lcmSessionKey, request.messages);
-        lcmArchived = true;
-      } catch (err) {
-        log.error(`access-observe LCM enqueue failed: ${err}`);
-      }
-    }
+      log.info(
+        `access-observe namespace=${namespace} effectiveNamespace=${writeNamespace} sessionKey=${request.sessionKey} messages=${request.messages.length} lcm=${lcmArchived} extraction=${extractionQueued} transcript=${transcriptPersisted}`
+      );
 
-    // 5b. Transcript persistence → the per-session transcript store the
-    // hourly summarizer reads (issue #2783). Best-effort like the LCM
-    // enqueue above: a transcript failure must not fail the observe.
-    const transcriptPersisted = resolvePresentationCapabilities(this.deps.orchestrator.config).transcript
-      ? await this.observeTranscriptPersister.persist(
-          this.deps.orchestrator,
-          request.sessionKey,
-          request.messages,
-        )
-      : false;
-
-    // 6. Extraction/replay → effective write namespace for STORAGE, ORIGINAL
-    //    sessionKey for IDENTITY (provenance + threading).
-    let extractionQueued = false;
-    if (request.skipExtraction !== true) {
-      const turns = request.messages.map((m) => ({
-        source: "openclaw" as const,
-        // Identity-vs-routing separation (#1505 thread 1, cursor): extraction
-        // derives the provenance principal via `resolvePrincipal(turn.sessionKey)`
-        // and threads `turn.sessionKey` into conversation threading. Feeding the
-        // namespace-PREFIXED `lcmSessionKey` here mis-derived the principal to
-        // `default` (a `<ns>:<key>` string matches no prefix/map rule and fails
-        // the `agent:` heuristic). Pass the ORIGINAL sessionKey so identity is
-        // correct; storage routing is pinned separately via
-        // writeNamespaceOverride below, and the authenticated principal is pinned
-        // via principalOverride.
+      return {
+        accepted: request.messages.length,
         sessionKey: request.sessionKey,
-        role: m.role,
-        content: m.content,
-        parts: m.parts,
-        rawContent: m.rawContent,
-        sourceFormat: m.sourceFormat,
-        timestamp: new Date().toISOString(),
-        ...(request.sourceConnector ? { sourceConnector: request.sourceConnector } : {}),
-      }));
-      // Pin extraction STORAGE to the effective namespace rather than letting the
-      // orchestrator re-derive one from the session key + coding overlay — that
-      // re-derivation would have to reparse identity and could miss the overlay
-      // (the #1495 drift). Passing writeNamespaceOverride makes the extraction
-      // target deterministic and identical to LCM/objective-state (rule 39).
-      //
-      // Pin WHENEVER namespaces are enabled, not only when writeNamespace differs
-      // from the default store (#1505 round 3, codex "Pin default-store extraction
-      // writes too"). For an unqualified/no-overlay observe by a principal that
-      // HAS a self namespace, writeNamespace is `config.defaultNamespace` but an
-      // unpinned `runExtraction` would fall back to
-      // `defaultNamespaceForPrincipal(principal)` = the SELF namespace — diverging
-      // from where LCM/objective-state/response wrote (`default`). Pinning the
-      // resolved writeNamespace forces all side effects onto the one scope-plan
-      // namespace. When namespaces are DISABLED the router collapses every
-      // namespace to one store, so leaving the override undefined preserves the
-      // existing single-store routing byte-for-byte.
-      const writeNamespaceOverride =
-        resolveNamespaceCapabilities(this.deps.orchestrator.config).namespaces === true ? writeNamespace : undefined;
-      // Pin provenance PRINCIPAL to the scope plan's resolved principal (#1505
-      // thread 1). The scope plan already applied auth precedence
-      // (authenticatedPrincipal/principalOverride > resolvePrincipal(original
-      // sessionKey)), so this is the same identity the surface authorized — never
-      // a `default` fallback parsed from a prefixed key. Omitted when no principal
-      // resolved (namespaces-disabled / unauthenticated single-store), preserving
-      // existing behavior.
-      const principalOverride =
-        typeof scope.principal === "string" && scope.principal.length > 0 ? scope.principal : undefined;
-      // Fire-and-forget: queue extraction in the background so the HTTP
-      // response returns immediately. LCM archival (above) is also
-      // enqueue-only; extraction involves LLM calls that can take
-      // minutes under load and should not block the caller.
-      //
-      // Backpressure: the orchestrator's own extraction queue already
-      // limits concurrency (one extraction at a time per session via
-      // queueBufferedExtraction). Fire-and-forget here just decouples
-      // the HTTP response from the queue drain.
-      if (!observePreparation.isCancelled()) {
-
-      try {
-        const observeAbortController = new AbortController();
-        const extractionPromise = this.deps.orchestrator.ingestReplayBatch(turns, {
-          archiveLcm: false,
-          writeNamespaceOverride,
-          principalOverride,
-          abortSignal: observeAbortController.signal,
-          ...(typeof request.authenticatedPrincipal === "string" && request.authenticatedPrincipal.trim().length > 0
-            ? { sessionOwnerPrincipal: request.authenticatedPrincipal.trim() }
-            : {}),
-        });
-        extractionPromise.catch((err) => {
-          log.error(`access-observe background extraction failed: ${err}`);
-        });
-        this.pendingObserveExtractions.track(
-          this.pendingObserveExtractions.key(request.sessionKey, scope.principal, writeNamespace),
-          extractionPromise,
-          observeAbortController,
-        );
-        extractionQueued = true;
-      } catch (err) {
-        // Synchronous enqueue failure (e.g. orchestrator disposed)
-        log.error(`access-observe extraction enqueue failed: ${err}`);
-      }
-    }
-      }
-
-
-    log.info(
-      `access-observe namespace=${namespace} effectiveNamespace=${writeNamespace} sessionKey=${request.sessionKey} messages=${request.messages.length} lcm=${lcmArchived} extraction=${extractionQueued} transcript=${transcriptPersisted}`
-    );
-
-    return {
-      accepted: request.messages.length,
-      sessionKey: request.sessionKey,
-      namespace,
-      effectiveNamespace: writeNamespace,
-      scopeDebug: {
-        principal: scope.principal,
-        explicitNamespace: scope.explicitNamespace,
-        baseNamespace: scope.baseNamespace,
-        writeNamespace: scope.writeNamespace,
-        codingOverlayApplied: scope.codingOverlayApplied,
-        readNamespaces: scope.readNamespaces,
-        scopeProfile: scope.scopeProfile,
-        writeLayer: scope.writeLayer,
-        layers: scope.layers,
-        promotionTargets: scope.promotionTargets,
-      },
-      lcmArchived,
-      extractionQueued,
-      transcriptPersisted,
-    };
+        namespace,
+        effectiveNamespace: writeNamespace,
+        scopeDebug: {
+          principal: scope.principal,
+          explicitNamespace: scope.explicitNamespace,
+          baseNamespace: scope.baseNamespace,
+          writeNamespace: scope.writeNamespace,
+          codingOverlayApplied: scope.codingOverlayApplied,
+          readNamespaces: scope.readNamespaces,
+          scopeProfile: scope.scopeProfile,
+          writeLayer: scope.writeLayer,
+          layers: scope.layers,
+          promotionTargets: scope.promotionTargets,
+        },
+        lcmArchived,
+        extractionQueued,
+        transcriptPersisted,
+      };
     } finally {
       observePreparation.release();
-  }
+    }
   }
 
   async extractionForceFlush(
-    request: EngramAccessExtractionForceFlushRequest,
+    request: EngramAccessExtractionForceFlushRequest
   ): Promise<EngramAccessExtractionForceFlushResponse> {
     return extractionForceFlush(
       this.deps,
@@ -932,8 +926,8 @@ export class AccessObserveWriteSurface {
           namespace,
           abortSignal,
           registerCancellation,
-          scopeHint,
-        ),
+          scopeHint
+        )
     );
   }
   async workTask(request: {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -169,10 +169,7 @@ import {
   redactSensitive,
 } from "./admin/admin-surfaces.js";
 import { FileCalendarSource, buildBriefing, parseBriefingFocus, parseBriefingWindow } from "./briefing.js";
-import {
-  type DeepRecallResult,
-  runBudgetedDeepRecall,
-} from "./deep-recall.js";
+import { type DeepRecallResult, runBudgetedDeepRecall } from "./deep-recall.js";
 import { callDeepRecallPolicyLlm } from "./deep-recall-policy-llm.js";
 import { createDeepRecallSeedSearch } from "./deep-recall-seeds.js";
 import { renderDeepRecallResult } from "./deep-recall-renderer.js";
@@ -319,7 +316,13 @@ import { decideDisclosureEscalation } from "./recall-disclosure-escalation.js";
 import { toRecallExplainJson } from "./recall-explain-renderer.js";
 import { type TagMatchMode, applyTagFilter, normalizeTags, parseTagMatch } from "./recall-tag-filter.js";
 import { type RecallXraySnapshot, estimateRecallTokens } from "./recall-xray.js";
-import { computeWhoKnows, loadWhoKnowsEntities, validateWhoKnowsInput, WHO_KNOWS_DEFAULT_LIMIT, type WhoKnowsResult } from "./who-knows.js";
+import {
+  computeWhoKnows,
+  loadWhoKnowsEntities,
+  validateWhoKnowsInput,
+  WHO_KNOWS_DEFAULT_LIMIT,
+  type WhoKnowsResult,
+} from "./who-knows.js";
 import { computePromotionCandidates, type PromotionCandidatesResult } from "./memory-subject.js";
 import { SupportPassportAccessServiceBase } from "./support-passport/access-service-base.js";
 import {
@@ -992,9 +995,7 @@ export interface EngramAccessObserveMessage {
  * consumes the transport-cleaned message form (the wire schema tolerates
  * nullable `parts`/`sourceFormat`, the service maps them to `undefined`).
  */
-export interface EngramAccessObserveRequest
-  extends Omit<ObserveRequest, "messages">,
-    SourceConnectorProvenance {
+export interface EngramAccessObserveRequest extends Omit<ObserveRequest, "messages">, SourceConnectorProvenance {
   messages: EngramAccessObserveMessage[];
   authenticatedPrincipal?: string;
   readonly suppressQuarantine?: boolean; // #1888: replay re-submit skips dead-lettering.
@@ -2735,12 +2736,12 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
       if (cfg.maxSteps <= 0) {
         if (requestedSteps > 0) {
           throw new EngramAccessInputError(
-            "deepRecall: the policy loop is disabled (deepRecall.maxSteps=0); maxSteps must be 0",
+            "deepRecall: the policy loop is disabled (deepRecall.maxSteps=0); maxSteps must be 0"
           );
         }
       } else if (requestedSteps > cfg.maxSteps) {
         throw new EngramAccessInputError(
-          `deepRecall: maxSteps ${requestedSteps} exceeds the configured ceiling ${cfg.maxSteps}`,
+          `deepRecall: maxSteps ${requestedSteps} exceeds the configured ceiling ${cfg.maxSteps}`
         );
       }
       effective = { ...cfg, maxSteps: requestedSteps };
@@ -2759,8 +2760,7 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
     // goes to the base namespace only); passing it here made every non-default
     // namespace load the DEFAULT namespace's nodes and anchors, missing its own
     // anchor expansions and exposing foreign graph metadata on an id collision.
-    const graphStoreDir =
-      resolvedNamespace === config.defaultNamespace ? config.abstractionNodeStoreDir : undefined;
+    const graphStoreDir = resolvedNamespace === config.defaultNamespace ? config.abstractionNodeStoreDir : undefined;
     // Seeds route through the namespace search router (never the base
     // `config.qmdCollection`, which is the DEFAULT namespace's collection):
     // a non-default caller must search its own suffixed collection or deep
@@ -2799,14 +2799,9 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
           if (!memory || isSupportPassportPrivateMemory(memory)) return null;
           return {
             memoryId,
-            content: memory.frontmatter.structuredAttributes
-              ? stripAttributesSuffix(memory.content)
-              : memory.content,
+            content: memory.frontmatter.structuredAttributes ? stripAttributesSuffix(memory.content) : memory.content,
             // Enumerate the active set — never an exclusion list (§41).
-            active: inferMemoryStatus(
-              memory.frontmatter,
-              toMemoryPathRel(storage.dir, memory.path)
-            ) === "active",
+            active: inferMemoryStatus(memory.frontmatter, toMemoryPathRel(storage.dir, memory.path)) === "active",
           };
         },
         callPolicy: (statePrompt, timeoutMs) =>
@@ -2818,7 +2813,7 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
             timeoutMs,
           }),
       },
-      query,
+      query
     );
     return { ...result, rendered: renderDeepRecallResult(result) };
   }
@@ -2912,13 +2907,13 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
     const limit = request.limit ?? 20;
     if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
       throw new EngramAccessInputError(
-        `promotion_candidates: limit expects an integer in [1, 100] (got ${String(request.limit)})`,
+        `promotion_candidates: limit expects an integer in [1, 100] (got ${String(request.limit)})`
       );
     }
     const resolvedNamespace = this.resolveReadableNamespace(request.namespace, request.authenticatedPrincipal);
     const resolvedTarget = this.resolveReadableNamespace(
       request.targetNamespace ?? this.orchestrator.config.sharedNamespace,
-      request.authenticatedPrincipal,
+      request.authenticatedPrincipal
     );
     const minAccessCount = this.orchestrator.config.promotionCandidates.minAccessCount;
     const [memories, targetMemories] = await Promise.all([
@@ -3466,7 +3461,8 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
     const resolvedNamespace = this.resolveReadableNamespace(namespace, principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
     const memory = await storage.getMemoryByIdIncludingArchived(memoryId);
-    if (!memory || isSupportPassportPrivateMemory(memory)) return { found: false, namespace: resolvedNamespace, count: 0, timeline: [] };
+    if (!memory || isSupportPassportPrivateMemory(memory))
+      return { found: false, namespace: resolvedNamespace, count: 0, timeline: [] };
     const timeline = await storage.getMemoryTimeline(memoryId, limit);
     return {
       found: timeline.length > 0,
@@ -3827,6 +3823,7 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
     summariesWritten: number;
     staleStore: boolean;
     newestEntryTimestamp: string | null;
+    scanFailed: boolean;
     warning?: string;
   }> {
     // Issue #2783: the daemon-side summarizer must not report success on
@@ -3834,11 +3831,20 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
     // signature (11 days of silent ok:true in the field report); surface
     // it as a distinct warning plus counts so monitoring can alert on it.
     const stats = await this.orchestrator.summarizer.runHourly();
+    if (stats.scanFailed) {
+      // A FAILED scan is an unreadable store (permissions, I/O) — a
+      // different incident from an empty one; never conflate them.
+      return {
+        ok: true,
+        message: "Hourly summarization completed, but the transcript store scan FAILED (unreadable directory or I/O error). Investigate the daemon's memoryDir.",
+        ...stats,
+        warning: "transcript store scan failed",
+      };
+    }
     if (stats.sessionsConsidered === 0) {
       return {
         ok: true,
-        message:
-          "Hourly summarization completed, but the transcript store is empty — no sessions found. If turns are ingested via observe, transcript persistence may be disabled or failing.",
+        message: "Hourly summarization completed, but the transcript store is empty — no sessions found. If turns are ingested via observe, transcript persistence may be disabled or failing.",
         ...stats,
         warning: "transcript store is empty",
       };

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4,6 +4,7 @@ import { readdirSync, unlinkSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import * as nodeFs from "node:fs/promises";
 import { ZodError } from "zod";
+import { summarizeHourlyStatus } from "./summarizer.js";
 import { decodeCitationNamespace } from "./access-citation-namespace.js";
 import {
   type CitationUsageRequest,
@@ -3826,42 +3827,10 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
     scanFailed: boolean;
     warning?: string;
   }> {
-    // Issue #2783: the daemon-side summarizer must not report success on
-    // empty work. An empty or stale transcript store is the starvation
-    // signature (11 days of silent ok:true in the field report); surface
-    // it as a distinct warning plus counts so monitoring can alert on it.
+    // Issue #2783: the summarizer must not report success on empty work.
+    // Stats interpretation lives with the stats (summarizeHourlyStatus).
     const stats = await this.orchestrator.summarizer.runHourly();
-    if (stats.scanFailed) {
-      // A FAILED scan is an unreadable store (permissions, I/O) — a
-      // different incident from an empty one; never conflate them.
-      return {
-        ok: true,
-        message: "Hourly summarization completed, but the transcript store scan FAILED (unreadable directory or I/O error). Investigate the daemon's memoryDir.",
-        ...stats,
-        warning: "transcript store scan failed",
-      };
-    }
-    if (stats.sessionsConsidered === 0) {
-      return {
-        ok: true,
-        message: "Hourly summarization completed, but the transcript store is empty — no sessions found. If turns are ingested via observe, transcript persistence may be disabled or failing.",
-        ...stats,
-        warning: "transcript store is empty",
-      };
-    }
-    if (stats.sessionsWithEntries === 0 && stats.staleStore) {
-      return {
-        ok: true,
-        message: `Hourly summarization completed with no transcript entries for the target hour, and the store looks stale (newest entry ${stats.newestEntryTimestamp ?? "unknown"}).`,
-        ...stats,
-        warning: "no transcript entries for the target hour and no new entries recently",
-      };
-    }
-    return {
-      ok: true,
-      message: `Hourly summarization completed: ${stats.summariesWritten} summar${stats.summariesWritten === 1 ? "y" : "ies"} written across ${stats.sessionsWithEntries} session${stats.sessionsWithEntries === 1 ? "" : "s"} with transcript entries.`,
-      ...stats,
-    };
+    return { ok: true, ...stats, ...summarizeHourlyStatus(stats) };
   }
 
   async conversationIndexUpdate(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1045,6 +1045,8 @@ export interface EngramAccessObserveResponse {
   scopeDebug?: EngramAccessScopeDebug;
   lcmArchived: boolean;
   extractionQueued: boolean;
+  /** True when at least one observe-derived turn was appended to the transcript store (issue #2783). False when the transcript capability is off, every message was filtered/deduped, or every append failed. */
+  transcriptPersisted: boolean;
   /** True when replayed from the idempotency cache (issue #1649); lets the HTTP surface skip the write-quota slot, matching memory_store replay semantics. */
   idempotencyReplay?: boolean;
 }
@@ -3820,11 +3822,39 @@ export class EngramAccessService extends SupportPassportAccessServiceBase {
   async memorySummarizeHourly(): Promise<{
     ok: true;
     message: string;
+    sessionsConsidered: number;
+    sessionsWithEntries: number;
+    summariesWritten: number;
+    staleStore: boolean;
+    newestEntryTimestamp: string | null;
+    warning?: string;
   }> {
-    await this.orchestrator.summarizer.runHourly();
+    // Issue #2783: the daemon-side summarizer must not report success on
+    // empty work. An empty or stale transcript store is the starvation
+    // signature (11 days of silent ok:true in the field report); surface
+    // it as a distinct warning plus counts so monitoring can alert on it.
+    const stats = await this.orchestrator.summarizer.runHourly();
+    if (stats.sessionsConsidered === 0) {
+      return {
+        ok: true,
+        message:
+          "Hourly summarization completed, but the transcript store is empty — no sessions found. If turns are ingested via observe, transcript persistence may be disabled or failing.",
+        ...stats,
+        warning: "transcript store is empty",
+      };
+    }
+    if (stats.sessionsWithEntries === 0 && stats.staleStore) {
+      return {
+        ok: true,
+        message: `Hourly summarization completed with no transcript entries for the target hour, and the store looks stale (newest entry ${stats.newestEntryTimestamp ?? "unknown"}).`,
+        ...stats,
+        warning: "no transcript entries for the target hour and no new entries recently",
+      };
+    }
     return {
       ok: true,
-      message: "Hourly summarization completed. Check the summaries directory for results.",
+      message: `Hourly summarization completed: ${stats.summariesWritten} summar${stats.summariesWritten === 1 ? "y" : "ies"} written across ${stats.sessionsWithEntries} session${stats.sessionsWithEntries === 1 ? "" : "s"} with transcript entries.`,
+      ...stats,
     };
   }
 

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -47,6 +47,25 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Outcome stats of one `runHourly` pass (issue #2783). The summarizer must
+ * not report success on empty work: an empty or stale transcript store is
+ * the delegate-mode starvation signature, and callers surface these counts
+ * and the staleness flag as a distinct warning instead of a bare ok.
+ */
+export interface HourlySummarizerRunStats {
+  sessionsConsidered: number;
+  sessionsWithEntries: number;
+  summariesWritten: number;
+  /** True when the newest transcript entry across the store is older than STALE_STORE_MS. */
+  staleStore: boolean;
+  /** ISO timestamp of the newest transcript entry seen by the scan, when any exist. */
+  newestEntryTimestamp: string | null;
+}
+
+/** A store whose newest entry is older than this is considered stale (starvation signal, issue #2783). */
+const STALE_STORE_MS = 2 * 60 * 60 * 1000;
+
 export class HourlySummarizer {
   private summariesDir: string;
   private config: PluginConfig;
@@ -653,6 +672,10 @@ Respond with valid JSON matching this schema:
     return summaries;
   }
 
+  // Newest transcript entry timestamp seen by the last getActiveSessions
+  // scan (issue #2783 starvation signal).
+  private newestTranscriptTimestamp: string | null = null;
+
   // Format summaries for recall injection
   formatForRecall(summaries: HourlySummary[], maxCount: number): string {
     if (summaries.length === 0) return "";
@@ -671,11 +694,14 @@ Respond with valid JSON matching this schema:
   }
 
   // Main entry point for cron job
-  async runHourly(): Promise<void> {
+  async runHourly(): Promise<HourlySummarizerRunStats> {
     log.debug("running hourly summary generation");
 
     // Get active sessions from transcript
+    this.newestTranscriptTimestamp = null;
     const sessions = await this.getActiveSessions();
+    let sessionsWithEntries = 0;
+    let summariesWritten = 0;
 
     for (const sessionKey of sessions) {
       // Calculate the hour we want to summarize (previous hour)
@@ -691,14 +717,28 @@ Respond with valid JSON matching this schema:
         log.debug(`no transcript entries for ${sessionKey} at ${hourStart.toISOString()}`);
         continue;
       }
+      sessionsWithEntries += 1;
 
       // Generate and save summary
       const summary = await this.generateSummary(sessionKey, hourStart, entries);
       if (summary) {
         await this.saveSummary(summary);
+        summariesWritten += 1;
         log.info(`generated hourly summary for ${sessionKey} (${entries.length} turns)`);
       }
     }
+
+    return {
+      sessionsConsidered: sessions.length,
+      sessionsWithEntries,
+      summariesWritten,
+      // Staleness signal (issue #2783): newest entry across the whole
+      // store, from the same scan getActiveSessions already performs.
+      staleStore:
+        this.newestTranscriptTimestamp !== null &&
+        Date.now() - new Date(this.newestTranscriptTimestamp).getTime() > STALE_STORE_MS,
+      newestEntryTimestamp: this.newestTranscriptTimestamp,
+    };
   }
 
   // Get list of active sessions from transcript directory
@@ -747,6 +787,13 @@ Respond with valid JSON matching this schema:
           const entry = JSON.parse(line) as TranscriptEntry;
           if (typeof entry.sessionKey === "string" && entry.sessionKey.length > 0) {
             sessionKeys.add(entry.sessionKey);
+          }
+          if (
+            typeof entry.timestamp === "string" &&
+            (this.newestTranscriptTimestamp === null ||
+              entry.timestamp > this.newestTranscriptTimestamp)
+          ) {
+            this.newestTranscriptTimestamp = entry.timestamp;
           }
         } catch {
           // ignore malformed transcript lines

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -753,6 +753,7 @@ Respond with valid JSON matching this schema:
 
     const sessionKeys = new Set<string>();
     let newestEntryTimestamp: string | null = null;
+    let newestEntryTimeMs = Number.NaN;
     const collect = async (transcriptPath: string): Promise<void> => {
       try {
         const raw = await readFile(transcriptPath, "utf-8");
@@ -763,11 +764,15 @@ Respond with valid JSON matching this schema:
             if (typeof entry.sessionKey === "string" && entry.sessionKey.length > 0) {
               sessionKeys.add(entry.sessionKey);
             }
-            if (
-              typeof entry.timestamp === "string" &&
-              (newestEntryTimestamp === null || entry.timestamp > newestEntryTimestamp)
-            ) {
-              newestEntryTimestamp = entry.timestamp;
+            // Compare parsed epoch values, never strings: a malformed
+            // timestamp in a hand-edited file must not poison the staleness
+            // signal with a lexically-maximal garbage value (review).
+            if (typeof entry.timestamp === "string") {
+              const timeMs = new Date(entry.timestamp).getTime();
+              if (Number.isFinite(timeMs) && (Number.isNaN(newestEntryTimeMs) || timeMs > newestEntryTimeMs)) {
+                newestEntryTimeMs = timeMs;
+                newestEntryTimestamp = entry.timestamp;
+              }
             }
           } catch {
             // ignore malformed transcript lines

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -9,20 +9,14 @@ import { extractJsonCandidates } from "./json-extract.js";
 import type { HourlySummary, TranscriptEntry, PluginConfig, GatewayConfig } from "./types.js";
 import type { TranscriptManager } from "./transcript.js";
 import { readSummarySnapshot, upsertSummarySnapshot, writeSummarySnapshot } from "./summary-snapshot.js";
-import {
-  encodeStoragePathSegment,
-  resolveSafeStoragePath,
-} from "./storage-paths.js";
+import { encodeStoragePathSegment, resolveSafeStoragePath } from "./storage-paths.js";
 import { sessionStoragePaths } from "./session-identity.js";
 import { resolveLocalLlmCapabilities } from "./capabilities.js";
 import { resolvePipelineProcessingCapabilities } from "./capabilities.js";
 
 // Schema for LLM summary output
 const HourlySummarySchema = z.object({
-  bullets: z
-    .array(z.string().trim().min(1))
-    .min(1)
-    .describe("3-5 bullet points summarizing the hour's activity"),
+  bullets: z.array(z.string().trim().min(1)).min(1).describe("3-5 bullet points summarizing the hour's activity"),
 });
 
 type HourlySummaryResult = z.infer<typeof HourlySummarySchema>;
@@ -61,6 +55,8 @@ export interface HourlySummarizerRunStats {
   staleStore: boolean;
   /** ISO timestamp of the newest transcript entry seen by the scan, when any exist. */
   newestEntryTimestamp: string | null;
+  /** True when the transcript scan itself FAILED (unreadable store) — distinct from an empty store. */
+  scanFailed: boolean;
 }
 
 /** A store whose newest entry is older than this is considered stale (starvation signal, issue #2783). */
@@ -74,7 +70,12 @@ export class HourlySummarizer {
   private modelRegistry: ModelRegistry;
   private transcript?: TranscriptManager;
 
-  constructor(config: PluginConfig, gatewayConfig?: GatewayConfig, modelRegistry?: ModelRegistry, transcript?: TranscriptManager) {
+  constructor(
+    config: PluginConfig,
+    gatewayConfig?: GatewayConfig,
+    modelRegistry?: ModelRegistry,
+    transcript?: TranscriptManager
+  ) {
     this.config = config;
     this.summariesDir = path.join(config.memoryDir, "summaries", "hourly");
     this.modelRegistry = modelRegistry ?? new ModelRegistry(config.memoryDir);
@@ -84,12 +85,13 @@ export class HourlySummarizer {
     this.localLlm = new LocalLlmClient(config, this.modelRegistry);
 
     // Initialize fallback client with gateway config
-    this.fallbackLlm = new FallbackLlmClient(
-      gatewayConfig,
-      fallbackLlmRuntimeContextFromConfig(config),
-    );
+    this.fallbackLlm = new FallbackLlmClient(gatewayConfig, fallbackLlmRuntimeContextFromConfig(config));
 
-    if (!gatewayConfig?.agents?.defaults?.model?.primary && !resolveLocalLlmCapabilities(config).localLlm && config.modelSource !== "gateway") {
+    if (
+      !gatewayConfig?.agents?.defaults?.model?.primary &&
+      !resolveLocalLlmCapabilities(config).localLlm &&
+      config.modelSource !== "gateway"
+    ) {
       log.warn("no gateway default AI and local LLM disabled — hourly summarization disabled");
     }
   }
@@ -102,7 +104,9 @@ export class HourlySummarizer {
     return resolveLocalLlmCapabilities(this.config).localLlm && !this.useGatewayModelSource;
   }
 
-  private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
+  private withGatewayAgent(
+    options: import("./fallback-llm.js").FallbackLlmOptions
+  ): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
     // Shared resolution (taskModelChain > gatewayAgentId) — gotcha #22. Issue #1365.
     return { ...options, ...gatewayTaskChainOptions(this.config) };
@@ -114,10 +118,7 @@ export class HourlySummarizer {
   }
 
   private async summarySessionDir(sessionKey: string): Promise<string> {
-    return resolveSafeStoragePath(
-      this.summariesDir,
-      encodeStoragePathSegment(sessionKey, "session"),
-    );
+    return resolveSafeStoragePath(this.summariesDir, encodeStoragePathSegment(sessionKey, "session"));
   }
 
   private async legacySummarySessionDir(sessionKey: string): Promise<string | null> {
@@ -146,9 +147,7 @@ export class HourlySummarizer {
     if (entries.length === 0) return null;
 
     // Format entries for the LLM
-    const conversation = entries
-      .map((e) => `[${e.role}] ${e.content}`)
-      .join("\n\n");
+    const conversation = entries.map((e) => `[${e.role}] ${e.content}`).join("\n\n");
 
     if (resolvePipelineProcessingCapabilities(this.config).hourlySummariesExtended) {
       const extended = await this.generateExtended(sessionKey, hourStart, conversation, entries);
@@ -182,9 +181,7 @@ export class HourlySummarizer {
         const localResult = await this.generateWithLocalLlm(conversation);
         if (localResult) {
           const durationMs = Date.now() - startTime;
-          log.debug(
-            `generated hourly summary for ${sessionKey} at ${hourIso} in ${durationMs}ms using local LLM`
-          );
+          log.debug(`generated hourly summary for ${sessionKey} at ${hourIso} in ${durationMs}ms using local LLM`);
           return {
             hour: hourIso,
             sessionKey,
@@ -236,15 +233,13 @@ Respond with valid JSON matching this schema:
       const result = await this.fallbackLlm.parseWithSchema(
         messages,
         HourlySummarySchema,
-        this.withGatewayAgent({ temperature: 0.3, maxTokens: 8192 }),
+        this.withGatewayAgent({ temperature: 0.3, maxTokens: 8192 })
       );
 
       const durationMs = Date.now() - startTime;
 
       if (result) {
-        log.debug(
-          `generated hourly summary for ${sessionKey} at ${hourIso} in ${durationMs}ms via fallback`,
-        );
+        log.debug(`generated hourly summary for ${sessionKey} at ${hourIso} in ${durationMs}ms via fallback`);
         return {
           hour: hourIso,
           sessionKey,
@@ -266,7 +261,7 @@ Respond with valid JSON matching this schema:
     sessionKey: string,
     hourStart: Date,
     conversation: string,
-    entries: TranscriptEntry[],
+    entries: TranscriptEntry[]
   ): Promise<(HourlySummaryExtendedResult & { _meta: HourlySummaryExtendedMeta }) | null> {
     const hourIso = hourStart.toISOString();
     const startTime = Date.now();
@@ -280,12 +275,17 @@ Respond with valid JSON matching this schema:
 
     const sys = `You are a conversation summarization system.\n\nSummarize the hour into structured sections.\n\nReturn valid JSON matching:\n{\n  \"topics\": [\"...\"],\n  \"decisions\": [\"...\"],\n  \"actionItems\": [\"...\"],\n  \"rejected\": [\"...\"]\n}\n\nGuidelines:\n- Prefer concrete topics and decisions.\n- Action items should be imperative.\n- Rejected ideas are things that were explicitly discarded or reversed.\n- If there are none for a section, return an empty array.\n`;
 
-    const toolStatsLine = Object.keys(toolCounts).length > 0
-      ? `Tools used (counts): ${Object.entries(toolCounts).sort((a,b)=>b[1]-a[1]).slice(0,10).map(([k,v])=>`${k}=${v}`).join(", ")}\n\n`
-      : "";
+    const toolStatsLine =
+      Object.keys(toolCounts).length > 0
+        ? `Tools used (counts): ${Object.entries(toolCounts)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 10)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(", ")}\n\n`
+        : "";
     const userTurns = entries.filter((e) => e.role === "user").length;
     const assistantTurns = entries.filter((e) => e.role === "assistant").length;
-    const toolCalls = Object.values(toolCounts).reduce((a,b)=>a+b,0);
+    const toolCalls = Object.values(toolCounts).reduce((a, b) => a + b, 0);
     const statsLine = `Stats: userTurns=${userTurns}, assistantTurns=${assistantTurns}, toolCalls=${toolCalls}\n\n`;
 
     const user = `Hour: ${hourIso}\nSession: ${sessionKey}\n\n${statsLine}${toolStatsLine}Conversation:\n${conversation}\n`;
@@ -293,8 +293,14 @@ Respond with valid JSON matching this schema:
     // Try local LLM first if enabled
     if (this.shouldUseLocalLlm) {
       try {
-        const contextSizes = this.modelRegistry.calculateContextSizes(this.config.localLlmModel, this.config.localLlmMaxContext);
-        const truncated = user.length > contextSizes.maxInputChars ? user.slice(0, contextSizes.maxInputChars) + "\n\n[truncated]" : user;
+        const contextSizes = this.modelRegistry.calculateContextSizes(
+          this.config.localLlmModel,
+          this.config.localLlmMaxContext
+        );
+        const truncated =
+          user.length > contextSizes.maxInputChars
+            ? user.slice(0, contextSizes.maxInputChars) + "\n\n[truncated]"
+            : user;
         const response = await this.localLlm.chatCompletion(
           [
             { role: "system", content: "Output valid JSON only." },
@@ -305,7 +311,7 @@ Respond with valid JSON matching this schema:
             maxTokens: contextSizes.maxOutputTokens,
             operation: "hourly_summary_extended",
             priority: "background",
-          },
+          }
         );
         if (response?.content) {
           const content = response.content.trim();
@@ -314,7 +320,7 @@ Respond with valid JSON matching this schema:
               const parsed = JSON.parse(candidate);
               const result = HourlySummaryExtendedSchema.parse(parsed);
               log.debug(
-                `generated extended hourly summary for ${sessionKey} at ${hourIso} in ${Date.now() - startTime}ms (local)`,
+                `generated extended hourly summary for ${sessionKey} at ${hourIso} in ${Date.now() - startTime}ms (local)`
               );
               return { ...result, _meta: { userTurns, assistantTurns, toolCalls, toolCounts } };
             } catch {
@@ -335,10 +341,12 @@ Respond with valid JSON matching this schema:
           { role: "user" as const, content: user },
         ],
         HourlySummaryExtendedSchema,
-        this.withGatewayAgent({ temperature: 0.2, maxTokens: 2048 }),
+        this.withGatewayAgent({ temperature: 0.2, maxTokens: 2048 })
       );
       if (result) {
-        log.debug(`generated extended hourly summary for ${sessionKey} at ${hourIso} in ${Date.now() - startTime}ms (fallback)`);
+        log.debug(
+          `generated extended hourly summary for ${sessionKey} at ${hourIso} in ${Date.now() - startTime}ms (fallback)`
+        );
         return { ...result, _meta: { userTurns, assistantTurns, toolCalls, toolCounts } };
       }
       return null;
@@ -361,9 +369,10 @@ Respond with valid JSON matching this schema:
     log.debug(`Summarizer model context: ${contextSizes.description}`);
 
     const maxConversationChars = contextSizes.maxInputChars;
-    const truncatedConversation = conversation.length > maxConversationChars
-      ? conversation.slice(0, maxConversationChars) + "\n\n[truncated]"
-      : conversation;
+    const truncatedConversation =
+      conversation.length > maxConversationChars
+        ? conversation.slice(0, maxConversationChars) + "\n\n[truncated]"
+        : conversation;
 
     const instructions = `You are a conversation summarization system. Summarize the following conversation transcript into 3-5 concise bullet points.
 
@@ -392,7 +401,7 @@ Respond with valid JSON matching this schema:
         maxTokens: contextSizes.maxOutputTokens,
         operation: "hourly_summary",
         priority: "background",
-      },
+      }
     );
 
     if (!response?.content) {
@@ -452,9 +461,7 @@ Respond with valid JSON matching this schema:
       nextHeaderPattern.lastIndex = sectionStart + hourHeader.length;
       const nextHeader = nextHeaderPattern.exec(existingContent);
       const beforeHour = existingContent.slice(0, sectionStart);
-      const afterHour = nextHeader
-        ? existingContent.slice(nextHeader.index + 1)
-        : "";
+      const afterHour = nextHeader ? existingContent.slice(nextHeader.index + 1) : "";
       const newSection = this.formatHourSection(summary, hourHeader);
       existingContent = beforeHour + newSection.trimEnd() + (afterHour ? "\n\n" + afterHour : "\n");
 
@@ -478,13 +485,15 @@ Respond with valid JSON matching this schema:
       await upsertSummarySnapshot(this.config.memoryDir, summary);
     } catch (error) {
       log.warn(
-        `hourly summarizer: failed to update summary snapshot for ${summary.sessionKey} (fail-open): ${String(error)}`,
+        `hourly summarizer: failed to update summary snapshot for ${summary.sessionKey} (fail-open): ${String(error)}`
       );
     }
   }
 
   private formatHourSection(summary: HourlySummary, hourHeader: string): string {
-    const ext = (summary as any)._extended as (HourlySummaryExtendedResult & { _meta?: HourlySummaryExtendedMeta }) | undefined;
+    const ext = (summary as any)._extended as
+      | (HourlySummaryExtendedResult & { _meta?: HourlySummaryExtendedMeta })
+      | undefined;
     const meta = (summary as any)._extendedMeta as HourlySummaryExtendedMeta | undefined;
     const lines: string[] = [hourHeader, ""];
 
@@ -556,24 +565,18 @@ Respond with valid JSON matching this schema:
       }
 
       const sortedSummaries = Array.from(byHour.values()).sort(
-        (a, b) => new Date(b.hour).getTime() - new Date(a.hour).getTime(),
+        (a, b) => new Date(b.hour).getTime() - new Date(a.hour).getTime()
       );
 
       // Filter to recent hours while materializing the full parsed history.
-      const recent = sortedSummaries.filter(
-        (s) => new Date(s.hour).getTime() >= cutoffTime,
-      );
+      const recent = sortedSummaries.filter((s) => new Date(s.hour).getTime() >= cutoffTime);
 
       if (sortedSummaries.length > 0) {
         try {
-          await writeSummarySnapshot(
-            this.config.memoryDir,
-            sessionKey,
-            sortedSummaries,
-          );
+          await writeSummarySnapshot(this.config.memoryDir, sessionKey, sortedSummaries);
         } catch (error) {
           log.warn(
-            `hourly summarizer: failed to materialize summary snapshot for ${sessionKey} (fail-open): ${String(error)}`,
+            `hourly summarizer: failed to materialize summary snapshot for ${sessionKey} (fail-open): ${String(error)}`
           );
         }
       }
@@ -585,10 +588,7 @@ Respond with valid JSON matching this schema:
     }
   }
 
-  private async readSummaryDir(
-    sessionDir: string,
-    sessionKey: string,
-  ): Promise<HourlySummary[]> {
+  private async readSummaryDir(sessionDir: string, sessionKey: string): Promise<HourlySummary[]> {
     let files: string[];
     try {
       files = await readdir(sessionDir);
@@ -613,11 +613,7 @@ Respond with valid JSON matching this schema:
     return summaries;
   }
 
-  private parseSummaryFile(
-    content: string,
-    sessionKey: string,
-    filename: string
-  ): HourlySummary[] {
+  private parseSummaryFile(content: string, sessionKey: string, filename: string): HourlySummary[] {
     const summaries: HourlySummary[] = [];
 
     // Extract date from filename (YYYY-MM-DD.md)
@@ -672,10 +668,6 @@ Respond with valid JSON matching this schema:
     return summaries;
   }
 
-  // Newest transcript entry timestamp seen by the last getActiveSessions
-  // scan (issue #2783 starvation signal).
-  private newestTranscriptTimestamp: string | null = null;
-
   // Format summaries for recall injection
   formatForRecall(summaries: HourlySummary[], maxCount: number): string {
     if (summaries.length === 0) return "";
@@ -697,9 +689,11 @@ Respond with valid JSON matching this schema:
   async runHourly(): Promise<HourlySummarizerRunStats> {
     log.debug("running hourly summary generation");
 
-    // Get active sessions from transcript
-    this.newestTranscriptTimestamp = null;
-    const sessions = await this.getActiveSessions();
+    // Get active sessions from transcript. The scan outcome is kept LOCAL to
+    // this invocation (review round 2): shared instance state would let two
+    // concurrent runHourly calls cross-report each other's timestamps.
+    const scan = await this.getActiveSessions();
+    const sessions = scan.sessionKeys;
     let sessionsWithEntries = 0;
     let summariesWritten = 0;
 
@@ -735,22 +729,56 @@ Respond with valid JSON matching this schema:
       // Staleness signal (issue #2783): newest entry across the whole
       // store, from the same scan getActiveSessions already performs.
       staleStore:
-        this.newestTranscriptTimestamp !== null &&
-        Date.now() - new Date(this.newestTranscriptTimestamp).getTime() > STALE_STORE_MS,
-      newestEntryTimestamp: this.newestTranscriptTimestamp,
+        scan.newestEntryTimestamp !== null &&
+        Date.now() - new Date(scan.newestEntryTimestamp).getTime() > STALE_STORE_MS,
+      newestEntryTimestamp: scan.newestEntryTimestamp,
+      scanFailed: scan.scanFailed,
     };
   }
 
-  // Get list of active sessions from transcript directory
-  private async getActiveSessions(): Promise<string[]> {
-    const transcriptDir = await resolveSafeStoragePath(
-      this.config.memoryDir,
-      "transcripts",
-    ).catch(() => null);
-    if (transcriptDir === null) return [];
+  // Get list of active sessions from the transcript directory, plus the
+  // scan bookkeeping runHourly reports: newest entry timestamp (staleness
+  // signal) and whether the scan itself FAILED. A failed scan must not be
+  // reported as an empty store — those are different incidents (review
+  // round 2).
+  private async getActiveSessions(): Promise<{
+    sessionKeys: string[];
+    newestEntryTimestamp: string | null;
+    scanFailed: boolean;
+  }> {
+    const transcriptDir = await resolveSafeStoragePath(this.config.memoryDir, "transcripts").catch(() => null);
+    if (transcriptDir === null) {
+      return { sessionKeys: [], newestEntryTimestamp: null, scanFailed: false };
+    }
+
+    const sessionKeys = new Set<string>();
+    let newestEntryTimestamp: string | null = null;
+    const collect = async (transcriptPath: string): Promise<void> => {
+      try {
+        const raw = await readFile(transcriptPath, "utf-8");
+        for (const line of raw.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            const entry = JSON.parse(line) as TranscriptEntry;
+            if (typeof entry.sessionKey === "string" && entry.sessionKey.length > 0) {
+              sessionKeys.add(entry.sessionKey);
+            }
+            if (
+              typeof entry.timestamp === "string" &&
+              (newestEntryTimestamp === null || entry.timestamp > newestEntryTimestamp)
+            ) {
+              newestEntryTimestamp = entry.timestamp;
+            }
+          } catch {
+            // ignore malformed transcript lines
+          }
+        }
+      } catch {
+        // ignore unreadable transcript files
+      }
+    };
 
     try {
-      const sessionKeys = new Set<string>();
       const typeEntries = await readdir(transcriptDir, { withFileTypes: true });
       for (const typeEnt of typeEntries) {
         if (!typeEnt.isDirectory()) continue;
@@ -765,51 +793,29 @@ Respond with valid JSON matching this schema:
           for (const file of files) {
             const transcriptPath = await resolveSafeStoragePath(chanDir, file).catch(() => null);
             if (transcriptPath === null) continue;
-            await this.collectTranscriptSessionKeys(transcriptPath, sessionKeys);
+            await collect(transcriptPath);
           }
         }
       }
-      return Array.from(sessionKeys);
-    } catch {
-      return [];
-    }
-  }
-
-  private async collectTranscriptSessionKeys(
-    transcriptPath: string,
-    sessionKeys: Set<string>,
-  ): Promise<void> {
-    try {
-      const raw = await readFile(transcriptPath, "utf-8");
-      for (const line of raw.split("\n")) {
-        if (!line.trim()) continue;
-        try {
-          const entry = JSON.parse(line) as TranscriptEntry;
-          if (typeof entry.sessionKey === "string" && entry.sessionKey.length > 0) {
-            sessionKeys.add(entry.sessionKey);
-          }
-          if (
-            typeof entry.timestamp === "string" &&
-            (this.newestTranscriptTimestamp === null ||
-              entry.timestamp > this.newestTranscriptTimestamp)
-          ) {
-            this.newestTranscriptTimestamp = entry.timestamp;
-          }
-        } catch {
-          // ignore malformed transcript lines
-        }
+      return {
+        sessionKeys: Array.from(sessionKeys),
+        newestEntryTimestamp,
+        scanFailed: false,
+      };
+    } catch (err) {
+      // ENOENT on the root is a never-written store — an EMPTY store, not a
+      // scan failure (those are different incidents).
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") {
+        return { sessionKeys: [], newestEntryTimestamp: null, scanFailed: false };
       }
-    } catch {
-      // ignore unreadable transcript files
+      log.warn(`transcript scan failed: ${err}`);
+      return { sessionKeys: [], newestEntryTimestamp: null, scanFailed: true };
     }
   }
 
   // Get transcript entries for a session within a time range
-  private async getTranscriptEntries(
-    sessionKey: string,
-    startTime: Date,
-    endTime: Date
-  ): Promise<TranscriptEntry[]> {
+  private async getTranscriptEntries(sessionKey: string, startTime: Date, endTime: Date): Promise<TranscriptEntry[]> {
     // Shared session-identity layer (issue #1496, rule #22). Arbitrary keys
     // route to `session/<hash>`; legacy `agent:<id>:...` keep their paths. The
     // shared helper also supplies the read-back-only candidate dirs (mirrors
@@ -821,8 +827,8 @@ Respond with valid JSON matching this schema:
       const transcriptRoot = path.join(this.config.memoryDir, "transcripts");
       const candidateDirs = new Set(
         [paths.dir, paths.alternateDir, paths.legacyDir, ...paths.readbackDirs].filter(
-          (dir): dir is string => typeof dir === "string" && dir.length > 0,
-        ),
+          (dir): dir is string => typeof dir === "string" && dir.length > 0
+        )
       );
       const entries: TranscriptEntry[] = [];
       // Dedup identical raw rows that a partially-applied migration may have

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -62,6 +62,47 @@ export interface HourlySummarizerRunStats {
 /** A store whose newest entry is older than this is considered stale (starvation signal, issue #2783). */
 const STALE_STORE_MS = 2 * 60 * 60 * 1000;
 
+/**
+ * Interpret one {@link HourlySummarizerRunStats} into the operator-facing
+ * message/warning (issue #2783). Every degraded shape — failed scan, empty
+ * store, backend-down, stale store — is DISTINCT from success; monitoring
+ * alerts on `warning`, never on `ok` (ok only means "the run completed").
+ */
+export function summarizeHourlyStatus(stats: HourlySummarizerRunStats): {
+  message: string;
+  warning?: string;
+} {
+  if (stats.scanFailed) {
+    return {
+      message:
+        "Hourly summarization completed, but the transcript store scan FAILED (unreadable directory or I/O error). Investigate the daemon's memoryDir.",
+      warning: "transcript store scan failed",
+    };
+  }
+  if (stats.sessionsConsidered === 0) {
+    return {
+      message:
+        "Hourly summarization completed, but the transcript store is empty — no sessions found. If turns are ingested via observe, transcript persistence may be disabled or failing.",
+      warning: "transcript store is empty",
+    };
+  }
+  if (stats.sessionsWithEntries > 0 && stats.summariesWritten === 0) {
+    return {
+      message: `Hourly summarization found ${stats.sessionsWithEntries} session(s) with transcript entries but wrote no summaries — the summarizer backend may be down.`,
+      warning: "sessions with entries produced no summaries",
+    };
+  }
+  if (stats.sessionsWithEntries === 0 && stats.staleStore) {
+    return {
+      message: `Hourly summarization completed with no transcript entries for the target hour, and the store looks stale (newest entry ${stats.newestEntryTimestamp ?? "unknown"}).`,
+      warning: "no transcript entries for the target hour and no new entries recently",
+    };
+  }
+  return {
+    message: `Hourly summarization completed: ${stats.summariesWritten} summar${stats.summariesWritten === 1 ? "y" : "ies"} written across ${stats.sessionsWithEntries} session${stats.sessionsWithEntries === 1 ? "" : "s"} with transcript entries.`,
+  };
+}
+
 export class HourlySummarizer {
   private summariesDir: string;
   private config: PluginConfig;
@@ -754,6 +795,7 @@ Respond with valid JSON matching this schema:
     const sessionKeys = new Set<string>();
     let newestEntryTimestamp: string | null = null;
     let newestEntryTimeMs = Number.NaN;
+    let fileReadFailed = false;
     const collect = async (transcriptPath: string): Promise<void> => {
       try {
         const raw = await readFile(transcriptPath, "utf-8");
@@ -778,8 +820,14 @@ Respond with valid JSON matching this schema:
             // ignore malformed transcript lines
           }
         }
-      } catch {
-        // ignore unreadable transcript files
+      } catch (err) {
+        // ENOENT is a concurrently-deleted file — ignore. Any other read
+        // failure (permissions, I/O) means the store is partially UNREADABLE:
+        // mark the scan failed so the caller warns instead of reporting an
+        // empty store (review round 3).
+        if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+          fileReadFailed = true;
+        }
       }
     };
 
@@ -805,7 +853,7 @@ Respond with valid JSON matching this schema:
       return {
         sessionKeys: Array.from(sessionKeys),
         newestEntryTimestamp,
-        scanFailed: false,
+        scanFailed: fileReadFailed,
       };
     } catch (err) {
       // ENOENT on the root is a never-written store — an EMPTY store, not a

--- a/packages/remnic-core/src/summary-snapshot.test.ts
+++ b/packages/remnic-core/src/summary-snapshot.test.ts
@@ -605,10 +605,11 @@ test("runHourly keeps processing later sessions when snapshot upsert fails after
     },
   ] as any[];
 
-  (summarizer as any).getActiveSessions = async () => [
-    failingSession,
-    succeedingSession,
-  ];
+  (summarizer as any).getActiveSessions = async () => ({
+    sessionKeys: [failingSession, succeedingSession],
+    newestEntryTimestamp: null,
+    scanFailed: false,
+  });
   (summarizer as any).getTranscriptEntries = async () => fakeEntries;
   (summarizer as any).generateSummary = async (
     sessionKey: string,
@@ -680,11 +681,12 @@ test("hourly active session discovery reads every session key in a transcript fi
     "utf-8",
   );
 
-  const sessions = await (summarizer as any).getActiveSessions();
+  const scan = await (summarizer as any).getActiveSessions();
   assert.deepEqual(
-    [...sessions].sort(),
+    [...scan.sessionKeys].sort(),
     ["agent:first:main", "agent:second:main"],
   );
+  assert.equal(scan.scanFailed, false);
 });
 
 test("hourly transcript lookup ignores traversal channel paths", async () => {

--- a/tests/access-service-observe.test.ts
+++ b/tests/access-service-observe.test.ts
@@ -37,6 +37,7 @@ test("EngramAccessObserveResponse shape matches contract", () => {
     },
     lcmArchived: true,
     extractionQueued: true,
+    transcriptPersisted: true,
   };
   assert.equal(response.accepted, 2);
   assert.equal(response.sessionKey, "test-session");
@@ -45,6 +46,8 @@ test("EngramAccessObserveResponse shape matches contract", () => {
   assert.equal(response.scopeDebug?.codingOverlayApplied, true);
   assert.equal(response.lcmArchived, true);
   assert.equal(response.extractionQueued, true);
+  // #2783: observe reports whether transcript persistence appended turns.
+  assert.equal(response.transcriptPersisted, true);
 });
 
 test("EngramAccessObserveRequest with skipExtraction matches contract", () => {


### PR DESCRIPTION
## Summary

Fixes #2783.

A delegate-mode gateway (`@remnic/plugin-openclaw` with `REMNIC_BRIDGE_MODE=delegate`) POSTs every turn to `/engram/v1/observe`, but nothing in the daemon's observe path wrote the transcript store that `memory_summarize_hourly` reads. The hourly summarizer starved silently while every run reported `ok: true` — 11 days and 1,323 consecutive empty runs in the field report.

## Changes

- **Transcript persistence in the observe path.** `runObserve` now appends each eligible message to the per-session transcript store through the new `ObserveTranscriptPersister` (`access-observe-transcript.ts`). It mirrors the embedded runtime's `agent_end` append: same `TranscriptManager`, same entry shape, same `transcriptEnabled` presentation gate, same 10-char noise floor. Turns are deduped against a bounded process-lifetime `(session, role, content)` fingerprint — the daemon-side equivalent of the embedded runtime's `observedInboundContentFingerprints`, extended to both roles because an un-keyed client re-POST always carries the whole turn. Best-effort by design: an append failure logs and never fails the observe (same policy as the LCM enqueue).
  - Response gains `transcriptPersisted`; the `access-observe` log line gains `transcript=`.
- **Distinct empty/stale signal from the summarizer.** `runHourly` returns `HourlySummarizerRunStats` (sessions considered / with entries / summaries written, plus the newest transcript entry timestamp from the scan `getActiveSessions` already performs). `memory_summarize_hourly` reports those counts and an explicit `warning` when the store is empty (no sessions) or stale (no new entries in >2h and nothing in the target hour) instead of an unconditional bare ok. The MCP output schema gains the new optional fields.

## Verification

- New suite `access-observe-transcript-persistence.test.ts` (6 tests): persistence + entry shape, noise floor, re-POST dedupe with new-turn passthrough, capability gate, empty-store warning, stale-store warning.
- `tsc --noEmit` clean; `scripts/check-ratchets.mjs` OK (the persister is a sibling module — the observe surface stays under its 1200-LOC cap); `scripts/check-docs-parity.mjs` OK.
- Full local access-suite sweep: 240 tests across `src/access-*.test.ts` plus the new suite, all passing.

## Notes

- Deployments that do not want transcript persistence can set `transcriptEnabled: false` (the existing documented switch) — no new config knob.
- The summarizer warning is stateless (no last-run sidecar): the staleness threshold is 2h, chosen so a legitimately idle hour with recent activity does not warn while a starved store warns on the first run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observed messages can be persisted to session transcripts when enabled.
  * Observe responses report whether transcript persistence succeeded.
  * Transcript storage is isolated by effective namespace.
  * Hourly summarization reports session counts, summaries written, newest entries, and transcript scan status.
  * Added warnings for empty, outdated, or unreadable transcript stores.

* **Bug Fixes**
  * Prevented duplicate transcript entries during retries and concurrent processing.
  * Ignored messages that are too short to provide meaningful transcript content.
  * Skipped configured channel types during transcript persistence.
  * Transcript persistence failures no longer interrupt observation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->