### PR TITLE
feat(core,server): Grok and OpenCode transport adapters + standalone trustPrincipalHeader

### DIFF
--- a/.changeset/2782-grok-opencode-adapters.md
+++ b/.changeset/2782-grok-opencode-adapters.md
@@ -1,13 +1,8 @@
 ---
 "@remnic/core": minor
+"@remnic/server": minor
 ---
 
 Add `GrokAdapter` and `OpenCodeAdapter` to the adapter registry. Grok and OpenCode MCP clients now resolve a transport principal (and default namespace) the same way Codex, Claude Code, Hermes, and Replit do — via `clientInfo.name`, `User-Agent`, or the user-configured `X-Engram-Client-Id` header — so namespaced calls work without inventing a session key. Adapters never trust `X-Engram-Principal`; that stays behind the server's `trustPrincipalHeader` gate. Fixes #2782.
-
----
-
----
-"@remnic/server": minor
----
 
 Parse `server.trustPrincipalHeader` in standalone `remnic-server` config and pass it to the HTTP access server, so the documented `X-Engram-Principal` per-request override works outside the OpenClaw hosted path (issue #2782). Accepts boolean-like strings (`"true"`/`"1"`/`"on"`), defaults to false.

--- a/.changeset/2782-grok-opencode-adapters.md
+++ b/.changeset/2782-grok-opencode-adapters.md
@@ -1,0 +1,13 @@
+---
+"@remnic/core": minor
+---
+
+Add `GrokAdapter` and `OpenCodeAdapter` to the adapter registry. Grok and OpenCode MCP clients now resolve a transport principal (and default namespace) the same way Codex, Claude Code, Hermes, and Replit do — via `clientInfo.name`, `User-Agent`, or the user-configured `X-Engram-Client-Id` header — so namespaced calls work without inventing a session key. Adapters never trust `X-Engram-Principal`; that stays behind the server's `trustPrincipalHeader` gate. Fixes #2782.
+
+---
+
+---
+"@remnic/server": minor
+---
+
+Parse `server.trustPrincipalHeader` in standalone `remnic-server` config and pass it to the HTTP access server, so the documented `X-Engram-Principal` per-request override works outside the OpenClaw hosted path (issue #2782). Accepts boolean-like strings (`"true"`/`"1"`/`"on"`), defaults to false.

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -275,8 +275,9 @@ Then start the server normally with `npx remnic-server` (or `remnic daemon start
 if your config is already in place).
 
 For multi-tenant access from a single standalone instance, prefer session-key
-prefix rules. Header-based per-request principal override is not currently
-available through `remnic-server` (see [Per-Request Principal Override](#per-request-principal-override) below).
+prefix rules when possible. If you intentionally trust the bearer token to
+select a principal per request, enable `server.trustPrincipalHeader` and send
+`X-Engram-Principal` (see [Per-Request Principal Override](#per-request-principal-override) below).
 
 See the [Namespaces documentation](../namespaces.md) for full details on namespace storage layout, QMD collection configuration, and CLI tooling.
 
@@ -422,7 +423,7 @@ openclaw engram access http-serve \
   --trust-principal-header
 ```
 
-### Usage (OpenClaw compatibility path)
+### Usage (standalone and OpenClaw compatibility paths)
 
 Include the header in your requests:
 
@@ -444,9 +445,9 @@ The `X-Engram-Principal` header value becomes the authenticated principal for th
 
 ### Security considerations
 
-- **Only enable `--trust-principal-header` when the bearer token provides sufficient trust.** Anyone with the token can impersonate any principal.
+- **Only enable `server.trustPrincipalHeader` (or `--trust-principal-header` for OpenClaw) when the bearer token provides sufficient trust.** Anyone with the token can impersonate any principal.
 - If you run the server behind a reverse proxy, ensure the proxy strips or validates the `X-Engram-Principal` header from untrusted clients.
-- Without `--trust-principal-header`, the header is silently ignored — principal resolution falls back to configured principal or session key rules.
+- Without the corresponding trust gate, the header is silently ignored — principal resolution falls back to the configured principal or session key rules.
 - For production multi-tenant standalone setups, consider running separate server instances per tenant with different tokens and fixed configured principals, rather than trusting a single token with header-based principal resolution.
 
 ## Shared knowledge layer

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -400,12 +400,19 @@ If `lcmEnabled` is `false`, the response will have an empty `results` array and 
 
 ## Per-request principal override
 
-Standalone `remnic-server` does not currently expose a CLI flag to enable
-trusted per-request principal override. In standalone mode, principal resolution
-comes from `server.principal` in config or from session-key prefix rules.
+Standalone `remnic-server` supports trusted per-request principal override via
+the `server.trustPrincipalHeader` config option (issue #2782):
 
-If you need `X-Engram-Principal` header trust today, use the OpenClaw-hosted HTTP
-access server instead of `remnic-server`:
+```json
+{
+  "server": {
+    "authToken": "set-me",
+    "trustPrincipalHeader": true
+  }
+}
+```
+
+The same gate exists on the OpenClaw-hosted HTTP access server as a CLI flag:
 
 ```bash
 openclaw engram access http-serve \

--- a/packages/remnic-core/src/adapters/grok-opencode.test.ts
+++ b/packages/remnic-core/src/adapters/grok-opencode.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AdapterRegistry } from "./registry.js";
+import { GrokAdapter } from "./grok.js";
+import { OpenCodeAdapter } from "./opencode.js";
+import type { AdapterContext } from "./types.js";
+
+function context(overrides: Partial<AdapterContext> = {}): AdapterContext {
+  return { headers: {}, ...overrides };
+}
+
+test("GrokAdapter matches clientInfo names containing grok", () => {
+  const adapter = new GrokAdapter();
+  assert.equal(adapter.matches(context({ clientInfo: { name: "grok" } })), true);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "grok-cli" } })), true);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "Grok-Desktop" } })), true);
+});
+
+test("GrokAdapter matches User-Agent and configured client-id headers", () => {
+  const adapter = new GrokAdapter();
+  assert.equal(adapter.matches(context({ headers: { "user-agent": "grok/4.6" } })), true);
+  assert.equal(
+    adapter.matches(context({ headers: { "X-Engram-Client-Id": "grok" } })),
+    true,
+  );
+});
+
+test("GrokAdapter rejects unrelated clients", () => {
+  const adapter = new GrokAdapter();
+  assert.equal(adapter.matches(context()), false);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "claude-code" } })), false);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "codex-mcp-client" } })), false);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "opencode" } })), false);
+  assert.equal(
+    adapter.matches(context({ headers: { "X-Engram-Client-Id": "codex" } })),
+    false,
+  );
+});
+
+test("GrokAdapter resolves identity with adapter-owned principal and header namespace", () => {
+  const adapter = new GrokAdapter();
+  assert.deepEqual(
+    adapter.resolveIdentity(context({
+      headers: {
+        "mcp-session-id": "sess-grok-1",
+        "x-engram-namespace": "my-project",
+      },
+    })),
+    {
+      namespace: "my-project",
+      principal: "grok",
+      sessionKey: "sess-grok-1",
+      adapterId: "grok",
+    },
+  );
+  assert.deepEqual(
+    adapter.resolveIdentity(context({ sessionKey: "session-1" })).principal,
+    "grok",
+  );
+  // Default namespace when no explicit header is present.
+  assert.equal(
+    adapter.resolveIdentity(context()).namespace,
+    "grok",
+  );
+});
+
+test("OpenCodeAdapter matches clientInfo, User-Agent, and configured client-id headers", () => {
+  const adapter = new OpenCodeAdapter();
+  assert.equal(adapter.matches(context({ clientInfo: { name: "opencode" } })), true);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "OpenCode/1.0" } })), true);
+  assert.equal(adapter.matches(context({ headers: { "user-agent": "opencode/2.3.0" } })), true);
+  assert.equal(
+    adapter.matches(context({ headers: { "X-Engram-Client-Id": "opencode" } })),
+    true,
+  );
+});
+
+test("OpenCodeAdapter rejects unrelated clients", () => {
+  const adapter = new OpenCodeAdapter();
+  assert.equal(adapter.matches(context()), false);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "claude-code" } })), false);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "codex-mcp-client" } })), false);
+  assert.equal(adapter.matches(context({ clientInfo: { name: "grok" } })), false);
+});
+
+test("OpenCodeAdapter resolves identity with adapter-owned principal", () => {
+  const adapter = new OpenCodeAdapter();
+  const resolved = adapter.resolveIdentity(context({
+    headers: { "mcp-session-id": "sess-oc-1" },
+  }));
+  assert.deepEqual(resolved, {
+    namespace: "opencode",
+    principal: "opencode",
+    sessionKey: "sess-oc-1",
+    adapterId: "opencode",
+  });
+});
+
+test("default registry registers grok and opencode adapters in order", () => {
+  const registry = new AdapterRegistry();
+  assert.deepEqual(registry.list(), [
+    "hermes",
+    "replit",
+    "codex",
+    "claude-code",
+    "grok",
+    "opencode",
+  ]);
+});
+
+test("issue #2782 reproduction: Grok headers resolve a transport principal without a session key", () => {
+  const registry = new AdapterRegistry();
+  const resolved = registry.resolve({
+    headers: {
+      "x-engram-client-id": "grok",
+      "x-engram-principal": "grok",
+    },
+  });
+  assert.ok(resolved, "expected the Grok adapter to resolve the request");
+  assert.equal(resolved.principal, "grok");
+  assert.equal(resolved.adapterId, "grok");
+  assert.equal(resolved.sessionKey, undefined);
+});
+
+test("issue #2782 reproduction: OpenCode headers resolve a transport principal without a session key", () => {
+  const registry = new AdapterRegistry();
+  const resolved = registry.resolve({
+    headers: { "x-engram-client-id": "opencode" },
+    clientInfo: { name: "opencode" },
+  });
+  assert.ok(resolved, "expected the OpenCode adapter to resolve the request");
+  assert.equal(resolved.principal, "opencode");
+});
+
+test("adapters never adopt X-Engram-Principal as their own resolution source", () => {
+  const registry = new AdapterRegistry();
+  for (const clientId of ["grok", "opencode"]) {
+    const resolved = registry.resolve({
+      headers: { "x-engram-client-id": clientId, "x-engram-principal": "spoofed-principal" },
+    });
+    assert.ok(resolved);
+    assert.equal(resolved.principal, clientId);
+    assert.notEqual(resolved.principal, "spoofed-principal");
+  }
+});

--- a/packages/remnic-core/src/adapters/grok.ts
+++ b/packages/remnic-core/src/adapters/grok.ts
@@ -1,0 +1,53 @@
+import { headerValue, type AdapterContext, type EngramAdapter, type ResolvedIdentity } from "./types.js";
+
+/**
+ * Grok adapter.
+ *
+ * Detection: Grok clients identify themselves with a clientInfo name
+ * containing "grok" in the MCP initialize handshake, and send
+ * User-Agent: grok/<version> on HTTP requests. The exact clientInfo
+ * name is not yet stable across Grok surfaces (desktop app, CLI), so
+ * detection uses a contains-match for forward compatibility.
+ *
+ * User-configured identification is also supported via headers:
+ *      "headers": { "X-Engram-Client-Id": "grok" }
+ *
+ * Principal overrides are intentionally handled only by the HTTP server's
+ * trustPrincipalHeader gate. Adapters must not independently trust
+ * X-Engram-Principal.
+ */
+export class GrokAdapter implements EngramAdapter {
+  readonly id = "grok";
+
+  matches(context: AdapterContext): boolean {
+    // Primary: MCP clientInfo from initialize handshake
+    const clientName = context.clientInfo?.name?.toLowerCase() ?? "";
+    if (clientName.includes("grok")) return true;
+
+    // Fallback: User-Agent header ("grok/<version>")
+    const ua = headerValue(context.headers, "user-agent");
+    if (ua && ua.toLowerCase().startsWith("grok/")) return true;
+
+    // Fallback: user-configured client identifier header
+    const clientId = headerValue(context.headers, "x-engram-client-id");
+    if (clientId?.toLowerCase() === "grok") return true;
+
+    return false;
+  }
+
+  resolveIdentity(context: AdapterContext): ResolvedIdentity {
+    // MCP session ID (standard MCP header, server-assigned)
+    const mcpSessionId = headerValue(context.headers, "mcp-session-id");
+
+    // Namespace: explicit header > default
+    const namespace = headerValue(context.headers, "x-engram-namespace")
+      || "grok";
+
+    return {
+      namespace,
+      principal: "grok",
+      sessionKey: mcpSessionId ?? context.sessionKey,
+      adapterId: this.id,
+    };
+  }
+}

--- a/packages/remnic-core/src/adapters/index.ts
+++ b/packages/remnic-core/src/adapters/index.ts
@@ -1,6 +1,8 @@
 export type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
 export { ClaudeCodeAdapter } from "./claude-code.js";
 export { CodexAdapter } from "./codex.js";
+export { GrokAdapter } from "./grok.js";
+export { OpenCodeAdapter } from "./opencode.js";
 export { ReplitAdapter } from "./replit.js";
 export { HermesAdapter } from "./hermes.js";
 export { AdapterRegistry } from "./registry.js";

--- a/packages/remnic-core/src/adapters/opencode.ts
+++ b/packages/remnic-core/src/adapters/opencode.ts
@@ -1,0 +1,52 @@
+import { headerValue, type AdapterContext, type EngramAdapter, type ResolvedIdentity } from "./types.js";
+
+/**
+ * OpenCode adapter.
+ *
+ * Detection: OpenCode identifies itself as "opencode" in the MCP
+ * clientInfo of its initialize handshake, and sends
+ * User-Agent: opencode/<version> on HTTP requests.
+ *
+ * User-configured identification is also supported via headers in the
+ * OpenCode MCP server config:
+ *      "headers": { "X-Engram-Client-Id": "opencode" }
+ *
+ * Principal overrides are intentionally handled only by the HTTP server's
+ * trustPrincipalHeader gate. Adapters must not independently trust
+ * X-Engram-Principal.
+ */
+export class OpenCodeAdapter implements EngramAdapter {
+  readonly id = "opencode";
+
+  matches(context: AdapterContext): boolean {
+    // Primary: MCP clientInfo from initialize handshake
+    const clientName = context.clientInfo?.name?.toLowerCase() ?? "";
+    if (clientName.includes("opencode")) return true;
+
+    // Fallback: User-Agent header ("opencode/<version>")
+    const ua = headerValue(context.headers, "user-agent");
+    if (ua && ua.toLowerCase().startsWith("opencode/")) return true;
+
+    // Fallback: user-configured client identifier header
+    const clientId = headerValue(context.headers, "x-engram-client-id");
+    if (clientId?.toLowerCase() === "opencode") return true;
+
+    return false;
+  }
+
+  resolveIdentity(context: AdapterContext): ResolvedIdentity {
+    // MCP session ID (standard MCP header, server-assigned)
+    const mcpSessionId = headerValue(context.headers, "mcp-session-id");
+
+    // Namespace: explicit header > default
+    const namespace = headerValue(context.headers, "x-engram-namespace")
+      || "opencode";
+
+    return {
+      namespace,
+      principal: "opencode",
+      sessionKey: mcpSessionId ?? context.sessionKey,
+      adapterId: this.id,
+    };
+  }
+}

--- a/packages/remnic-core/src/adapters/registry.ts
+++ b/packages/remnic-core/src/adapters/registry.ts
@@ -1,6 +1,8 @@
 import type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
 import { ClaudeCodeAdapter } from "./claude-code.js";
 import { CodexAdapter } from "./codex.js";
+import { GrokAdapter } from "./grok.js";
+import { OpenCodeAdapter } from "./opencode.js";
 import { ReplitAdapter } from "./replit.js";
 import { HermesAdapter } from "./hermes.js";
 
@@ -18,6 +20,8 @@ export class AdapterRegistry {
       new ReplitAdapter(),
       new CodexAdapter(),
       new ClaudeCodeAdapter(),
+      new GrokAdapter(),
+      new OpenCodeAdapter(),
     ];
   }
 

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -14,6 +15,21 @@ async function writeConfig(content: string): Promise<{ filePath: string; cleanup
   return { filePath, cleanup: () => rm(dir, { recursive: true, force: true }) };
 }
 
+async function reserveFreePort(): Promise<number> {
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  const probe = net.createServer();
+  probe.once("error", reject);
+  probe.listen(0, "127.0.0.1", () => {
+    const address = probe.address();
+    if (address && typeof address === "object") {
+      const { port } = address;
+      probe.close(() => resolve(port));
+    } else {
+      probe.close(() => reject(new Error("no address")));
+    }
+  });
+  return promise;
+}
 
 test("server config merge preserves openaiApiKey=false over OPENAI_API_KEY env override", () => {
   const merged = mergeRemnicConfigForServer(
@@ -227,8 +243,9 @@ test("server config parser rejects ephemeral and blank ports in user-facing conf
   );
 });
 
-test("standalone startServer forwards a trusted request principal", async () => {
+test("standalone startServer applies the runtime port override and forwards a trusted request principal", async () => {
   const { filePath, cleanup } = await writeConfig("{}");
+  const requestedPort = await reserveFreePort();
   const memoryDir = path.join(path.dirname(filePath), "memory");
   await writeFile(
     filePath,
@@ -251,6 +268,7 @@ test("standalone startServer forwards a trusted request principal", async () => 
       },
       server: {
         host: "127.0.0.1",
+        port: requestedPort === 65535 ? requestedPort - 1 : requestedPort + 1,
         authToken: "test-token",
         trustPrincipalHeader: true,
       },
@@ -263,10 +281,9 @@ test("standalone startServer forwards a trusted request principal", async () => 
     result = await startServer({
       configPath: filePath,
       authToken: "test-token",
-      // OS-assigned ephemeral port at bind time; result.port reports the
-      // bound value. Avoids the probe-then-close EADDRINUSE race.
-      allowEphemeralPort: true,
+      port: requestedPort,
     });
+    assert.equal(result.port, requestedPort);
     const url = `http://127.0.0.1:${result.port}/engram/v1/memories?namespace=tenant-a&limit=10&offset=0&sort=updated_desc`;
     const withoutHeader = await fetch(url, {
       headers: { authorization: "Bearer test-token" },

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -1,17 +1,38 @@
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { parseConfig } from "@remnic/core";
-import { createAdminControls, envOverrides, loadConfigFile, mergeRemnicConfigForServer, parseServerConfig } from "./index.js";
+import { createAdminControls, envOverrides, loadConfigFile, mergeRemnicConfigForServer, parseServerConfig, startServer, type ServerResult } from "./index.js";
 
 async function writeConfig(content: string): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-config-"));
   const filePath = path.join(dir, "config.json");
   await writeFile(filePath, content, "utf-8");
   return { filePath, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+function getFreePort(): Promise<number> {
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  const server = net.createServer();
+  server.unref();
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", () => {
+    const address = server.address();
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else if (!address || typeof address === "string") {
+        reject(new Error("Failed to allocate a free TCP port"));
+      } else {
+        resolve(address.port);
+      }
+    });
+  });
+  return promise;
 }
 
 test("server config merge preserves openaiApiKey=false over OPENAI_API_KEY env override", () => {
@@ -208,6 +229,63 @@ test("server config parser rejects invalid trustPrincipalHeader values", () => {
     () => parseServerConfig({ trustPrincipalHeader: "maybe" as unknown as boolean }),
     /server\.trustPrincipalHeader: expected a boolean/,
   );
+});
+
+test("standalone startServer forwards a trusted request principal", async () => {
+  const { filePath, cleanup } = await writeConfig("{}");
+  const memoryDir = path.join(path.dirname(filePath), "memory");
+  const port = await getFreePort();
+  await writeFile(
+    filePath,
+    JSON.stringify({
+      remnic: {
+        memoryDir,
+        qmdEnabled: false,
+        qmdDaemonEnabled: false,
+        searchBackend: "noop",
+        namespacesEnabled: true,
+        defaultNamespace: "default",
+        defaultRecallNamespaces: ["self"],
+        namespacePolicies: [
+          {
+            name: "tenant-a",
+            readPrincipals: ["header-agent"],
+            writePrincipals: ["header-agent"],
+          },
+        ],
+      },
+      server: {
+        host: "127.0.0.1",
+        port,
+        authToken: "test-token",
+        trustPrincipalHeader: true,
+      },
+    }),
+    "utf8",
+  );
+
+  let result: ServerResult | undefined;
+  try {
+    result = await startServer({ configPath: filePath, authToken: "test-token" });
+    const url = `http://127.0.0.1:${result.port}/engram/v1/memories?namespace=tenant-a&limit=10&offset=0&sort=updated_desc`;
+    const withoutHeader = await fetch(url, {
+      headers: { authorization: "Bearer test-token" },
+    });
+    assert.equal(withoutHeader.status, 400, await withoutHeader.text());
+
+    const withHeader = await fetch(url, {
+      headers: {
+        authorization: "Bearer test-token",
+        "x-engram-principal": "header-agent",
+      },
+    });
+    assert.equal(withHeader.status, 200);
+    const body = (await withHeader.json()) as { namespace?: string };
+    assert.equal(body.namespace, "tenant-a");
+  } finally {
+    await result?.stop();
+    await cleanup();
+  }
 });
 
 test("server config parser rejects invalid field types", () => {

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -190,6 +190,26 @@ test("server config parser disables the admin console by default", () => {
   assert.equal(parseServerConfig({}).adminConsolePrefillToken, false);
 });
 
+test("server config parser defaults trustPrincipalHeader to false and accepts boolean-like strings", () => {
+  assert.equal(parseServerConfig({}).trustPrincipalHeader, false);
+  assert.equal(parseServerConfig({ trustPrincipalHeader: true }).trustPrincipalHeader, true);
+  assert.equal(
+    parseServerConfig({ trustPrincipalHeader: "true" as unknown as boolean }).trustPrincipalHeader,
+    true,
+  );
+  assert.equal(
+    parseServerConfig({ trustPrincipalHeader: "0" as unknown as boolean }).trustPrincipalHeader,
+    false,
+  );
+});
+
+test("server config parser rejects invalid trustPrincipalHeader values", () => {
+  assert.throws(
+    () => parseServerConfig({ trustPrincipalHeader: "maybe" as unknown as boolean }),
+    /server\.trustPrincipalHeader: expected a boolean/,
+  );
+});
+
 test("server config parser rejects invalid field types", () => {
   assert.throws(
     () => parseServerConfig({ host: 123 as unknown as string }),

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -15,25 +14,6 @@ async function writeConfig(content: string): Promise<{ filePath: string; cleanup
   return { filePath, cleanup: () => rm(dir, { recursive: true, force: true }) };
 }
 
-function getFreePort(): Promise<number> {
-  const { promise, resolve, reject } = Promise.withResolvers<number>();
-  const server = net.createServer();
-  server.unref();
-  server.once("error", reject);
-  server.listen(0, "127.0.0.1", () => {
-    const address = server.address();
-    server.close((error) => {
-      if (error) {
-        reject(error);
-      } else if (!address || typeof address === "string") {
-        reject(new Error("Failed to allocate a free TCP port"));
-      } else {
-        resolve(address.port);
-      }
-    });
-  });
-  return promise;
-}
 
 test("server config merge preserves openaiApiKey=false over OPENAI_API_KEY env override", () => {
   const merged = mergeRemnicConfigForServer(
@@ -234,7 +214,6 @@ test("server config parser rejects invalid trustPrincipalHeader values", () => {
 test("standalone startServer forwards a trusted request principal", async () => {
   const { filePath, cleanup } = await writeConfig("{}");
   const memoryDir = path.join(path.dirname(filePath), "memory");
-  const port = await getFreePort();
   await writeFile(
     filePath,
     JSON.stringify({
@@ -256,7 +235,9 @@ test("standalone startServer forwards a trusted request principal", async () => 
       },
       server: {
         host: "127.0.0.1",
-        port,
+        // Port 0 lets the OS assign a free port atomically at bind time;
+        // startServer reports the bound port via result.port.
+        port: 0,
         authToken: "test-token",
         trustPrincipalHeader: true,
       },

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -211,6 +211,22 @@ test("server config parser rejects invalid trustPrincipalHeader values", () => {
   );
 });
 
+test("server config parser rejects ephemeral and blank ports in user-facing config", () => {
+  // Port 0 is reserved for the programmatic allowEphemeralPort runtime
+  // option: user-facing server.port / REMNIC_PORT / --port must stay 1-65535
+  // so runServerHealthcheck never probes port 0 (review: PR #2790).
+  assert.throws(
+    () => parseServerConfig({ port: 0 }),
+    /server\.port: expected an integer port from 1 to 65535/,
+  );
+  // Number("".trim()) === 0, so a blank string must be rejected explicitly
+  // rather than silently resolving to an ephemeral port.
+  assert.throws(
+    () => parseServerConfig({ port: "" }),
+    /server\.port: expected an integer port from 1 to 65535/,
+  );
+});
+
 test("standalone startServer forwards a trusted request principal", async () => {
   const { filePath, cleanup } = await writeConfig("{}");
   const memoryDir = path.join(path.dirname(filePath), "memory");
@@ -235,9 +251,6 @@ test("standalone startServer forwards a trusted request principal", async () => 
       },
       server: {
         host: "127.0.0.1",
-        // Port 0 lets the OS assign a free port atomically at bind time;
-        // startServer reports the bound port via result.port.
-        port: 0,
         authToken: "test-token",
         trustPrincipalHeader: true,
       },
@@ -247,7 +260,13 @@ test("standalone startServer forwards a trusted request principal", async () => 
 
   let result: ServerResult | undefined;
   try {
-    result = await startServer({ configPath: filePath, authToken: "test-token" });
+    result = await startServer({
+      configPath: filePath,
+      authToken: "test-token",
+      // OS-assigned ephemeral port at bind time; result.port reports the
+      // bound value. Avoids the probe-then-close EADDRINUSE race.
+      allowEphemeralPort: true,
+    });
     const url = `http://127.0.0.1:${result.port}/engram/v1/memories?namespace=tenant-a&limit=10&offset=0&sort=updated_desc`;
     const withoutHeader = await fetch(url, {
       headers: { authorization: "Bearer test-token" },

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -66,12 +66,10 @@ function parseServerPort(value: unknown, source: string): number {
   if (
     typeof port !== "number" ||
     !Number.isInteger(port) ||
-    port < 0 ||
+    port < 1 ||
     port > 65535
   ) {
-    // Port 0 is allowed: the OS assigns an ephemeral port at bind time and
-    // startServer reports the bound port via ServerResult.port.
-    throw new Error(`Invalid ${source}: expected an integer port from 0 to 65535 (0 = ephemeral)`);
+    throw new Error(`Invalid ${source}: expected an integer port from 1 to 65535`);
   }
   return port;
 }
@@ -264,6 +262,8 @@ type ServerRuntimeOptions = {
   host?: string;
   port?: number;
   authToken?: string;
+  /** Test/programmatic-only: bind an OS-assigned ephemeral port (port 0). */
+  allowEphemeralPort?: boolean;
 };
 
 type EffectiveServerRuntimeConfig = {
@@ -282,9 +282,11 @@ function resolveEffectiveServerRuntimeConfig(
   const { remnic: envRemnic, ...envServer } = envOverrides();
   const cliServerConfig: Partial<ServerConfig["server"]> = {};
   if (options?.host !== undefined) cliServerConfig.host = options.host;
-  if (options?.port !== undefined) cliServerConfig.port = parseServerPort(options.port, "options.port");
   if (options?.authToken !== undefined) cliServerConfig.authToken = options.authToken;
-
+  // User-facing config (server.port, REMNIC_PORT, --port) stays 1-65535 so
+  // runServerHealthcheck's configured-port probe never targets port 0.
+  // allowEphemeralPort bypasses the parser AFTER validation instead.
+  const ephemeralRequested = options?.allowEphemeralPort === true && options.port === undefined;
   const serverConfig = {
     ...fileConfig.server,
     ...envServer,
@@ -296,12 +298,14 @@ function resolveEffectiveServerRuntimeConfig(
       ? "REMNIC_PORT/ENGRAM_PORT"
       : "server.port";
 
+  const parsedServerConfig = parseServerConfig(serverConfig, { portSource });
+  if (ephemeralRequested) parsedServerConfig.port = 0;
   return {
     resolvedConfigPath,
     fileConfig,
     envRemnic,
     serverConfig,
-    parsedServerConfig: parseServerConfig(serverConfig, { portSource }),
+    parsedServerConfig,
   };
 }
 

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -283,6 +283,7 @@ function resolveEffectiveServerRuntimeConfig(
   const cliServerConfig: Partial<ServerConfig["server"]> = {};
   if (options?.host !== undefined) cliServerConfig.host = options.host;
   if (options?.authToken !== undefined) cliServerConfig.authToken = options.authToken;
+  if (options?.port !== undefined) cliServerConfig.port = options.port;
   // User-facing config (server.port, REMNIC_PORT, --port) stays 1-65535 so
   // runServerHealthcheck's configured-port probe never targets port 0.
   // allowEphemeralPort bypasses the parser AFTER validation instead.

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -66,10 +66,12 @@ function parseServerPort(value: unknown, source: string): number {
   if (
     typeof port !== "number" ||
     !Number.isInteger(port) ||
-    port < 1 ||
+    port < 0 ||
     port > 65535
   ) {
-    throw new Error(`Invalid ${source}: expected an integer port from 1 to 65535`);
+    // Port 0 is allowed: the OS assigns an ephemeral port at bind time and
+    // startServer reports the bound port via ServerResult.port.
+    throw new Error(`Invalid ${source}: expected an integer port from 0 to 65535 (0 = ephemeral)`);
   }
   return port;
 }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -44,7 +44,6 @@ export interface ServerConfig {
     port?: unknown;
     authToken?: string;
     principal?: string;
-    /** Trust X-Engram-Principal per request (issue #2782; same gate as OpenClaw --trust-principal-header). */
     trustPrincipalHeader?: boolean;
     maxBodyBytes?: number;
     /** Max write requests per rolling window before 429 write_rate_limited (issue #1937). */
@@ -62,7 +61,6 @@ export interface ServerConfig {
     oauth?: unknown;
   } & AdminConsoleServerFields;
 }
-
 function parseServerPort(value: unknown, source: string): number {
   const port = typeof value === "string" ? Number(value.trim()) : value;
   if (

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -44,6 +44,8 @@ export interface ServerConfig {
     port?: unknown;
     authToken?: string;
     principal?: string;
+    /** Trust X-Engram-Principal per request (issue #2782; same gate as OpenClaw --trust-principal-header). */
+    trustPrincipalHeader?: boolean;
     maxBodyBytes?: number;
     /** Max write requests per rolling window before 429 write_rate_limited (issue #1937). */
     writeRateLimitMaxRequests?: number;
@@ -133,6 +135,7 @@ export interface ParsedServerConfig extends ParsedAdminConsoleConfig {
   port: number;
   authToken?: string;
   principal?: string;
+  trustPrincipalHeader?: boolean;
   maxBodyBytes?: number;
   writeRateLimitMaxRequests?: number;
   writeRateLimitWindowMs?: number;
@@ -151,6 +154,7 @@ export function parseServerConfig(
       : parseServerPort(raw.port, options?.portSource ?? "server.port"),
     authToken: parseOptionalString(raw.authToken, "server.authToken"),
     principal: parseOptionalString(raw.principal, "server.principal"),
+    trustPrincipalHeader: parseOptionalBoolean(raw.trustPrincipalHeader, "server.trustPrincipalHeader") ?? false,
     maxBodyBytes: parseOptionalPositiveInteger(raw.maxBodyBytes, "server.maxBodyBytes"),
     writeRateLimitMaxRequests: parseOptionalPositiveInteger(
       raw.writeRateLimitMaxRequests,
@@ -845,6 +849,7 @@ export async function startServer(options?: ServerRuntimeOptions): Promise<Serve
     tokenPathPolicy: (connector, pathname) => connector !== "chatgpt" || pathname === "/mcp",
     readiness: () => readiness,
     principal: parsedServerConfig.principal,
+    trustPrincipalHeader: parsedServerConfig.trustPrincipalHeader,
     maxBodyBytes: parsedServerConfig.maxBodyBytes,
     writeRateLimitMaxRequests: parsedServerConfig.writeRateLimitMaxRequests,
     writeRateLimitWindowMs: parsedServerConfig.writeRateLimitWindowMs,


### PR DESCRIPTION
Fixes #2782

## Summary

With namespaces enabled, Grok and OpenCode MCP clients could `initialize` / `tools/list` but every namespaced tool call failed with:

```
authentication required: namespaces are enabled and no principal was supplied
```

Two gaps caused this (both confirmed on current `main` through 9.69.16):

1. The adapter registry only knew hermes, replit, codex, and claude-code — no adapter matched `X-Engram-Client-Id: grok`/`opencode` or their `clientInfo.name`, so `/engram/v1/adapters` returned `resolved: null`.
2. Standalone `remnic-server` never parsed `server.trustPrincipalHeader`, so the documented `X-Engram-Principal` path silently didn't work there either.

## Changes

### `@remnic/core`

- New **`GrokAdapter`** and **`OpenCodeAdapter`**, mirroring the existing Codex/Claude Code detection style:
  - primary: MCP `clientInfo.name` (`grok*` / `opencode*`, case-insensitive contains-match for forward compat since Grok's exact client name isn't stable across surfaces)
  - fallback: `User-Agent: <name>/<version>`
  - fallback: user-configured `X-Engram-Client-Id`
- Both resolve an **adapter-owned** principal (`grok` / `opencode`) and default namespace; `mcp-session-id` or explicit session key carries continuity. Explicit `X-Engram-Namespace` still wins.
- Registered at the end of the default `AdapterRegistry`, so precedence for all existing clients is unchanged.
- Per the issue's constraint: **adapters never adopt `X-Engram-Principal` themselves** — that stays behind the HTTP server's `trustPrincipalHeader` gate (covered by a dedicated spoofing-guard test).

### `@remnic/server`

- `parseServerConfig` now parses `server.trustPrincipalHeader` using the same strict boolean parser as neighboring flags (accepts `"true"`/`"1"`/`"on"` strings from config-file/CLI sources, rejects anything else with a precise error) and passes it to `EngramAccessHttpServer`.

### Docs

- `docs/guides/standalone-server.md` no longer claims per-request principal override is OpenClaw-only; it documents `server.trustPrincipalHeader` while keeping the OpenClaw flag as the equivalent path.

## Tests

New `packages/remnic-core/src/adapters/grok-opencode.test.ts` (11 tests):

- matching via clientInfo / User-Agent / configured header for both adapters
- rejection of unrelated clients (claude-code, codex, each other, unknown)
- identity resolution: adapter-owned principal, namespace defaults + header override, `mcp-session-id` continuity
- registry order including the new entries
- direct reproductions of the issue's Grok/OpenCode header scenarios resolving a transport principal without any session key
- guard test: adapters never adopt a spoofed `X-Engram-Principal`

Plus server config tests for `trustPrincipalHeader` (default false, boolean-like strings accepted, invalid values rejected).

Validation:

- `npm run check-types` in both `packages/remnic-core` and `packages/remnic-server` → clean
- `tsx --test src/adapters/*.test.ts` → 14 pass / 0 fail
- `tsx --test src/access-http.test.ts` → 96 pass / 0 fail
- `tsx --test src/config.test.ts` (server) → 18 pass / 0 fail
- `tsx --test src/support-passport.test.ts` (server) → 10 pass / 0 fail

Changesets added for both `@remnic/core` (minor) and `@remnic/server` (minor).

🤖 *PR body generated with AI assistance.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic identification and identity resolution for Grok and OpenCode connections.
  * Added configurable trusted principal-header handling for standalone servers, disabled by default.
  * Standalone servers can now use OS-assigned ports programmatically.

* **Security**
  * Principal headers are ignored unless explicitly trusted through server configuration.

* **Documentation**
  * Updated standalone server guidance for trusted principal overrides.

* **Bug Fixes**
  * Improved validation for configured ports, accepting only values from 1–65535.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->