### PR TITLE
fix(plugin-pi): accept underscore-form Remnic MCP tool names

### DIFF
--- a/.changeset/2788-pi-omp-tools-filtering.md
+++ b/.changeset/2788-pi-omp-tools-filtering.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-pi": patch
+---
+
+Accept both MCP tool-name catalog shapes in plugin-pi: current Remnic servers expose underscore-form names (`remnic_recall`), while the plugin previously filtered on the legacy dotted prefix (`remnic.`) only, so every Remnic tool was silently dropped before `pi.registerTool()`. Registration now normalizes only recognized `remnic.`/`remnic_` prefixed names, echoes the catalog name verbatim in `tools/call`, dedupes mixed-shape catalogs, and emits an actionable diagnostic when discovery succeeds but no Remnic tools match. Fixes #2788.

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1594,6 +1594,8 @@ test("matchRemnicMcpToolName normalizes only the recognized Remnic namespace", (
   assert.equal(matchRemnicMcpToolName(""), null);
   assert.equal(matchRemnicMcpToolName(undefined), null);
   assert.equal(matchRemnicMcpToolName(42), null);
+  assert.equal(matchRemnicMcpToolName("remnic_!"), null);
+  assert.equal(matchRemnicMcpToolName("remnic.recall!"), null);
 });
 
 type RegisteredTool = Record<string, unknown> & {
@@ -1616,45 +1618,57 @@ async function registerToolsFromCatalog(catalogToolNames: string[]): Promise<{
   const registeredTools: RegisteredTool[] = [];
   const calledToolNames: string[] = [];
   const appendedEntries: Array<{ customType: string; data: unknown }> = [];
-  globalThis.fetch = async (_input, init) => {
-    const body = JSON.parse(String(init?.body ?? "{}")) as {
-      method?: string;
-      params?: { name?: string };
+  try {
+    globalThis.fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        method?: string;
+        params?: { name?: string };
+      };
+      if (body.method === "tools/list") {
+        return new Response(JSON.stringify({
+          result: {
+            tools: catalogToolNames.map((name) => ({ name, inputSchema: { type: "object" } })),
+          },
+        }), { status: 200 });
+      }
+      if (body.method === "tools/call") {
+        calledToolNames.push(body.params?.name ?? "");
+        return new Response(JSON.stringify({ result: { ok: true } }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ result: {} }), { status: 200 });
     };
-    if (body.method === "tools/list") {
-      return new Response(JSON.stringify({
-        result: {
-          tools: catalogToolNames.map((name) => ({ name, inputSchema: { type: "object" } })),
-        },
-      }), { status: 200 });
-    }
-    if (body.method === "tools/call") {
-      calledToolNames.push(body.params?.name ?? "");
-      return new Response(JSON.stringify({ result: { ok: true } }), { status: 200 });
-    }
-    return new Response(JSON.stringify({ result: {} }), { status: 200 });
-  };
 
-  const extension = createRemnicPiExtension({
-    config: {
-      ...baseConfig(),
-      authToken: "catalog-test-token",
-      namespace: "configured-namespace",
-      recallEnabled: false,
-      observeEnabled: false,
-      compactionEnabled: false,
-      statusEnabled: false,
-      mcpToolsEnabled: true,
-    },
-  });
-  await extension({
-    on: () => undefined,
-    registerCommand: () => undefined,
-    registerTool: (tool: Record<string, unknown>) => registeredTools.push(tool as RegisteredTool),
-    appendEntry: (customType: string, data?: unknown) => appendedEntries.push({ customType, data }),
-  });
+    const extension = createRemnicPiExtension({
+      config: {
+        ...baseConfig(),
+        authToken: "catalog-test-token",
+        namespace: "configured-namespace",
+        recallEnabled: false,
+        observeEnabled: false,
+        compactionEnabled: false,
+        statusEnabled: false,
+        mcpToolsEnabled: true,
+      },
+    });
+    await extension({
+      on: () => undefined,
+      registerCommand: () => undefined,
+      registerTool: (tool: Record<string, unknown>) => registeredTools.push(tool as RegisteredTool),
+      appendEntry: (customType: string, data?: unknown) => appendedEntries.push({ customType, data }),
+    });
 
-  return { registeredTools, calledToolNames, appendedEntries };
+    const firstTool = registeredTools[0];
+    if (firstTool) {
+      await firstTool.execute("call-1", { query: "q" }, undefined, undefined, {
+        cwd: "/tmp/remnic-pi",
+        sessionManager: { getSessionId: () => "catalog-tool" },
+      });
+    }
+
+    return { registeredTools, calledToolNames, appendedEntries };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 }
 
 test("underscore-form MCP catalogs register Pi-safe tools that call the catalog tool name", async () => {
@@ -1670,10 +1684,6 @@ test("underscore-form MCP catalogs register Pi-safe tools that call the catalog 
   );
   assert.equal(registeredTools[0].label, "remnic_recall");
 
-  await registeredTools[0].execute("call-1", { query: "q" }, undefined, undefined, {
-    cwd: "/tmp/remnic-pi",
-    sessionManager: { getSessionId: () => "catalog-underscore" },
-  });
   assert.deepEqual(calledToolNames, ["remnic_recall"]);
 });
 
@@ -1690,10 +1700,6 @@ test("legacy dotted MCP catalogs keep working and call the dotted server-side na
   );
   assert.equal(registeredTools[0].label, "remnic.recall");
 
-  await registeredTools[0].execute("call-1", { query: "q" }, undefined, undefined, {
-    cwd: "/tmp/remnic-pi",
-    sessionManager: { getSessionId: () => "catalog-dotted" },
-  });
   assert.deepEqual(calledToolNames, ["remnic.recall"]);
 });
 
