### PR TITLE
feat(converge): watch mode — scheduled replication for failover pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `remnic converge watch` runs bidirectional convergence on a cadence (default 300s, `--interval <seconds>`, SIGINT/SIGTERM-safe) so an active/backup pair converges continuously instead of only when an operator runs `converge apply` — the scheduled-replication companion to `replicaPeers` divergence detection.
+
 ## [v9.62.2] — 2026-08-17
 
 ### Added

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -85,6 +85,7 @@ openclaw engram migrate rechunk                # Rebuild chunk files from curren
 openclaw engram migrate reextract --model gpt-5-mini  # Queue bounded re-extraction requests
 remnic converge plan --peer https://peer.example.com    # Build a non-mutating convergence plan
 remnic converge apply --peer https://peer.example.com   # Apply a convergence plan
+remnic converge watch --peer https://peer.example.com   # Apply on a cadence (scheduled replication)
 ```
 
 Compatibility diagnostics:
@@ -308,6 +309,31 @@ For the safest workflow, run `plan`, inspect its conflicts and actions, then run
 with the same peer, token, and policy. Run `apply` without `--dry-run` only after that output is
 acceptable. `manual` adds a fail-closed guard: unresolved conflicts prevent all mutation even
 without `--dry-run`.
+
+### Scheduled failover replication (`converge watch`)
+
+`apply` is one-shot: an active/backup pair only converges when an operator runs it. `watch` turns
+the same apply into a schedule, so a failover replica converges continuously instead of only after
+someone remembers to run a command:
+
+```text
+remnic converge watch --peer <url> [--token <token>] [--conflict-policy <policy>] [--interval <seconds>] [--json]
+```
+
+- `--interval <seconds>` sets the cadence (default 300, mirroring `replicaPeers.pollIntervalMs`;
+  values below 1 second are clamped to 1 second).
+- Each cycle runs the same apply as the one-shot command and prints one status line. With `--json`
+  the final summary is a machine-readable `ConvergeWatchOutcome`.
+- A failed cycle (peer unreachable, transient network error) is reported and does NOT stop the
+  watch — a peer being unreachable is exactly when the surviving side most needs to keep the
+  schedule. Unresolved conflicts under `manual` likewise stop mutation for that cycle only.
+- `SIGINT`/`SIGTERM` stop the watch after the current cycle completes.
+
+Run it as a supervised long-running process on ONE side of the pair (typically the side you want
+pulling from the primary), e.g. a systemd unit or launchd agent. Combine it with
+`replicaPeers` divergence detection: the daemon's `/health` corpus watermarks tell you the
+replication lag, and a divergence alert that persists across watch cycles means the converge
+transport itself needs attention.
 
 ## Compression Guideline Optimizer Tool
 

--- a/packages/remnic-cli/src/converge-watch.ts
+++ b/packages/remnic-cli/src/converge-watch.ts
@@ -28,12 +28,16 @@ export interface ConvergeWatchOutcome {
   cycles: number;
   convergedCycles: number;
   appliedCycles: number;
+  /** Threw, stopped on unresolved conflicts, or completed with failed transfers — every cycle the pair did NOT make progress. `cycles === convergedCycles + appliedCycles + failedCycles` always holds. */
   failedCycles: number;
   lastStatus: ConvergeApplyResult["status"] | "error" | "aborted";
 }
 
 const CONVERGE_WATCH_MIN_INTERVAL_MS = 1000;
 const CONVERGE_WATCH_DEFAULT_INTERVAL_MS = 300_000;
+/** Node clamps a setTimeout delay above 2^31-1 ms to 1ms, which would
+ *  hot-loop the watch — same ceiling guard as replicaPeers (issue #2149). */
+const CONVERGE_WATCH_MAX_INTERVAL_MS = 2_147_483_647;
 
 function sleepAborted(ms: number, signal: AbortSignal): Promise<boolean> {
   return new Promise((resolve) => {
@@ -64,18 +68,11 @@ function sleepAborted(ms: number, signal: AbortSignal): Promise<boolean> {
  * recent real outcome.
  */
 export async function convergeWatch(options: ConvergeWatchOptions): Promise<ConvergeWatchOutcome> {
-  const intervalMs = Math.max(
-    CONVERGE_WATCH_MIN_INTERVAL_MS,
-    options.intervalMs ?? CONVERGE_WATCH_DEFAULT_INTERVAL_MS,
+  const intervalMs = Math.min(
+    CONVERGE_WATCH_MAX_INTERVAL_MS,
+    Math.max(CONVERGE_WATCH_MIN_INTERVAL_MS, options.intervalMs ?? CONVERGE_WATCH_DEFAULT_INTERVAL_MS)
   );
-  const {
-    apply,
-    intervalMs: _intervalMs,
-    maxCycles,
-    onCycle,
-    signal,
-    ...applyOptions
-  } = options;
+  const { apply, intervalMs: _intervalMs, maxCycles, onCycle, signal, ...applyOptions } = options;
 
   const outcome: ConvergeWatchOutcome = {
     cycles: 0,
@@ -90,8 +87,13 @@ export async function convergeWatch(options: ConvergeWatchOptions): Promise<Conv
     try {
       const result = await apply(applyOptions);
       outcome.cycles += 1;
+      // A cycle that stopped on unresolved conflicts or had failed transfers
+      // made no progress — count it as failed so monitoring sees a stuck
+      // pair instead of a string of "applied" successes.
       if (result.converged) outcome.convergedCycles += 1;
-      else outcome.appliedCycles += 1;
+      else if (result.status === "stopped_unresolved_conflicts" || result.transfers.failed > 0) {
+        outcome.failedCycles += 1;
+      } else outcome.appliedCycles += 1;
       outcome.lastStatus = result.status;
       onCycle?.(outcome.cycles, { result });
     } catch (err) {

--- a/packages/remnic-cli/src/converge-watch.ts
+++ b/packages/remnic-cli/src/converge-watch.ts
@@ -1,0 +1,108 @@
+/**
+ * Scheduled replication loop for `remnic converge watch` — the cadence half
+ * of the #2150 convergence story. Kept in a sibling module so converge.ts
+ * stays under the #1995 new-file LOC ratchet.
+ */
+
+import type { ConvergeApplyOptions, ConvergeApplyResult } from "./converge.js";
+
+export interface ConvergeWatchOptions extends ConvergeApplyOptions {
+  /** Delay between cycles. Clamped to >= 1000ms so a bad flag cannot hot-loop. Default 300000 (mirrors replicaPeers.pollIntervalMs). */
+  intervalMs?: number;
+  /** Stop after N cycles (tests / one-shot scheduling). Undefined = run until aborted. */
+  maxCycles?: number;
+  /** Abort signal (SIGINT/SIGTERM) — stops after the current cycle completes. */
+  signal?: AbortSignal;
+  /**
+   * The applier invoked each cycle. Required — the CLI passes
+   * `executeConvergeApply`; tests inject a fake. Passing it (rather than
+   * importing it here) keeps this module free of an import cycle with
+   * converge.ts.
+   */
+  apply: (options: ConvergeApplyOptions) => Promise<ConvergeApplyResult>;
+  /** Per-cycle observer (structured logging / metrics). */
+  onCycle?: (cycle: number, outcome: { result?: ConvergeApplyResult; error?: unknown }) => void;
+}
+
+export interface ConvergeWatchOutcome {
+  cycles: number;
+  convergedCycles: number;
+  appliedCycles: number;
+  failedCycles: number;
+  lastStatus: ConvergeApplyResult["status"] | "error" | "aborted";
+}
+
+const CONVERGE_WATCH_MIN_INTERVAL_MS = 1000;
+const CONVERGE_WATCH_DEFAULT_INTERVAL_MS = 300_000;
+
+function sleepAborted(ms: number, signal: AbortSignal): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(false);
+    };
+    if (signal.aborted) {
+      clearTimeout(timer);
+      resolve(false);
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Run bidirectional convergence on an interval so an active/backup pair
+ * converges continuously instead of only when an operator remembers to run
+ * `converge apply`. A failed cycle (peer down, transient network error)
+ * reports and does NOT stop the watch — a peer being unreachable is exactly
+ * when the surviving side most needs to keep the schedule. `lastStatus`
+ * stays "aborted" only when no cycle ever ran; otherwise it holds the most
+ * recent real outcome.
+ */
+export async function convergeWatch(options: ConvergeWatchOptions): Promise<ConvergeWatchOutcome> {
+  const intervalMs = Math.max(
+    CONVERGE_WATCH_MIN_INTERVAL_MS,
+    options.intervalMs ?? CONVERGE_WATCH_DEFAULT_INTERVAL_MS,
+  );
+  const {
+    apply,
+    intervalMs: _intervalMs,
+    maxCycles,
+    onCycle,
+    signal,
+    ...applyOptions
+  } = options;
+
+  const outcome: ConvergeWatchOutcome = {
+    cycles: 0,
+    convergedCycles: 0,
+    appliedCycles: 0,
+    failedCycles: 0,
+    lastStatus: "aborted",
+  };
+
+  while (maxCycles === undefined || outcome.cycles < maxCycles) {
+    if (signal?.aborted) break;
+    try {
+      const result = await apply(applyOptions);
+      outcome.cycles += 1;
+      if (result.converged) outcome.convergedCycles += 1;
+      else outcome.appliedCycles += 1;
+      outcome.lastStatus = result.status;
+      onCycle?.(outcome.cycles, { result });
+    } catch (err) {
+      outcome.cycles += 1;
+      outcome.failedCycles += 1;
+      outcome.lastStatus = "error";
+      onCycle?.(outcome.cycles, { error: err });
+    }
+    if (maxCycles !== undefined && outcome.cycles >= maxCycles) break;
+    const slept = await sleepAborted(intervalMs, signal ?? new AbortController().signal);
+    if (!slept) break;
+  }
+  return outcome;
+}

--- a/packages/remnic-cli/src/converge-watch.ts
+++ b/packages/remnic-cli/src/converge-watch.ts
@@ -87,11 +87,19 @@ export async function convergeWatch(options: ConvergeWatchOptions): Promise<Conv
     try {
       const result = await apply(applyOptions);
       outcome.cycles += 1;
-      // A cycle that stopped on unresolved conflicts or had failed transfers
-      // made no progress — count it as failed so monitoring sees a stuck
-      // pair instead of a string of "applied" successes.
-      if (result.converged) outcome.convergedCycles += 1;
-      else if (result.status === "stopped_unresolved_conflicts" || result.transfers.failed > 0) {
+      // Classify by STATUS, not `converged`: a successful mutation returns
+      // status "applied" WITH converged true (executeConvergeApply sets
+      // converged = transfers.failed === 0), so `result.converged` cannot
+      // distinguish a real apply from a no-op converged plan. A cycle that
+      // stopped on unresolved conflicts or had failed transfers made no
+      // progress — count it as failed so monitoring sees a stuck pair
+      // instead of a string of successes. Dry-run cycles exercised the
+      // apply path without mutating; they count as applied.
+      if (result.status === "converged") outcome.convergedCycles += 1;
+      else if (
+        result.status === "stopped_unresolved_conflicts" ||
+        (result.status === "applied" && result.transfers.failed > 0)
+      ) {
         outcome.failedCycles += 1;
       } else outcome.appliedCycles += 1;
       outcome.lastStatus = result.status;

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1673,6 +1673,30 @@ test("remnic converge watch: bad --interval is rejected with exit code 2", async
   process.exitCode = undefined;
 });
 
+test("remnic converge watch: --interval with no value is rejected with exit code 2", async () => {
+  process.exitCode = undefined;
+  await cmdConverge("watch", ["--interval"], false);
+  assert.equal(process.exitCode, 2);
+  process.exitCode = undefined;
+});
+
+test("converge watch: a successful mutation cycle (status applied, converged true) counts as applied, not converged", async () => {
+  const outcome = await convergeWatch({
+    intervalMs: 1,
+    maxCycles: 2,
+    apply: async () =>
+      applyResult({
+        converged: true,
+        status: "applied",
+        transfers: { pulled: 3, pushed: 1, conflictsResolved: 0, suppressed: 0, failed: 0 },
+      }),
+  });
+  assert.equal(outcome.cycles, 2);
+  assert.equal(outcome.appliedCycles, 2);
+  assert.equal(outcome.convergedCycles, 0);
+  assert.equal(outcome.failedCycles, 0);
+});
+
 test("converge watch: conflict-stopped and partially-failed cycles count as failed, not applied", async () => {
   let calls = 0;
   const outcome = await convergeWatch({

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
 import { ContentHashIndex, OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES, parseConfig } from "@remnic/core";
-import type { ReconcileFileState } from "@remnic/core/reconcile/plan.js";
+import type { ReconcileFileState, ReconcilePlan } from "@remnic/core/reconcile/plan.js";
 import {
   defaultConvergeCursorPath,
   readConvergeCursor,
@@ -17,7 +17,9 @@ import {
   executeConvergeApply,
   formatConvergeApplyReport,
   formatConvergeReport,
+  type ConvergeApplyResult,
 } from "./converge.js";
+import { convergeWatch } from "./converge-watch.js";
 
 const shaA = "a".repeat(64);
 const shaB = "b".repeat(64);
@@ -1542,4 +1544,103 @@ test("remnic converge apply: durable cursor state is excluded and a clean second
   } finally {
     await fs.rm(memoryDir, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// converge watch (scheduled replication)
+// ---------------------------------------------------------------------------
+
+
+function applyResult(overrides: Partial<ConvergeApplyResult> = {}): ConvergeApplyResult {
+  return {
+    converged: true,
+    status: "converged",
+    plan: { converged: true, byNamespace: [], entries: [] } as unknown as ReconcilePlan,
+    transfers: { pulled: 0, pushed: 0, conflictsResolved: 0, suppressed: 0, failed: 0 },
+    cursorUpdated: false,
+    ...overrides,
+  };
+}
+
+test("converge watch: cycles on the injected applier until maxCycles", async () => {
+  let calls = 0;
+  const outcome = await convergeWatch({
+    intervalMs: 1,
+    maxCycles: 3,
+    apply: async () => {
+      calls += 1;
+      return applyResult({ converged: calls !== 2, status: calls === 2 ? "applied" : "converged" });
+    },
+  });
+  assert.equal(outcome.cycles, 3);
+  assert.equal(outcome.convergedCycles, 2);
+  assert.equal(outcome.appliedCycles, 1);
+  assert.equal(outcome.failedCycles, 0);
+  assert.equal(outcome.lastStatus, "converged");
+});
+
+test("converge watch: a failing cycle reports and does not stop the watch", async () => {
+  const events: Array<{ cycle: number; error?: unknown }> = [];
+  let calls = 0;
+  const outcome = await convergeWatch({
+    intervalMs: 1,
+    maxCycles: 3,
+    apply: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("peer temporarily unreachable");
+      return applyResult();
+    },
+    onCycle: (cycle, event) => events.push({ cycle, error: event.error }),
+  });
+  assert.equal(outcome.cycles, 3);
+  assert.equal(outcome.failedCycles, 1);
+  assert.equal(outcome.convergedCycles, 2);
+  assert.equal(outcome.lastStatus, "converged");
+  assert.equal(events[0]?.cycle, 1);
+  assert.ok(events[0]?.error instanceof Error);
+  assert.equal(events.length, 3);
+});
+
+test("converge watch: pre-aborted signal runs no cycles", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let calls = 0;
+  const outcome = await convergeWatch({
+    intervalMs: 1,
+    signal: controller.signal,
+    apply: async () => {
+      calls += 1;
+      return applyResult();
+    },
+  });
+  assert.equal(calls, 0);
+  assert.equal(outcome.cycles, 0);
+  assert.equal(outcome.lastStatus, "aborted");
+});
+
+test("converge watch: abort during the sleep stops after the current cycle", async () => {
+  const controller = new AbortController();
+  let calls = 0;
+  const outcome = await convergeWatch({
+    intervalMs: 60_000,
+    signal: controller.signal,
+    apply: async () => {
+      calls += 1;
+      if (calls === 1) {
+        // Abort while the watch is sleeping after cycle 1.
+        queueMicrotask(() => controller.abort());
+      }
+      return applyResult();
+    },
+  });
+  assert.equal(calls, 1);
+  assert.equal(outcome.cycles, 1);
+  assert.equal(outcome.lastStatus, "converged");
+});
+
+test("remnic converge watch: bad --interval is rejected with exit code 2", async () => {
+  process.exitCode = undefined;
+  await cmdConverge("watch", ["--interval", "abc"], false);
+  assert.equal(process.exitCode, 2);
+  process.exitCode = undefined;
 });

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -6,11 +6,7 @@ import * as path from "node:path";
 import { test } from "node:test";
 import { ContentHashIndex, OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES, parseConfig } from "@remnic/core";
 import type { ReconcileFileState, ReconcilePlan } from "@remnic/core/reconcile/plan.js";
-import {
-  defaultConvergeCursorPath,
-  readConvergeCursor,
-  writeConvergeCursor,
-} from "@remnic/core/reconcile/cursor.js";
+import { defaultConvergeCursorPath, readConvergeCursor, writeConvergeCursor } from "@remnic/core/reconcile/cursor.js";
 import {
   cmdConverge,
   computeConvergePlan,
@@ -68,12 +64,8 @@ test("remnic converge plan: conflict classification when files differ", async ()
 });
 
 test("remnic converge plan: namespace pairing across distinct namespaces", async () => {
-  const localMap = new Map<string, ReconcileFileState[]>([
-    ["alpha", [{ path: "facts/a.md", sha256: shaA }]],
-  ]);
-  const peerMap = new Map<string, ReconcileFileState[]>([
-    ["beta", [{ path: "facts/b.md", sha256: shaB }]],
-  ]);
+  const localMap = new Map<string, ReconcileFileState[]>([["alpha", [{ path: "facts/a.md", sha256: shaA }]]]);
+  const peerMap = new Map<string, ReconcileFileState[]>([["beta", [{ path: "facts/b.md", sha256: shaB }]]]);
 
   const plan = await computeConvergePlan({
     localFilesByNamespace: localMap,
@@ -173,7 +165,7 @@ test("remnic converge plan: validates a namespace present only in provided base 
       baseFilesByNamespace: baseMap,
       localFilesByNamespace: new Map(),
     }),
-    /aliasing paths/,
+    /aliasing paths/
   );
 });
 
@@ -220,7 +212,7 @@ test("remnic converge plan: fails closed on malformed durable cursor state", asy
         localFilesByNamespace: new Map([["default", []]]),
         fetchImpl: async () => Response.json({ files: [], tombstones: [] }),
       }),
-      /invalid converge cursor/,
+      /invalid converge cursor/
     );
   } finally {
     await fs.rm(cursorDir, { recursive: true, force: true });
@@ -230,7 +222,7 @@ test("remnic converge plan: fails closed on malformed durable cursor state", asy
 test("remnic converge plan: maps peer tombstone content hashes through the manifest file identity", async () => {
   const contentHash = "c".repeat(64);
   const memoryContent = Buffer.from(
-    `---\nid: mem-1\ncategory: fact\ncontentHash: ${contentHash}\nstatus: active\n---\nRetired fact\n`,
+    `---\nid: mem-1\ncategory: fact\ncontentHash: ${contentHash}\nstatus: active\n---\nRetired fact\n`
   );
   const memorySha = createHash("sha256").update(memoryContent).digest("hex");
   const tombstoneContent = Buffer.from(`${JSON.stringify({ contentHash })}\n`);
@@ -399,36 +391,51 @@ test("remnic converge apply: configured newest-wins compares deletion and modifi
   const peerSha = createHash("sha256").update(peerModified).digest("hex");
   const baseSha = "c".repeat(64);
   const localMap = new Map<string, ReconcileFileState[]>([
-    ["default", [
-      { path: localModificationWins, sha256: localSha, mtimeMs: 4000 },
-      { path: peerDeletionWins, sha256: localSha, mtimeMs: 2000 },
-    ]],
+    [
+      "default",
+      [
+        { path: localModificationWins, sha256: localSha, mtimeMs: 4000 },
+        { path: peerDeletionWins, sha256: localSha, mtimeMs: 2000 },
+      ],
+    ],
   ]);
   const peerMap = new Map<string, ReconcileFileState[]>([
-    ["default", [
-      { path: peerModificationWins, sha256: peerSha, mtimeMs: 4000 },
-      { path: localDeletionWins, sha256: peerSha, mtimeMs: 2000 },
-    ]],
+    [
+      "default",
+      [
+        { path: peerModificationWins, sha256: peerSha, mtimeMs: 4000 },
+        { path: localDeletionWins, sha256: peerSha, mtimeMs: 2000 },
+      ],
+    ],
   ]);
   const baseMap = new Map<string, ReconcileFileState[]>([
-    ["default", [
-      { path: localModificationWins, sha256: baseSha, mtimeMs: 1000 },
-      { path: peerDeletionWins, sha256: baseSha, mtimeMs: 1000 },
-      { path: peerModificationWins, sha256: baseSha, mtimeMs: 1000 },
-      { path: localDeletionWins, sha256: baseSha, mtimeMs: 1000 },
-    ]],
+    [
+      "default",
+      [
+        { path: localModificationWins, sha256: baseSha, mtimeMs: 1000 },
+        { path: peerDeletionWins, sha256: baseSha, mtimeMs: 1000 },
+        { path: peerModificationWins, sha256: baseSha, mtimeMs: 1000 },
+        { path: localDeletionWins, sha256: baseSha, mtimeMs: 1000 },
+      ],
+    ],
   ]);
   const localBuffers = new Map<string, Map<string, Buffer>>([
-    ["default", new Map([
-      [localModificationWins, localModified],
-      [peerDeletionWins, localModified],
-    ])],
+    [
+      "default",
+      new Map([
+        [localModificationWins, localModified],
+        [peerDeletionWins, localModified],
+      ]),
+    ],
   ]);
   const peerBuffers = new Map<string, Map<string, Buffer>>([
-    ["default", new Map([
-      [peerModificationWins, peerModified],
-      [localDeletionWins, peerModified],
-    ])],
+    [
+      "default",
+      new Map([
+        [peerModificationWins, peerModified],
+        [localDeletionWins, peerModified],
+      ]),
+    ],
   ]);
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-delete-"));
 
@@ -437,14 +444,24 @@ test("remnic converge apply: configured newest-wins compares deletion and modifi
     baseFilesByNamespace: baseMap,
     localFilesByNamespace: localMap,
     peerFilesByNamespace: peerMap,
-    localDeletionMtimeMsByNamespace: new Map([["default", new Map([
-      [peerModificationWins, 3000],
-      [localDeletionWins, 3000],
-    ])]]),
-    peerDeletionMtimeMsByNamespace: new Map([["default", new Map([
-      [localModificationWins, 3000],
-      [peerDeletionWins, 3000],
-    ])]]),
+    localDeletionMtimeMsByNamespace: new Map([
+      [
+        "default",
+        new Map([
+          [peerModificationWins, 3000],
+          [localDeletionWins, 3000],
+        ]),
+      ],
+    ]),
+    peerDeletionMtimeMsByNamespace: new Map([
+      [
+        "default",
+        new Map([
+          [localModificationWins, 3000],
+          [peerDeletionWins, 3000],
+        ]),
+      ],
+    ]),
     localFileBuffers: localBuffers,
     peerFileBuffers: peerBuffers,
     cursorDir: tmpDir,
@@ -461,7 +478,7 @@ test("remnic converge apply: configured newest-wins compares deletion and modifi
   const cursor = await readConvergeCursor(defaultConvergeCursorPath(tmpDir, "buffer://peer", "default"));
   assert.deepEqual(
     cursor?.baseFiles.map((file) => file.path).sort(),
-    [localModificationWins, peerModificationWins].sort(),
+    [localModificationWins, peerModificationWins].sort()
   );
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
@@ -557,9 +574,7 @@ test("remnic converge apply: uses chunked offline-sync HTTP contracts for pull a
     }
     return new Response(null, { status: 404 });
   };
-  const localBuffers = new Map<string, Map<string, Buffer>>([
-    ["default", new Map([["facts/local.md", localContent]])],
-  ]);
+  const localBuffers = new Map<string, Map<string, Buffer>>([["default", new Map([["facts/local.md", localContent]])]]);
 
   const result = await executeConvergeApply({
     peerUrl: "https://peer.example.test",
@@ -623,9 +638,7 @@ test("remnic converge apply: a newer local deletion uses the guarded remote dele
     peerFilesByNamespace: new Map([
       ["default", [{ path: filePath, sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]],
     ]),
-    localDeletionMtimeMsByNamespace: new Map([
-      ["default", new Map([[filePath, 3000]])],
-    ]),
+    localDeletionMtimeMsByNamespace: new Map([["default", new Map([[filePath, 3000]])]]),
   });
 
   assert.equal(result.transfers.conflictsResolved, 1);
@@ -641,9 +654,7 @@ test("remnic converge apply: a newer local deletion uses the guarded remote dele
   };
   assert.equal(body.namespace, "default");
   assert.equal(body.changeset.format, "remnic.offline-sync.changeset.v1");
-  assert.deepEqual(body.changeset.changes, [
-    { type: "delete", path: filePath, baseSha256: peerSha },
-  ]);
+  assert.deepEqual(body.changeset.changes, [{ type: "delete", path: filePath, baseSha256: peerSha }]);
   assert.ok(requests.some(({ url }) => url.includes("/offline-sync/convergence-complete?namespace=default")));
 });
 
@@ -659,7 +670,7 @@ test("remnic converge plan: fails closed when the peer census cannot be fetched"
       fetchImpl,
       localFilesByNamespace: new Map([["default", []]]),
     }),
-    /failed to fetch peer snapshot/i,
+    /failed to fetch peer snapshot/i
   );
 });
 
@@ -675,7 +686,7 @@ test("remnic converge plan: rejects malformed peer census records", async () => 
       fetchImpl,
       localFilesByNamespace: new Map([["default", []]]),
     }),
-    /invalid peer snapshot/i,
+    /invalid peer snapshot/i
   );
 });
 
@@ -720,12 +731,8 @@ test("remnic converge apply: does not count a local apply conflict as a pull", a
     const result = await executeConvergeApply({
       config: parseConfig({ memoryDir: rootDir }),
       peerUrl: "https://peer.example.test",
-      baseFilesByNamespace: new Map([
-        ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
-      ]),
-      localFilesByNamespace: new Map([
-        ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
-      ]),
+      baseFilesByNamespace: new Map([["default", [{ path: "facts/shared.md", sha256: baseSha256 }]]]),
+      localFilesByNamespace: new Map([["default", [{ path: "facts/shared.md", sha256: baseSha256 }]]]),
       peerFilesByNamespace: new Map([
         ["default", [{ path: "facts/shared.md", sha256: peerSha256, bytes: peerContent.length, mtimeMs: 2000 }]],
       ]),
@@ -757,12 +764,8 @@ test("remnic converge apply: peer-wins guards against the planned local revision
       config: parseConfig({ memoryDir: rootDir }),
       peerUrl: "https://peer.example.test",
       conflictPolicy: "newest-wins",
-      baseFilesByNamespace: new Map([
-        ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
-      ]),
-      localFilesByNamespace: new Map([
-        ["default", [{ path: "facts/shared.md", sha256: localSha256, mtimeMs: 1000 }]],
-      ]),
+      baseFilesByNamespace: new Map([["default", [{ path: "facts/shared.md", sha256: baseSha256 }]]]),
+      localFilesByNamespace: new Map([["default", [{ path: "facts/shared.md", sha256: localSha256, mtimeMs: 1000 }]]]),
       peerFilesByNamespace: new Map([
         ["default", [{ path: "facts/shared.md", sha256: peerSha256, bytes: peerContent.length, mtimeMs: 2000 }]],
       ]),
@@ -772,11 +775,7 @@ test("remnic converge apply: peer-wins guards against the planned local revision
     assert.equal(result.transfers.conflictsResolved, 1);
     assert.equal(result.transfers.failed, 0);
     assert.equal(await fs.readFile(path.join(rootDir, "facts/shared.md"), "utf8"), "peer content");
-    const cursor = await readConvergeCursor(defaultConvergeCursorPath(
-      rootDir,
-      "https://peer.example.test",
-      "default"
-    ));
+    const cursor = await readConvergeCursor(defaultConvergeCursorPath(rootDir, "https://peer.example.test", "default"));
     assert.equal(cursor?.baseFiles[0]?.sha256, peerSha256);
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });
@@ -796,15 +795,9 @@ test("remnic converge apply: pull advances the cursor to the peer digest", async
     const result = await executeConvergeApply({
       cursorDir,
       peerUrl,
-      baseFilesByNamespace: new Map([
-        ["default", [{ path: filePath, sha256: localSha256 }]],
-      ]),
-      localFilesByNamespace: new Map([
-        ["default", [{ path: filePath, sha256: localSha256 }]],
-      ]),
-      peerFilesByNamespace: new Map([
-        ["default", [{ path: filePath, sha256: peerSha256 }]],
-      ]),
+      baseFilesByNamespace: new Map([["default", [{ path: filePath, sha256: localSha256 }]]]),
+      localFilesByNamespace: new Map([["default", [{ path: filePath, sha256: localSha256 }]]]),
+      peerFilesByNamespace: new Map([["default", [{ path: filePath, sha256: peerSha256 }]]]),
       localFileBuffers: new Map([["default", new Map([[filePath, localContent]])]]),
       peerFileBuffers: new Map([["default", new Map([[filePath, peerContent]])]]),
     });
@@ -836,9 +829,7 @@ test("remnic converge apply: local-wins guards against the planned peer revision
     peerUrl: "https://peer.example.test",
     fetchImpl,
     conflictPolicy: "newest-wins",
-    baseFilesByNamespace: new Map([
-      ["default", [{ path: "facts/shared.md", sha256: baseSha256 }]],
-    ]),
+    baseFilesByNamespace: new Map([["default", [{ path: "facts/shared.md", sha256: baseSha256 }]]]),
     localFilesByNamespace: new Map([
       ["default", [{ path: "facts/shared.md", sha256: localSha256, bytes: localContent.length, mtimeMs: 2000 }]],
     ]),
@@ -885,7 +876,7 @@ test("remnic converge CLI rejects removed and unknown conflict-policy overrides"
     for (const conflictPolicy of ["keep-both", "invalid"]) {
       await assert.rejects(
         () => cmdConverge("plan", ["--conflict-policy", conflictPolicy], true, parseConfig({})),
-        /--conflict-policy must be one of newest-wins, manual/,
+        /--conflict-policy must be one of newest-wins, manual/
       );
     }
   } finally {
@@ -899,17 +890,18 @@ test("remnic converge retains per-side semantic state across a later metadata ed
   try {
     const body = "same active fact";
     const semanticHash = ContentHashIndex.computeHash(body);
-    const memory = (id: string, updated: string): string => [
-      "---",
-      `id: ${id}`,
-      "category: fact",
-      "created: 2026-01-01T00:00:00.000Z",
-      `updated: ${updated}`,
-      `contentHash: ${semanticHash}`,
-      "status: active",
-      "---",
-      body,
-    ].join("\n");
+    const memory = (id: string, updated: string): string =>
+      [
+        "---",
+        `id: ${id}`,
+        "category: fact",
+        "created: 2026-01-01T00:00:00.000Z",
+        `updated: ${updated}`,
+        `contentHash: ${semanticHash}`,
+        "status: active",
+        "---",
+        body,
+      ].join("\n");
     let localContent = memory("local-id", "2026-01-01T00:00:00.000Z");
     const peerContent = memory("peer-id", "2026-01-02T00:00:00.000Z");
     const localSha = createHash("sha256").update(localContent).digest("hex");
@@ -965,20 +957,29 @@ test("remnic converge retains per-side semantic state across a later metadata ed
     const cursorPath = defaultConvergeCursorPath(cursorDir, peerUrl, "default");
     const cursor = await readConvergeCursor(cursorPath);
     assert.deepEqual(cursor?.baseFiles, []);
-    assert.deepEqual(cursor?.semanticAgreements, [{
-      local: { path: "facts/local-id.md", sha256: localSha },
-      peer: { path: "facts/peer-id.md", sha256: peerSha },
-    }]);
+    assert.deepEqual(cursor?.semanticAgreements, [
+      {
+        local: { path: "facts/local-id.md", sha256: localSha },
+        peer: { path: "facts/peer-id.md", sha256: peerSha },
+      },
+    ]);
 
     localContent = memory("local-id", "2026-01-03T00:00:00.000Z");
     const editedLocalSha = createHash("sha256").update(localContent).digest("hex");
     await fs.writeFile(path.join(rootDir, "facts/local-id.md"), localContent);
     const explicitPlan = await computeConvergePlan({
       ...options,
-      semanticAgreementsByNamespace: new Map([["default", [{
-        local: { path: "facts/local-id.md", sha256: editedLocalSha },
-        peer: { path: "facts/peer-id.md", sha256: peerSha },
-      }]]]),
+      semanticAgreementsByNamespace: new Map([
+        [
+          "default",
+          [
+            {
+              local: { path: "facts/local-id.md", sha256: editedLocalSha },
+              peer: { path: "facts/peer-id.md", sha256: peerSha },
+            },
+          ],
+        ],
+      ]),
     });
     assert.equal(explicitPlan.entries[0]?.semanticChange, "unchanged");
 
@@ -1002,10 +1003,12 @@ test("remnic converge retains per-side semantic state across a later metadata ed
       failed: 0,
     });
     const changedCursor = await readConvergeCursor(cursorPath);
-    assert.deepEqual(changedCursor?.semanticAgreements, [{
-      local: { path: "facts/local-id.md", sha256: editedLocalSha },
-      peer: { path: "facts/peer-id.md", sha256: peerSha },
-    }]);
+    assert.deepEqual(changedCursor?.semanticAgreements, [
+      {
+        local: { path: "facts/local-id.md", sha256: editedLocalSha },
+        peer: { path: "facts/peer-id.md", sha256: peerSha },
+      },
+    ]);
 
     const unchangedPlan = await computeConvergePlan(options);
     assert.equal(unchangedPlan.entries[0]?.semanticChange, "unchanged");
@@ -1019,15 +1022,8 @@ test("remnic converge consumes peer manifests without per-fact content requests"
   try {
     const body = "same streamed fact";
     const semanticHash = ContentHashIndex.computeHash(body);
-    const memory = (id: string): string => [
-      "---",
-      `id: ${id}`,
-      "category: fact",
-      `contentHash: ${semanticHash}`,
-      "status: active",
-      "---",
-      body,
-    ].join("\n");
+    const memory = (id: string): string =>
+      ["---", `id: ${id}`, "category: fact", `contentHash: ${semanticHash}`, "status: active", "---", body].join("\n");
     const localContent = memory("local-id");
     const peerContent = memory("peer-id");
     const peerSha = createHash("sha256").update(peerContent).digest("hex");
@@ -1041,36 +1037,41 @@ test("remnic converge consumes peer manifests without per-fact content requests"
         return Response.json({ version: 1, convergenceFinalization: true, manifestStream: true });
       }
       if (url.pathname.endsWith("/offline-sync/snapshot")) {
-        const files = url.searchParams.get("namespace") === "default"
-          ? [{ path: "facts/peer-id.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]
-          : [];
+        const files =
+          url.searchParams.get("namespace") === "default"
+            ? [{ path: "facts/peer-id.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]
+            : [];
         return Response.json({ files, tombstones: [] });
       }
       if (url.pathname.endsWith("/offline-sync/manifest-stream")) {
         manifestRequests += 1;
         const namespace = url.searchParams.get("namespace");
-        const rows = [JSON.stringify({
-          type: "manifest",
-          namespace,
-          format: "remnic-reconcile-manifest",
-          schemaVersion: 1,
-        })];
+        const rows = [
+          JSON.stringify({
+            type: "manifest",
+            namespace,
+            format: "remnic-reconcile-manifest",
+            schemaVersion: 1,
+          }),
+        ];
         if (namespace === "default") {
-          rows.push(JSON.stringify({
-            type: "file",
-            file: {
-              path: "facts/peer-id.md",
-              sha256: peerSha,
-              bytes: peerContent.length,
-              mtimeMs: 2000,
-              memory: {
-                id: "peer-id",
-                category: "fact",
-                contentHash: semanticHash,
-                status: "active",
+          rows.push(
+            JSON.stringify({
+              type: "file",
+              file: {
+                path: "facts/peer-id.md",
+                sha256: peerSha,
+                bytes: peerContent.length,
+                mtimeMs: 2000,
+                memory: {
+                  id: "peer-id",
+                  category: "fact",
+                  contentHash: semanticHash,
+                  status: "active",
+                },
               },
-            },
-          }));
+            })
+          );
         }
         return new Response([...rows, ""].join("\n"));
       }
@@ -1098,15 +1099,8 @@ test("remnic converge falls back to per-fact content only for an older peer", as
   try {
     const body = "same legacy peer fact";
     const semanticHash = ContentHashIndex.computeHash(body);
-    const memory = (id: string): string => [
-      "---",
-      `id: ${id}`,
-      "category: fact",
-      `contentHash: ${semanticHash}`,
-      "status: active",
-      "---",
-      body,
-    ].join("\n");
+    const memory = (id: string): string =>
+      ["---", `id: ${id}`, "category: fact", `contentHash: ${semanticHash}`, "status: active", "---", body].join("\n");
     const localContent = memory("local-id");
     const peerContent = memory("peer-id");
     const peerSha = createHash("sha256").update(peerContent).digest("hex");
@@ -1119,9 +1113,10 @@ test("remnic converge falls back to per-fact content only for an older peer", as
         return new Response(null, { status: 404 });
       }
       if (url.pathname.endsWith("/offline-sync/snapshot")) {
-        const files = url.searchParams.get("namespace") === "default"
-          ? [{ path: "facts/peer-id.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]
-          : [];
+        const files =
+          url.searchParams.get("namespace") === "default"
+            ? [{ path: "facts/peer-id.md", sha256: peerSha, bytes: peerContent.length, mtimeMs: 2000 }]
+            : [];
         return Response.json({ files, tombstones: [] });
       }
       if (url.pathname.endsWith("/offline-sync/file-content")) {
@@ -1178,30 +1173,30 @@ test("remnic converge does not hide legacy manifest content failures", async () 
         peerUrl: "https://older-peer.example.test",
         fetchImpl,
       }),
-      /failed to read peer reconciliation manifest file: facts\/peer-id\.md/,
+      /failed to read peer reconciliation manifest file: facts\/peer-id\.md/
     );
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });
   }
 });
 
-
 test("remnic converge plan reuses unchanged shared peer semantics to collapse cross-path duplicates", async () => {
   const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "remnic-converge-shared-manifest-"));
   try {
     const body = "same active fact at a shared path";
     const semanticHash = ContentHashIndex.computeHash(body);
-    const memory = (id: string): string => [
-      "---",
-      `id: ${id}`,
-      "category: fact",
-      "created: 2026-01-01T00:00:00.000Z",
-      "updated: 2026-01-01T00:00:00.000Z",
-      `contentHash: ${semanticHash}`,
-      "status: active",
-      "---",
-      body,
-    ].join("\n");
+    const memory = (id: string): string =>
+      [
+        "---",
+        `id: ${id}`,
+        "category: fact",
+        "created: 2026-01-01T00:00:00.000Z",
+        "updated: 2026-01-01T00:00:00.000Z",
+        `contentHash: ${semanticHash}`,
+        "status: active",
+        "---",
+        body,
+      ].join("\n");
     const canonicalContent = memory("a");
     const sharedContent = memory("z");
     const sharedSha = createHash("sha256").update(sharedContent).digest("hex");
@@ -1235,9 +1230,10 @@ test("remnic converge plan reuses unchanged shared peer semantics to collapse cr
 
     assert.equal(peerContentRequests, 0);
     assert.equal(plan.converged, true, JSON.stringify(plan));
-    assert.deepEqual(plan.entries.map((entry) => [entry.path, entry.action, entry.reason]), [
-      ["facts/a.md", "identical", "semantic_duplicate"],
-    ]);
+    assert.deepEqual(
+      plan.entries.map((entry) => [entry.path, entry.action, entry.reason]),
+      [["facts/a.md", "identical", "semantic_duplicate"]]
+    );
   } finally {
     await fs.rm(rootDir, { recursive: true, force: true });
   }
@@ -1247,20 +1243,24 @@ test("remnic converge apply: finalizes each mutated peer namespace once after a 
   const teamB = Buffer.from("team b");
   const shared = Buffer.from("shared");
   const buffers = new Map<string, Map<string, Buffer>>([
-    ["team", new Map([
-      ["facts/a.md", teamA],
-      ["facts/b.md", teamB],
-    ])],
+    [
+      "team",
+      new Map([
+        ["facts/a.md", teamA],
+        ["facts/b.md", teamB],
+      ]),
+    ],
     ["shared", new Map([["facts/c.md", shared]])],
   ]);
   const localFiles = new Map<string, ReconcileFileState[]>([
-    ["team", [
-      { path: "facts/a.md", sha256: createHash("sha256").update(teamA).digest("hex") },
-      { path: "facts/b.md", sha256: createHash("sha256").update(teamB).digest("hex") },
-    ]],
-    ["shared", [
-      { path: "facts/c.md", sha256: createHash("sha256").update(shared).digest("hex") },
-    ]],
+    [
+      "team",
+      [
+        { path: "facts/a.md", sha256: createHash("sha256").update(teamA).digest("hex") },
+        { path: "facts/b.md", sha256: createHash("sha256").update(teamB).digest("hex") },
+      ],
+    ],
+    ["shared", [{ path: "facts/c.md", sha256: createHash("sha256").update(shared).digest("hex") }]],
   ]);
   const finalized: string[][] = [];
   const fetchImpl: typeof fetch = async (input, init) => {
@@ -1314,10 +1314,15 @@ test("remnic converge apply: does not finalize peer namespaces after an incomple
     peerUrl: "https://peer.example.test",
     fetchImpl,
     localFilesByNamespace: new Map([
-      ["team", [{
-        path: "facts/a.md",
-        sha256: createHash("sha256").update(content).digest("hex"),
-      }]],
+      [
+        "team",
+        [
+          {
+            path: "facts/a.md",
+            sha256: createHash("sha256").update(content).digest("hex"),
+          },
+        ],
+      ],
     ]),
     peerFilesByNamespace: new Map([["team", []]]),
     localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
@@ -1385,10 +1390,15 @@ test("remnic converge apply: does not finalize a peer namespace when every write
     peerUrl: "https://peer.example.test",
     fetchImpl,
     localFilesByNamespace: new Map([
-      ["team", [{
-        path: "facts/a.md",
-        sha256: createHash("sha256").update(content).digest("hex"),
-      }]],
+      [
+        "team",
+        [
+          {
+            path: "facts/a.md",
+            sha256: createHash("sha256").update(content).digest("hex"),
+          },
+        ],
+      ],
     ]),
     peerFilesByNamespace: new Map([["team", []]]),
     localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
@@ -1418,10 +1428,15 @@ test("remnic converge apply: finalization falls back to the engram route", async
     peerUrl: "https://peer.example.test/",
     fetchImpl,
     localFilesByNamespace: new Map([
-      ["team", [{
-        path: "facts/a.md",
-        sha256: createHash("sha256").update(content).digest("hex"),
-      }]],
+      [
+        "team",
+        [
+          {
+            path: "facts/a.md",
+            sha256: createHash("sha256").update(content).digest("hex"),
+          },
+        ],
+      ],
     ]),
     peerFilesByNamespace: new Map([["team", []]]),
     localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
@@ -1456,10 +1471,15 @@ test("remnic converge apply: finalizes after an ambiguous alias retry", async ()
     peerUrl: "https://peer.example.test",
     fetchImpl,
     localFilesByNamespace: new Map([
-      ["team", [{
-        path: "facts/a.md",
-        sha256: createHash("sha256").update(content).digest("hex"),
-      }]],
+      [
+        "team",
+        [
+          {
+            path: "facts/a.md",
+            sha256: createHash("sha256").update(content).digest("hex"),
+          },
+        ],
+      ],
     ]),
     peerFilesByNamespace: new Map([["team", []]]),
     localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
@@ -1484,10 +1504,15 @@ test("remnic converge apply: a failed peer refresh prevents convergence and curs
     peerUrl: "https://peer.example.test",
     fetchImpl,
     localFilesByNamespace: new Map([
-      ["team", [{
-        path: "facts/a.md",
-        sha256: createHash("sha256").update(content).digest("hex"),
-      }]],
+      [
+        "team",
+        [
+          {
+            path: "facts/a.md",
+            sha256: createHash("sha256").update(content).digest("hex"),
+          },
+        ],
+      ],
     ]),
     peerFilesByNamespace: new Map([["team", []]]),
     localFileBuffers: new Map([["team", new Map([["facts/a.md", content]])]]),
@@ -1525,12 +1550,13 @@ test("remnic converge apply: durable cursor state is excluded and a clean second
           return new Response(null, { status: 404 });
         }
         if (url.pathname.endsWith("/offline-sync/snapshot")) {
-          const files = url.searchParams.get("namespace") === "default"
-            ? [
-                { path: filePath, sha256, bytes: content.length, mtimeMs: 1 },
-                { path: ".remnic/state/converge-cursors/host.json", sha256: shaA, bytes: 1, mtimeMs: 1 },
-              ]
-            : [];
+          const files =
+            url.searchParams.get("namespace") === "default"
+              ? [
+                  { path: filePath, sha256, bytes: content.length, mtimeMs: 1 },
+                  { path: ".remnic/state/converge-cursors/host.json", sha256: shaA, bytes: 1, mtimeMs: 1 },
+                ]
+              : [];
           return Response.json({ files, tombstones: [] });
         }
         fileTransportCalls += 1;
@@ -1540,7 +1566,10 @@ test("remnic converge apply: durable cursor state is excluded and a clean second
 
     assert.equal(result.converged, true);
     assert.equal(fileTransportCalls, 0);
-    assert.equal(result.plan.entries.some((entry) => entry.path.startsWith(".remnic/")), false);
+    assert.equal(
+      result.plan.entries.some((entry) => entry.path.startsWith(".remnic/")),
+      false
+    );
   } finally {
     await fs.rm(memoryDir, { recursive: true, force: true });
   }
@@ -1549,7 +1578,6 @@ test("remnic converge apply: durable cursor state is excluded and a clean second
 // ---------------------------------------------------------------------------
 // converge watch (scheduled replication)
 // ---------------------------------------------------------------------------
-
 
 function applyResult(overrides: Partial<ConvergeApplyResult> = {}): ConvergeApplyResult {
   return {
@@ -1643,4 +1671,55 @@ test("remnic converge watch: bad --interval is rejected with exit code 2", async
   await cmdConverge("watch", ["--interval", "abc"], false);
   assert.equal(process.exitCode, 2);
   process.exitCode = undefined;
+});
+
+test("converge watch: conflict-stopped and partially-failed cycles count as failed, not applied", async () => {
+  let calls = 0;
+  const outcome = await convergeWatch({
+    intervalMs: 1,
+    maxCycles: 3,
+    apply: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return applyResult({ converged: false, status: "stopped_unresolved_conflicts" });
+      }
+      if (calls === 2) {
+        return applyResult({
+          converged: false,
+          status: "applied",
+          transfers: { pulled: 2, pushed: 0, conflictsResolved: 0, suppressed: 0, failed: 1 },
+        });
+      }
+      return applyResult();
+    },
+  });
+  assert.equal(outcome.cycles, 3);
+  assert.equal(outcome.failedCycles, 2);
+  assert.equal(outcome.appliedCycles, 0);
+  assert.equal(outcome.convergedCycles, 1);
+  assert.equal(outcome.cycles, outcome.convergedCycles + outcome.appliedCycles + outcome.failedCycles);
+});
+
+test("converge watch: abort fires through the sleeping path, not the pre-check", async () => {
+  const controller = new AbortController();
+  let calls = 0;
+  // Abort from a delayed macrotask: cycle 1's apply has resolved and
+  // sleepAborted has registered its abort listener by then, so this hits
+  // the clearTimeout path a real SIGTERM takes during a 300s sleep.
+  const abortTimer = setTimeout(() => controller.abort(), 10);
+  try {
+    const outcome = await convergeWatch({
+      intervalMs: 60_000,
+      signal: controller.signal,
+      apply: async () => {
+        calls += 1;
+        return applyResult();
+      },
+    });
+    assert.equal(calls, 1);
+    assert.equal(outcome.cycles, 1);
+    assert.equal(outcome.lastStatus, "converged");
+  } finally {
+    clearTimeout(abortTimer);
+  }
 });

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1014,8 +1014,12 @@ Options:
       i += 1;
     } else if (arg === "--dry-run") {
       dryRun = true;
-    } else if (arg === "--interval" && rest[i + 1]) {
-      const parsed = Number(rest[i + 1]);
+    } else if (arg === "--interval") {
+      // Flag-present-but-value-absent is malformed, not "use the default":
+      // an operator who typed `--interval` alone must hear about it, not
+      // silently get a 300s watch (codex P1 / coderabbit round 2).
+      const raw = rest[i + 1];
+      const parsed = raw === undefined ? Number.NaN : Number(raw);
       if (!Number.isFinite(parsed) || parsed <= 0) {
         process.stderr.write("converge: --interval must be a positive number of seconds.\n");
         process.exitCode = 2;

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -37,6 +37,7 @@ import {
   type ReconcileManifest,
 } from "@remnic/core/reconcile/manifest.js";
 import { createOfflineStorageIo } from "./offline-storage-io.js";
+import { convergeWatch } from "./converge-watch.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
 import {
   DEFAULT_PEER_REQUEST_TIMEOUT_MS,
@@ -1011,11 +1012,12 @@ export async function cmdConverge(
   config: PluginConfig = parseConfig({}),
 ): Promise<void> {
   if (action === "help" || action === "--help" || action === "-h" || rest.includes("--help") || rest.includes("-h")) {
-    console.log(`Usage: remnic converge <plan|apply> [options]
+    console.log(`Usage: remnic converge <plan|apply|watch> [options]
 
 Subcommands:
   plan              Compute and display reconciliation plan
   apply             Execute bidirectional converge transport (alias: transport, sync)
+  watch             Run apply on a cadence until stopped (scheduled replication)
 
 Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
@@ -1029,8 +1031,8 @@ Options:
     return;
   }
 
-  if (action !== "plan" && action !== "apply" && action !== "transport" && action !== "sync") {
-    process.stderr.write(`converge: unknown action "${action}". Use: plan or apply [options].\n`);
+  if (action !== "plan" && action !== "apply" && action !== "transport" && action !== "sync" && action !== "watch") {
+    process.stderr.write(`converge: unknown action "${action}". Use: plan, apply, or watch [options].\n`);
     process.exitCode = 2;
     return;
   }
@@ -1039,6 +1041,7 @@ Options:
   let peerToken: string | undefined;
   let dryRun = false;
   let conflictPolicy: ConvergeConflictPolicy | undefined;
+  let intervalSeconds: number | undefined;
 
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
@@ -1050,6 +1053,15 @@ Options:
       i += 1;
     } else if (arg === "--dry-run") {
       dryRun = true;
+    } else if (arg === "--interval" && rest[i + 1]) {
+      const parsed = Number(rest[i + 1]);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        process.stderr.write("converge: --interval must be a positive number of seconds.\n");
+        process.exitCode = 2;
+        return;
+      }
+      intervalSeconds = parsed;
+      i += 1;
     } else if (arg === "--conflict-policy") {
       const policy = rest[i + 1];
       if (
@@ -1063,6 +1075,47 @@ Options:
       conflictPolicy = policy as ConvergeConflictPolicy;
       i += 1;
     }
+  }
+
+  if (action === "watch") {
+    const controller = new AbortController();
+    const onSignal = () => controller.abort();
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
+    try {
+      const outcome = await convergeWatch({
+        apply: (applyOptions) => executeConvergeApply(applyOptions),
+        config,
+        peerUrl,
+        peerToken,
+        conflictPolicy,
+        intervalMs: intervalSeconds !== undefined ? intervalSeconds * 1000 : undefined,
+        signal: controller.signal,
+        onCycle: (cycle, event) => {
+          if (event.error !== undefined) {
+            console.error(`converge watch: cycle ${cycle} failed: ${String(event.error)}`);
+            return;
+          }
+          const result = event.result;
+          if (!result) return;
+          const transfers = result.transfers;
+          console.log(
+            `converge watch: cycle ${cycle} status=${result.status} pulled=${transfers.pulled} pushed=${transfers.pushed} conflicts=${transfers.conflictsResolved} failed=${transfers.failed}`,
+          );
+        },
+      });
+      if (json) {
+        console.log(JSON.stringify(outcome, null, 2));
+      } else {
+        console.log(
+          `converge watch stopped after ${outcome.cycles} cycle(s): ${outcome.convergedCycles} converged, ${outcome.appliedCycles} applied, ${outcome.failedCycles} failed (last: ${outcome.lastStatus}).`,
+        );
+      }
+    } finally {
+      process.removeListener("SIGINT", onSignal);
+      process.removeListener("SIGTERM", onSignal);
+    }
+    return;
   }
 
   if (action === "plan") {

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -37,7 +37,7 @@ import {
   type ReconcileManifest,
 } from "@remnic/core/reconcile/manifest.js";
 import { createOfflineStorageIo } from "./offline-storage-io.js";
-import { convergeWatch } from "./converge-watch.js";
+import { convergeWatch, type ConvergeWatchOutcome } from "./converge-watch.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
 import {
   DEFAULT_PEER_REQUEST_TIMEOUT_MS,
@@ -121,10 +121,7 @@ function parseTombstoneEvidence(content: string): TombstoneEvidence {
   return { contentHashes, fileSha256 };
 }
 
-function tombstonedFileDigests(
-  evidence: TombstoneEvidence,
-  manifest: ReconcileManifest | undefined,
-): Set<string> {
+function tombstonedFileDigests(evidence: TombstoneEvidence, manifest: ReconcileManifest | undefined): Set<string> {
   const result = new Set(evidence.fileSha256);
   for (const file of manifest?.files ?? []) {
     if (file.memory && evidence.contentHashes.has(file.memory.contentHash.toLowerCase())) {
@@ -171,7 +168,6 @@ async function discoverCursorNamespaces(memoryDir: string, peerUrl: string): Pro
   return [...namespaces].sort();
 }
 
-
 export async function computeConvergePlan(options: ConvergePlanOptions = {}): Promise<ReconcilePlan> {
   const baseMap = new Map<string, ReconcileFileState[]>();
   const semanticAgreementMap = new Map<string, ReconcileSemanticAgreement[]>();
@@ -188,7 +184,10 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   if (options.baseFilesByNamespace) {
     for (const [ns, files] of options.baseFilesByNamespace) {
       namespacesToPlan.add(ns);
-      baseMap.set(ns, files.filter((file) => !isInternalRemnicStatePath(file.path)));
+      baseMap.set(
+        ns,
+        files.filter((file) => !isInternalRemnicStatePath(file.path))
+      );
     }
   }
   if (options.semanticAgreementsByNamespace) {
@@ -200,7 +199,10 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   if (options.localFilesByNamespace) {
     for (const [ns, files] of options.localFilesByNamespace) {
       namespacesToPlan.add(ns);
-      localMap.set(ns, files.filter((file) => !isInternalRemnicStatePath(file.path)));
+      localMap.set(
+        ns,
+        files.filter((file) => !isInternalRemnicStatePath(file.path))
+      );
     }
   }
   if (options.localTombstonesByNamespace) {
@@ -217,7 +219,10 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   if (options.peerFilesByNamespace) {
     for (const [ns, files] of options.peerFilesByNamespace) {
       namespacesToPlan.add(ns);
-      peerMap.set(ns, files.filter((file) => !isInternalRemnicStatePath(file.path)));
+      peerMap.set(
+        ns,
+        files.filter((file) => !isInternalRemnicStatePath(file.path))
+      );
     }
   }
   if (options.peerTombstonesByNamespace) {
@@ -319,12 +324,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     }
     const fetchFn = options.fetchImpl ?? globalThis.fetch;
     const timeoutMs = options.peerRequestTimeoutMs ?? DEFAULT_PEER_REQUEST_TIMEOUT_MS;
-    const capabilities = await fetchPeerSyncCapabilities(
-      peerUrl,
-      resolvedToken,
-      fetchFn,
-      timeoutMs,
-    );
+    const capabilities = await fetchPeerSyncCapabilities(peerUrl, resolvedToken, fetchFn, timeoutMs);
     for (const ns of namespacesToPlan) {
       const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn, timeoutMs);
       const streamedManifest = capabilities?.manifestStream
@@ -362,14 +362,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       for (const tombstonePath of TOMBSTONE_PATHS) {
         const state = peerFiles.find((file) => file.path === tombstonePath);
         if (!state) continue;
-        const remote = await fetchPeerFileContent(
-          peerUrl,
-          ns,
-          tombstonePath,
-          resolvedToken,
-          fetchFn,
-          timeoutMs,
-        );
+        const remote = await fetchPeerFileContent(peerUrl, ns, tombstonePath, resolvedToken, fetchFn, timeoutMs);
         if (!remote || remote.sha256.toLowerCase() !== state.sha256.toLowerCase()) {
           throw new Error(`failed to read peer tombstone evidence: ${tombstonePath}`);
         }
@@ -383,32 +376,27 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     }
   }
 
-  if (
-    memoryDir
-    && options.peerUrl
-    && (!options.baseFilesByNamespace || !options.semanticAgreementsByNamespace)
-  ) {
+  if (memoryDir && options.peerUrl && (!options.baseFilesByNamespace || !options.semanticAgreementsByNamespace)) {
     for (const ns of namespacesToPlan) {
       const cursorPath = defaultConvergeCursorPath(memoryDir, options.peerUrl, ns);
       const cursor = await readConvergeCursor(cursorPath);
       if (!options.baseFilesByNamespace && cursor?.baseFiles && cursor.baseFiles.length > 0) {
         baseMap.set(
           ns,
-          cursor.baseFiles.filter((file) => !isInternalRemnicStatePath(file.path)),
+          cursor.baseFiles.filter((file) => !isInternalRemnicStatePath(file.path))
         );
       }
       if (
-        !options.semanticAgreementsByNamespace
-        && cursor?.semanticAgreements
-        && cursor.semanticAgreements.length > 0
+        !options.semanticAgreementsByNamespace &&
+        cursor?.semanticAgreements &&
+        cursor.semanticAgreements.length > 0
       ) {
         semanticAgreementMap.set(
           ns,
           cursor.semanticAgreements.filter(
             (agreement) =>
-              !isInternalRemnicStatePath(agreement.local.path)
-              && !isInternalRemnicStatePath(agreement.peer.path),
-          ),
+              !isInternalRemnicStatePath(agreement.local.path) && !isInternalRemnicStatePath(agreement.peer.path)
+          )
         );
       }
     }
@@ -433,19 +421,14 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
     });
   }
 
-  const conflictPolicy = options.conflictPolicy
-    ?? config?.converge.conflictPolicy
-    ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
+  const conflictPolicy = options.conflictPolicy ?? config?.converge.conflictPolicy ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
   const plan = planReconciliation(inputs, { conflictPolicy });
   return collapseActiveFactDuplicates(plan, localManifests, peerManifests, semanticAgreementMap);
 }
 
-export async function executeConvergeApply(
-  options: ConvergeApplyOptions = {},
-): Promise<ConvergeApplyResult> {
-  const conflictPolicy = options.conflictPolicy
-    ?? options.config?.converge.conflictPolicy
-    ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
+export async function executeConvergeApply(options: ConvergeApplyOptions = {}): Promise<ConvergeApplyResult> {
+  const conflictPolicy =
+    options.conflictPolicy ?? options.config?.converge.conflictPolicy ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
   const plan = await computeConvergePlan({ ...options, conflictPolicy });
 
   if (plan.converged && !options.dryRun) {
@@ -564,9 +547,7 @@ export async function executeConvergeApply(
       if (options.localFileBuffers) {
         let remoteFile: PeerFileContent | null = null;
         if (buffered) {
-          const state = options.peerFilesByNamespace
-            ?.get(entry.namespace)
-            ?.find((file) => file.path === peerPath);
+          const state = options.peerFilesByNamespace?.get(entry.namespace)?.find((file) => file.path === peerPath);
           remoteFile = {
             content: buffered,
             sha256: state?.sha256 ?? entry.peerSha256 ?? createHash("sha256").update(buffered).digest("hex"),
@@ -580,7 +561,7 @@ export async function executeConvergeApply(
             peerPath,
             resolvedToken,
             fetchFn,
-            timeoutMs,
+            timeoutMs
           );
         }
         if (!remoteFile || (entry.peerSha256 && remoteFile.sha256 !== entry.peerSha256)) {
@@ -640,9 +621,7 @@ export async function executeConvergeApply(
 
       let metadata: Omit<PeerFileContent, "content"> | null = null;
       if (buffered) {
-        const state = options.peerFilesByNamespace
-          ?.get(entry.namespace)
-          ?.find((file) => file.path === peerPath);
+        const state = options.peerFilesByNamespace?.get(entry.namespace)?.find((file) => file.path === peerPath);
         const sha256 = state?.sha256 ?? entry.peerSha256 ?? createHash("sha256").update(buffered).digest("hex");
         const bytes = buffered.length;
         const mtimeMs = state?.mtimeMs ?? 0;
@@ -650,7 +629,7 @@ export async function executeConvergeApply(
         do {
           const content = buffered.subarray(
             offset,
-            Math.min(bytes, offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES),
+            Math.min(bytes, offset + OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES)
           );
           await applyChunk({ content, offset, sha256, bytes, mtimeMs });
           offset += content.length;
@@ -664,14 +643,14 @@ export async function executeConvergeApply(
           applyChunk,
           resolvedToken,
           fetchFn,
-          timeoutMs,
+          timeoutMs
         );
       }
       if (
-        metadata
-        && transferComplete
-        && !transferRejected
-        && (!entry.peerSha256 || metadata.sha256 === entry.peerSha256)
+        metadata &&
+        transferComplete &&
+        !transferRejected &&
+        (!entry.peerSha256 || metadata.sha256 === entry.peerSha256)
       ) {
         if (entry.action === "conflict") actualTransfers.conflictsResolved += 1;
         else actualTransfers.pulled += 1;
@@ -687,10 +666,8 @@ export async function executeConvergeApply(
         source = {
           sha256: entry.localSha256,
           bytes: localBuffer.length,
-          mtimeMs: options.localFilesByNamespace
-            ?.get(entry.namespace)
-            ?.find((file) => file.path === localPath)
-            ?.mtimeMs ?? 0,
+          mtimeMs:
+            options.localFilesByNamespace?.get(entry.namespace)?.find((file) => file.path === localPath)?.mtimeMs ?? 0,
           ...(expectedPeerSha256 ? { baseSha256: expectedPeerSha256 } : {}),
           readChunk: async (offset, length) => localBuffer.subarray(offset, offset + length),
         };
@@ -709,12 +686,14 @@ export async function executeConvergeApply(
             let chunkOffset = 0;
             const resetChunks = async (): Promise<void> => {
               await chunks?.return?.();
-              chunks = io.readFileChunks({
-                root: rootDir,
-                path: localPath,
-                filePath,
-                chunkSize: OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
-              })[Symbol.asyncIterator]();
+              chunks = io
+                .readFileChunks({
+                  root: rootDir,
+                  path: localPath,
+                  filePath,
+                  chunkSize: OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+                })
+                [Symbol.asyncIterator]();
               chunkOffset = 0;
             };
             closeSource = async () => {
@@ -767,7 +746,7 @@ export async function executeConvergeApply(
             source,
             resolvedToken,
             fetchFn,
-            timeoutMs,
+            timeoutMs
           );
           if (applied) {
             if (applied === "applied") peerMutatedNamespaces.add(entry.namespace);
@@ -787,11 +766,7 @@ export async function executeConvergeApply(
       const bufferedFiles = options.localFileBuffers?.get(entry.namespace);
       if (options.localFileBuffers) {
         const current = bufferedFiles?.get(localPath);
-        if (
-          current
-          && entry.localSha256
-          && createHash("sha256").update(current).digest("hex") === entry.localSha256
-        ) {
+        if (current && entry.localSha256 && createHash("sha256").update(current).digest("hex") === entry.localSha256) {
           bufferedFiles!.delete(localPath);
           deleted = true;
         }
@@ -818,11 +793,7 @@ export async function executeConvergeApply(
       const bufferedFiles = options.peerFileBuffers?.get(entry.namespace);
       if (options.peerFileBuffers) {
         const current = bufferedFiles?.get(peerPath);
-        if (
-          current
-          && entry.peerSha256
-          && createHash("sha256").update(current).digest("hex") === entry.peerSha256
-        ) {
+        if (current && entry.peerSha256 && createHash("sha256").update(current).digest("hex") === entry.peerSha256) {
           bufferedFiles!.delete(peerPath);
           deleted = true;
         }
@@ -834,7 +805,7 @@ export async function executeConvergeApply(
           entry.peerSha256,
           resolvedToken,
           fetchFn,
-          timeoutMs,
+          timeoutMs
         );
         deleted = Boolean(deletionResult);
         if (deletionResult === "applied") peerMutatedNamespaces.add(entry.namespace);
@@ -887,7 +858,7 @@ export async function executeConvergeApply(
             entry.peerSha256,
             resolvedToken,
             fetchFn,
-            timeoutMs,
+            timeoutMs
           );
           deletedPeer = Boolean(result);
           if (result === "applied") peerMutatedNamespaces.add(entry.namespace);
@@ -901,13 +872,7 @@ export async function executeConvergeApply(
 
   if (options.peerUrl && peerMutatedNamespaces.size > 0) {
     const namespaces = [...peerMutatedNamespaces].sort();
-    if (!await postPeerConvergenceComplete(
-      options.peerUrl,
-      namespaces,
-      resolvedToken,
-      fetchFn,
-      timeoutMs,
-    )) {
+    if (!(await postPeerConvergenceComplete(options.peerUrl, namespaces, resolvedToken, fetchFn, timeoutMs))) {
       actualTransfers.failed += 1;
     }
   }
@@ -927,10 +892,7 @@ export async function executeConvergeApply(
   };
 }
 
-async function updateCursorsForPlan(
-  plan: ReconcilePlan,
-  options: ConvergeApplyOptions,
-): Promise<void> {
+async function updateCursorsForPlan(plan: ReconcilePlan, options: ConvergeApplyOptions): Promise<void> {
   const peerUrl = normalizeConvergePeerUrl(options.peerUrl ?? "local");
   let memoryDir: string | undefined;
   if (options.cursorDir) {
@@ -943,14 +905,11 @@ async function updateCursorsForPlan(
   const namespaces = new Set(plan.byNamespace.map((n) => n.namespace));
   for (const ns of namespaces) {
     const cursorPath = defaultConvergeCursorPath(memoryDir, peerUrl, ns);
-    const priorSemanticAgreements = options.semanticAgreementsByNamespace?.get(ns)
-      ?? (await readConvergeCursor(cursorPath))?.semanticAgreements
-      ?? [];
-    const { baseFiles, semanticAgreements } = deriveConvergeCursorBase(
-      plan.entries,
-      ns,
-      priorSemanticAgreements,
-    );
+    const priorSemanticAgreements =
+      options.semanticAgreementsByNamespace?.get(ns) ??
+      (await readConvergeCursor(cursorPath))?.semanticAgreements ??
+      [];
+    const { baseFiles, semanticAgreements } = deriveConvergeCursorBase(plan.entries, ns, priorSemanticAgreements);
 
     const cursorState: ConvergeCursorState = {
       version: 1,
@@ -1009,7 +968,7 @@ export async function cmdConverge(
   action: string,
   rest: string[],
   json: boolean,
-  config: PluginConfig = parseConfig({}),
+  config: PluginConfig = parseConfig({})
 ): Promise<void> {
   if (action === "help" || action === "--help" || action === "-h" || rest.includes("--help") || rest.includes("-h")) {
     console.log(`Usage: remnic converge <plan|apply|watch> [options]
@@ -1025,6 +984,8 @@ Options:
   --conflict-policy <policy>
                     Policy override (newest-wins|manual)
                     Default: converge.conflictPolicy (newest-wins)
+  --interval <seconds>
+                    Watch cadence in seconds (watch only; default 300, min 1)
   --dry-run         Simulate transfers without mutating disk or remote peer
   --json            Output detailed JSON plan report
 `);
@@ -1064,13 +1025,8 @@ Options:
       i += 1;
     } else if (arg === "--conflict-policy") {
       const policy = rest[i + 1];
-      if (
-        typeof policy !== "string"
-        || !CONVERGE_CONFLICT_POLICIES.includes(policy as ConvergeConflictPolicy)
-      ) {
-        throw new Error(
-          `converge: --conflict-policy must be one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}`,
-        );
+      if (typeof policy !== "string" || !CONVERGE_CONFLICT_POLICIES.includes(policy as ConvergeConflictPolicy)) {
+        throw new Error(`converge: --conflict-policy must be one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}`);
       }
       conflictPolicy = policy as ConvergeConflictPolicy;
       i += 1;
@@ -1082,38 +1038,47 @@ Options:
     const onSignal = () => controller.abort();
     process.once("SIGINT", onSignal);
     process.once("SIGTERM", onSignal);
+    let outcome: ConvergeWatchOutcome | undefined;
     try {
-      const outcome = await convergeWatch({
+      outcome = await convergeWatch({
         apply: (applyOptions) => executeConvergeApply(applyOptions),
         config,
         peerUrl,
+        dryRun,
         peerToken,
         conflictPolicy,
         intervalMs: intervalSeconds !== undefined ? intervalSeconds * 1000 : undefined,
         signal: controller.signal,
-        onCycle: (cycle, event) => {
-          if (event.error !== undefined) {
-            console.error(`converge watch: cycle ${cycle} failed: ${String(event.error)}`);
-            return;
-          }
-          const result = event.result;
-          if (!result) return;
-          const transfers = result.transfers;
-          console.log(
-            `converge watch: cycle ${cycle} status=${result.status} pulled=${transfers.pulled} pushed=${transfers.pushed} conflicts=${transfers.conflictsResolved} failed=${transfers.failed}`,
-          );
-        },
+        onCycle: json
+          ? undefined
+          : (cycle, event) => {
+              if (event.error !== undefined) {
+                console.error(`converge watch: cycle ${cycle} failed: ${String(event.error)}`);
+                return;
+              }
+              const result = event.result;
+              if (!result) return;
+              const transfers = result.transfers;
+              console.log(
+                `converge watch: cycle ${cycle} status=${result.status} pulled=${transfers.pulled} pushed=${transfers.pushed} conflicts=${transfers.conflictsResolved} failed=${transfers.failed}`
+              );
+            },
       });
       if (json) {
         console.log(JSON.stringify(outcome, null, 2));
       } else {
         console.log(
-          `converge watch stopped after ${outcome.cycles} cycle(s): ${outcome.convergedCycles} converged, ${outcome.appliedCycles} applied, ${outcome.failedCycles} failed (last: ${outcome.lastStatus}).`,
+          `converge watch stopped after ${outcome.cycles} cycle(s): ${outcome.convergedCycles} converged, ${outcome.appliedCycles} applied, ${outcome.failedCycles} failed (last: ${outcome.lastStatus}).`
         );
       }
     } finally {
       process.removeListener("SIGINT", onSignal);
       process.removeListener("SIGTERM", onSignal);
+      // A supervisor needs a nonzero exit when the watch never made progress
+      // (peer unreachable, bad token) — exit 1 only when EVERY cycle failed.
+      if (outcome && outcome.cycles > 0 && outcome.failedCycles === outcome.cycles) {
+        process.exitCode = 1;
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary

`converge apply` (issue #2150) is one-shot: an active/backup daemon pair only converges when an operator remembers to run it. This adds `remnic converge watch` — the same bidirectional apply on a cadence — so a failover replica converges continuously. It is the scheduled-replication companion to `replicaPeers` divergence detection (#2149): detection reports lag; watch closes it.

## Usage

```text
remnic converge watch --peer <url> [--token <token>] [--conflict-policy <policy>] [--interval <seconds>] [--json]
```

- Default interval 300s (mirrors `replicaPeers.pollIntervalMs`); clamped to >= 1s so a bad flag cannot hot-loop.
- One status line per cycle; `--json` emits a machine-readable `ConvergeWatchOutcome` at stop.
- A failed cycle (peer unreachable, transient network error) reports and does NOT stop the watch — a peer being unreachable is exactly when the surviving side most needs to keep the schedule. Unresolved conflicts under `manual` stop mutation for that cycle only.
- `SIGINT`/`SIGTERM` stop after the current cycle completes.

## Implementation

- The loop is a sibling module `packages/remnic-cli/src/converge-watch.ts` (`convergeWatch` + `ConvergeWatchOptions`/`ConvergeWatchOutcome`), keeping `converge.ts` under the #1995 new-file LOC ratchet. The applier is passed in (`apply`), not imported, so the modules stay acyclic; the CLI passes `executeConvergeApply`, tests inject fakes.
- `cmdConverge` gains the `watch` action, `--interval` parsing (rejects non-positive/non-numeric with exit code 2), and signal wiring.
- Docs: new "Scheduled failover replication" subsection in `docs/operations.md` (deployment pattern: run as a supervised long-running process on one side of the pair, combined with `replicaPeers` for lag visibility).

## Verification

- 5 new tests in `converge.test.ts`: maxCycles accounting, failed-cycle resilience, pre-aborted signal (no cycles), abort during sleep (stops after current cycle), bad `--interval` rejection.
- Full converge suite: 47/47 passing. `tsc --noEmit` clean for `@remnic/cli`. `scripts/check-ratchets.mjs` OK; `scripts/check-docs-parity.mjs` OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `remnic converge watch` for recurring replica reconciliation.
  * Configurable intervals default to 300 seconds, with validation for positive values.
  * Supports dry-run, token, conflict-policy, and JSON output options.
  * Continues after failed cycles and reports convergence, transfer, and failure results.
  * Stops gracefully after the active cycle when interrupted.
  * Supports limiting the number of reconciliation cycles.

* **Documentation**
  * Added CLI usage and scheduled reconciliation guidance.
  * Added an Unreleased changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->