@@ -1709,8 +1715,10 @@ test("non-Remnic and malformed catalog names are excluded without accidental nor
       "remnic",
       "remnic.",
       "remnic_",
+      "remnic_!",
+      "remnic.recall!",
     ]);
-    assert.deepEqual(registeredTools, []);
+    assert.equal(registeredTools.length, 0);
 
     const diagnostic = appendedEntries.find((entry) =>
       typeof entry.data === "object" && entry.data !== null && "code" in entry.data &&

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -10,6 +10,7 @@ import remnicPiExtension, {
   buildCompactionSummary,
   createRemnicPiExtension,
   isDaemonUnreachableError,
+  matchRemnicMcpToolName,
   observeMessages,
   resetProcessRecallBreakerForTest,
   stripSessionOwnedSchemaFields,
@@ -1567,6 +1568,168 @@ test("remnic-why remains available after the recall timeout breaker trips", asyn
   assert.deepEqual(notifications.at(-1), { message: JSON.stringify({ summary: "last recall" }, null, 2), level: "info" });
 });
 
+test("matchRemnicMcpToolName normalizes only the recognized Remnic namespace", () => {
+  assert.deepEqual(matchRemnicMcpToolName("remnic_recall"), {
+    serverToolName: "remnic_recall",
+    piToolName: "remnic_recall",
+  });
+  assert.deepEqual(matchRemnicMcpToolName("remnic_set_coding_context"), {
+    serverToolName: "remnic_set_coding_context",
+    piToolName: "remnic_set_coding_context",
+  });
+  assert.deepEqual(matchRemnicMcpToolName("remnic.recall"), {
+    serverToolName: "remnic.recall",
+    piToolName: "remnic_recall",
+  });
+  assert.deepEqual(matchRemnicMcpToolName("remnic.recall_explain"), {
+    serverToolName: "remnic.recall_explain",
+    piToolName: "remnic_recall_explain",
+  });
+
+  assert.equal(matchRemnicMcpToolName("myremnic_recall"), null);
+  assert.equal(matchRemnicMcpToolName("prefix_remnic_recall"), null);
+  assert.equal(matchRemnicMcpToolName("remnic"), null);
+  assert.equal(matchRemnicMcpToolName("remnic."), null);
+  assert.equal(matchRemnicMcpToolName("remnic_"), null);
+  assert.equal(matchRemnicMcpToolName(""), null);
+  assert.equal(matchRemnicMcpToolName(undefined), null);
+  assert.equal(matchRemnicMcpToolName(42), null);
+});
+
+type RegisteredTool = Record<string, unknown> & {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    ctx: unknown,
+  ) => Promise<unknown>;
+};
+
+async function registerToolsFromCatalog(catalogToolNames: string[]): Promise<{
+  registeredTools: RegisteredTool[];
+  calledToolNames: string[];
+  appendedEntries: Array<{ customType: string; data: unknown }>;
+}> {
+  const originalFetch = globalThis.fetch;
+  const registeredTools: RegisteredTool[] = [];
+  const calledToolNames: string[] = [];
+  const appendedEntries: Array<{ customType: string; data: unknown }> = [];
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      method?: string;
+      params?: { name?: string };
+    };
+    if (body.method === "tools/list") {
+      return new Response(JSON.stringify({
+        result: {
+          tools: catalogToolNames.map((name) => ({ name, inputSchema: { type: "object" } })),
+        },
+      }), { status: 200 });
+    }
+    if (body.method === "tools/call") {
+      calledToolNames.push(body.params?.name ?? "");
+      return new Response(JSON.stringify({ result: { ok: true } }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ result: {} }), { status: 200 });
+  };
+
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "catalog-test-token",
+      namespace: "configured-namespace",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      statusEnabled: false,
+      mcpToolsEnabled: true,
+    },
+  });
+  await extension({
+    on: () => undefined,
+    registerCommand: () => undefined,
+    registerTool: (tool: Record<string, unknown>) => registeredTools.push(tool as RegisteredTool),
+    appendEntry: (customType: string, data?: unknown) => appendedEntries.push({ customType, data }),
+  });
+
+  return { registeredTools, calledToolNames, appendedEntries };
+}
+
+test("underscore-form MCP catalogs register Pi-safe tools that call the catalog tool name", async () => {
+  const { registeredTools, calledToolNames } = await registerToolsFromCatalog([
+    "remnic_recall",
+    "remnic_recall_explain",
+    "remnic_set_coding_context",
+  ]);
+
+  assert.deepEqual(
+    registeredTools.map((tool) => tool.name),
+    ["remnic_recall", "remnic_recall_explain", "remnic_set_coding_context"],
+  );
+  assert.equal(registeredTools[0].label, "remnic_recall");
+
+  await registeredTools[0].execute("call-1", { query: "q" }, undefined, undefined, {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "catalog-underscore" },
+  });
+  assert.deepEqual(calledToolNames, ["remnic_recall"]);
+});
+
+test("legacy dotted MCP catalogs keep working and call the dotted server-side name", async () => {
+  const { registeredTools, calledToolNames } = await registerToolsFromCatalog([
+    "remnic.recall",
+    "remnic.recall_explain",
+    "remnic.set_coding_context",
+  ]);
+
+  assert.deepEqual(
+    registeredTools.map((tool) => tool.name),
+    ["remnic_recall", "remnic_recall_explain", "remnic_set_coding_context"],
+  );
+  assert.equal(registeredTools[0].label, "remnic.recall");
+
+  await registeredTools[0].execute("call-1", { query: "q" }, undefined, undefined, {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "catalog-dotted" },
+  });
+  assert.deepEqual(calledToolNames, ["remnic.recall"]);
+});
+
+test("non-Remnic and malformed catalog names are excluded without accidental normalization", async () => {
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+  try {
+    const { registeredTools, appendedEntries } = await registerToolsFromCatalog([
+      "other_server_tool",
+      "myremnic_recall",
+      "prefix_remnic_recall",
+      "remnic",
+      "remnic.",
+      "remnic_",
+    ]);
+    assert.deepEqual(registeredTools, []);
+
+    const diagnostic = appendedEntries.find((entry) =>
+      typeof entry.data === "object" && entry.data !== null && "code" in entry.data &&
+      (entry.data as { code: unknown }).code === "MCP_TOOLS_FILTERED"
+    );
+    assert.ok(diagnostic, "expected an MCP_TOOLS_FILTERED diagnostic entry");
+    assert.ok(warnings.some((line) => line.includes("none matched the Remnic namespace")));
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("mixed-shape catalogs dedupe onto one Pi-safe registration per tool", async () => {
+  const { registeredTools } = await registerToolsFromCatalog(["remnic.recall", "remnic_recall"]);
+  assert.deepEqual(
+    registeredTools.map((tool) => tool.name),
+    ["remnic_recall"],
+  );
+});
 function baseConfig(): RemnicPiConfig {
   return {
     remnicDaemonUrl: "http://127.0.0.1:4318",

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -57,10 +57,10 @@ const RECALL_PRODUCING_TOOL_NAMES: Record<string, true> = {
  * - legacy dotted form:  `remnic.recall`      -> pi: `remnic_recall`
  * - current underscore:  `remnic_recall`      -> pi: `remnic_recall`
  *
- * Only names starting with the exact `remnic.` or `remnic_` prefix are
- * normalized; arbitrary names that merely contain "remnic" are rejected.
- * The server-side name is echoed verbatim in tools/call so the request is
- * accepted by whichever server shape produced the catalog.
+ * Only names starting with the exact `remnic.` or `remnic_` prefix and a
+ * nonempty alphanumeric/underscore suffix are accepted. The server-side name
+ * is echoed verbatim in tools/call so the request is accepted by whichever
+ * server shape produced the catalog.
  */
 export function matchRemnicMcpToolName(name: unknown): { serverToolName: string; piToolName: string } | null {
   if (typeof name !== "string") return null;
@@ -70,10 +70,10 @@ export function matchRemnicMcpToolName(name: unknown): { serverToolName: string;
   } else if (name.startsWith("remnic_")) {
     rest = name.slice("remnic_".length);
   }
-  if (rest === null || rest.length === 0) return null;
+  if (rest === null || !/^[a-zA-Z0-9_]+$/.test(rest)) return null;
   return {
     serverToolName: name,
-    piToolName: `remnic_${rest}`.replace(/[^a-zA-Z0-9_]/g, "_"),
+    piToolName: `remnic_${rest}`,
   };
 }
 

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -50,6 +50,41 @@ const RECALL_PRODUCING_TOOL_NAMES: Record<string, true> = {
   "remnic.recall_xray": true,
 };
 
+/**
+ * Match an MCP tool name against the recognized Remnic namespace and derive the
+ * Pi-safe registered name. Two catalog shapes are supported:
+ *
+ * - legacy dotted form:  `remnic.recall`      -> pi: `remnic_recall`
+ * - current underscore:  `remnic_recall`      -> pi: `remnic_recall`
+ *
+ * Only names starting with the exact `remnic.` or `remnic_` prefix are
+ * normalized; arbitrary names that merely contain "remnic" are rejected.
+ * The server-side name is echoed verbatim in tools/call so the request is
+ * accepted by whichever server shape produced the catalog.
+ */
+export function matchRemnicMcpToolName(name: unknown): { serverToolName: string; piToolName: string } | null {
+  if (typeof name !== "string") return null;
+  let rest: string | null = null;
+  if (name.startsWith("remnic.")) {
+    rest = name.slice("remnic.".length);
+  } else if (name.startsWith("remnic_")) {
+    rest = name.slice("remnic_".length);
+  }
+  if (rest === null || rest.length === 0) return null;
+  return {
+    serverToolName: name,
+    piToolName: `remnic_${rest}`.replace(/[^a-zA-Z0-9_]/g, "_"),
+  };
+}
+
+/** Breaker lookup tolerant of both catalog shapes (`remnic_recall` <-> `remnic.recall`). */
+function isRecallProducingToolName(serverToolName: string): boolean {
+  return (
+    RECALL_PRODUCING_TOOL_NAMES[serverToolName] === true ||
+    RECALL_PRODUCING_TOOL_NAMES[serverToolName.replace(/^remnic_/, "remnic.")] === true
+  );
+}
+
 type PiSessionState = {
   observedHashes: Set<string>;
   liveObservedReplayKeys: Map<string, number>;
@@ -382,12 +417,19 @@ async function registerMcpTools(
   } catch {
     return;
   }
+  let registeredCount = 0;
+  const seenPiToolNames = new Set<string>();
   for (const tool of tools) {
-    if (!tool.name.startsWith("remnic.")) continue;
-    const piToolName = tool.name.replace(/^remnic\./, "remnic_").replace(/[^a-zA-Z0-9_]/g, "_");
+    const match = matchRemnicMcpToolName(tool.name);
+    if (!match) continue;
+    // A catalog that mixes shapes could map two names onto one Pi-safe name;
+    // register the first occurrence only.
+    if (seenPiToolNames.has(match.piToolName)) continue;
+    seenPiToolNames.add(match.piToolName);
+    registeredCount++;
     pi.registerTool({
-      name: piToolName,
-      label: tool.name,
+      name: match.piToolName,
+      label: match.serverToolName,
       description: tool.description ?? `Call ${tool.name}`,
       parameters: toPiToolParametersSchema(tool.inputSchema),
       async execute(_toolCallId: string, params: Record<string, unknown>, signal: AbortSignal | undefined, _onUpdate: unknown, ctx: any) {
@@ -398,7 +440,7 @@ async function registerMcpTools(
             details: { skipped: true, reason: "stale_context" },
           };
         }
-        if (recallTimeoutBreaker.isTripped() && RECALL_PRODUCING_TOOL_NAMES[tool.name] === true) {
+        if (recallTimeoutBreaker.isTripped() && isRecallProducingToolName(tool.name)) {
           const message = notifyRecallDisabled(session);
           return {
             content: [{ type: "text", text: message }],
@@ -412,10 +454,10 @@ async function registerMcpTools(
           namespace: config.namespace,
           cwd: session.cwd,
         };
-        const result = RECALL_PRODUCING_TOOL_NAMES[tool.name] === true
+        const result = isRecallProducingToolName(tool.name)
           ? await executeRecallWithBreaker(
               (breakerSignal) =>
-                client.mcpTool(tool.name, toolArguments, {
+                client.mcpTool(match.serverToolName, toolArguments, {
                   signal: signal ? AbortSignal.any([signal, breakerSignal]) : breakerSignal,
                 }),
               recallTimeoutBreaker,
@@ -423,12 +465,27 @@ async function registerMcpTools(
               session,
               config,
             )
-          : await client.mcpTool(tool.name, toolArguments, { signal });
+          : await client.mcpTool(match.serverToolName, toolArguments, { signal });
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           details: result,
         };
       },
+    });
+  }
+  if (tools.length > 0 && registeredCount === 0) {
+    const observedNames = tools.map((tool) => tool.name).filter(isString);
+    const observed = observedNames.slice(0, 10).join(", ");
+    const message =
+      `Remnic MCP tools/list returned ${tools.length} tool(s) but none matched the Remnic namespace` +
+      ` ("remnic." or "remnic_" prefix); no Remnic MCP tools were registered. Observed: ${observed}` +
+      `${observedNames.length > 10 ? ", …" : ""}. Check Remnic server/plugin version compatibility.`;
+    console.warn(`[remnic] ${message}`);
+    pi.appendEntry(STATE_CUSTOM_TYPE, {
+      level: "warning",
+      code: "MCP_TOOLS_FILTERED",
+      message,
+      observedToolNames: observedNames,
     });
   }
 }


### PR DESCRIPTION
Fixes #2788

## Summary

`@remnic/plugin-pi` filters discovered MCP tools with `tool.name.startsWith("remnic.")`, but current Remnic servers return **underscore-form** canonical names (`remnic_recall`, `remnic_recall_explain`, …) from authenticated `tools/list`. Every Remnic tool was therefore rejected before `pi.registerTool()`, while hooks kept working through the direct `/engram/v1/*` endpoints — a confusing partial-success state where the agent reports `remnic_recall` as unavailable despite a healthy Remnic connection. Full evidence and reproduction in #2788.

## Changes (focused, no unrelated refactors)

- Add exported `matchRemnicMcpToolName()` helper that normalizes **only** the recognized Remnic namespace prefixes:
  - legacy dotted: `remnic.recall` → Pi-safe `remnic_recall`
  - current underscore: `remnic_recall` → `remnic_recall`
  - arbitrary names merely containing "remnic" (`myremnic_recall`, `prefix_remnic_recall`), bare prefixes (`remnic.`, `remnic_`), and non-string values are rejected
- Registered tools echo the **catalog name verbatim** in `tools/call`, so requests are always accepted by whichever server shape produced the catalog.
- Recall-timeout-breaker detection (`remnic.recall` / `remnic.recall_xray`) now works for both catalog shapes.
- Mixed-shape catalogs dedupe onto one Pi-safe registration per tool (first occurrence wins).
- Diagnostics: if `tools/list` succeeds but zero tools match, the plugin logs a `console.warn` and appends a structured `remnic_state` entry (`code: "MCP_TOOLS_FILTERED"`) listing observed names — no more silent empty catalogs.
- No toolbox/OMP-specific interception; the fix lives entirely in shared plugin behavior.

## Tests

Focused regression tests in `packages/plugin-pi/src/index.test.ts`:

1. Underscore catalog (`remnic_recall`, `remnic_recall_explain`, `remnic_set_coding_context`) registers expected Pi-safe tools.
2. Legacy dotted catalog (`remnic.recall`, …) continues to register and call the dotted server-side name.
3. Registered tools send the correct server-side name in `tools/call` (both catalog shapes).
4. Non-Remnic tools remain excluded from the registration loop.
5. Malformed/unrelated names merely containing "remnic" are not normalized; empty-catalog-after-successful-discovery emits both console and structured diagnostics.
6. Mixed-shape catalog dedupe.
7. Unit coverage for `matchRemnicMcpToolName` edge cases.

Validation:

- `pnpm install --filter @remnic/plugin-pi...`
- `npm run check-types` in `packages/plugin-pi` → clean (`tsc --noEmit`)
- `npm test` in `packages/plugin-pi` → **176 pass / 0 fail**, including all pre-existing automatic recall, observe, sessionKey, namespace, and cwd injection tests

## Release notes

Added changeset `.changeset/2788-pi-omp-tools-filtering.md` (`@remnic/plugin-pi`: patch).

Observed on `@remnic/plugin-pi@9.69.4`; verified still present on current upstream `main` before fixing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Remnic MCP tools using dotted or underscore-based names.
  - Preserved original tool names when executing MCP calls.
  - Deduplicated tools with equivalent naming formats.
  - Added diagnostics and warnings when no matching tools are discovered.

- **Bug Fixes**
  - Improved recall tool compatibility across supported naming formats.
  - Excluded unrelated, malformed, or punctuation-containing tool names from registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->