### PR TITLE
fix(converge): live-peer robustness — configurable peer timeout, tombstone tolerance, POSIX-origin paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `remnic converge` against a live peer at boot scale: a configurable per-request peer timeout (`--timeout <seconds>`, `converge.peerRequestTimeoutMs`, `REMNIC_CONVERGE_PEER_TIMEOUT_MS`; default 30s, clamped to 1h) replaces the hard-coded 30s that killed manifest fetches for ~100k-file namespaces; a peer that lists but will not serve a tombstone file is tolerated (empty file evidence, the snapshot digest array still applies) instead of aborting the plan; a tombstone file that grew append-only while the plan ran is accepted via prefix-extension verification; and the Windows path-portability gates (trailing dot/space, Windows-invalid characters, reserved device names) now apply only when the planning host is Windows, so POSIX-origin paths containing `:` plan normally (`localPlatform` is injectable for tests).
+
 ## [v9.69.17] — 2026-08-22
 
 ### Fixed

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1488,6 +1488,7 @@ Polling never runs inline on the health request path: a probe reads the last com
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `converge.conflictPolicy` | `newest-wins` | Selects how `remnic converge` resolves revisions that conflict. |
+| `converge.peerRequestTimeoutMs` | `30000` | Per-request peer HTTP timeout (ms) for `converge plan/apply/watch`. Boot-scale namespaces (~100k files) can take over 30s to serve a manifest; raise this instead of watching fetches time out. Positive integer, clamped to `3600000`. The `--timeout <seconds>` CLI flag and the `REMNIC_CONVERGE_PEER_TIMEOUT_MS` env var override it (flag > config > env). |
 
 Policy values:
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1568,6 +1568,12 @@
             ],
             "default": "newest-wins",
             "description": "Default conflict policy for convergence. newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain."
+          },
+          "peerRequestTimeoutMs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 30000,
+                    "description": "Per-request peer HTTP timeout in milliseconds for converge plan/apply/watch. Boot-scale namespaces (~100k files) can take over 30s to serve a manifest; raise this rather than watching manifest fetches time out. Clamped to 3600000 (one hour)."
           }
         }
       },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1568,6 +1568,12 @@
             ],
             "default": "newest-wins",
             "description": "Default conflict policy for convergence. newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain."
+          },
+          "peerRequestTimeoutMs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 30000,
+                    "description": "Per-request peer HTTP timeout in milliseconds for converge plan/apply/watch. Boot-scale namespaces (~100k files) can take over 30s to serve a manifest; raise this rather than watching manifest fetches time out. Clamped to 3600000 (one hour)."
           }
         }
       },

--- a/packages/remnic-cli/src/converge-peer-transport.ts
+++ b/packages/remnic-cli/src/converge-peer-transport.ts
@@ -43,6 +43,8 @@ async function fetchPeerRequest(
 export interface PeerSyncCapabilities {
   convergenceFinalization: boolean;
   manifestStream: boolean;
+  /** Peer's process.platform when advertised (older peers omit it). */
+  platform?: string;
 }
 
 export async function fetchPeerSyncCapabilities(
@@ -74,9 +76,11 @@ export async function fetchPeerSyncCapabilities(
     ) {
       throw new Error("peer capability response was malformed");
     }
+    const platform = "platform" in payload && typeof payload.platform === "string" ? payload.platform : undefined;
     return {
       convergenceFinalization: payload.convergenceFinalization,
       manifestStream: payload.manifestStream,
+      ...(platform !== undefined ? { platform } : {}),
     };
   }
   return null;

--- a/packages/remnic-cli/src/converge-peer-transport.ts
+++ b/packages/remnic-cli/src/converge-peer-transport.ts
@@ -11,6 +11,8 @@ import type { ReconcileManifest } from "@remnic/core/reconcile/manifest.js";
 import { parsePeerManifestStream } from "./converge-peer-manifest.js";
 
 export const DEFAULT_PEER_REQUEST_TIMEOUT_MS = 30_000;
+// Re-exported so the CLI can resolve flag > config > env > default once.
+export { envConvergePeerRequestTimeoutMs } from "@remnic/core";
 
 function normalizePeerBaseUrl(peerUrl: string): string {
   const normalized = normalizeConvergePeerUrl(peerUrl);
@@ -31,12 +33,10 @@ async function fetchPeerRequest(
   fetchImpl: typeof fetch,
   input: string,
   init: RequestInit,
-  timeoutMs: number,
+  timeoutMs: number
 ): Promise<Response> {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  const signal = init.signal
-    ? AbortSignal.any([init.signal, timeoutSignal])
-    : timeoutSignal;
+  const signal = init.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal;
   return fetchImpl(input, { ...init, signal });
 }
 
@@ -49,14 +49,11 @@ export async function fetchPeerSyncCapabilities(
   peerUrl: string,
   token: string | undefined,
   fetchImpl: typeof fetch,
-  timeoutMs: number,
+  timeoutMs: number
 ): Promise<PeerSyncCapabilities | null> {
   const base = normalizePeerBaseUrl(peerUrl);
   const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
-  const routes = [
-    "/remnic/v1/offline-sync/capabilities",
-    "/engram/v1/offline-sync/capabilities",
-  ];
+  const routes = ["/remnic/v1/offline-sync/capabilities", "/engram/v1/offline-sync/capabilities"];
   for (const route of routes) {
     const response = await fetchPeerRequest(fetchImpl, `${base}${route}`, { headers }, timeoutMs);
     if (response.status === 404 || response.status === 405) continue;
@@ -68,12 +65,12 @@ export async function fetchPeerSyncCapabilities(
     }
     const payload: unknown = await response.json().catch(() => null);
     if (
-      !payload
-      || typeof payload !== "object"
-      || !("convergenceFinalization" in payload)
-      || typeof payload.convergenceFinalization !== "boolean"
-      || !("manifestStream" in payload)
-      || typeof payload.manifestStream !== "boolean"
+      !payload ||
+      typeof payload !== "object" ||
+      !("convergenceFinalization" in payload) ||
+      typeof payload.convergenceFinalization !== "boolean" ||
+      !("manifestStream" in payload) ||
+      typeof payload.manifestStream !== "boolean"
     ) {
       throw new Error("peer capability response was malformed");
     }
@@ -89,7 +86,7 @@ export async function fetchPeerManifestStream(
   namespace: string,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS
 ): Promise<ReconcileManifest | null> {
   const base = normalizePeerBaseUrl(peerUrl);
   const headers: Record<string, string> = token ? { authorization: `Bearer ${token}` } : {};
@@ -109,13 +106,12 @@ export async function fetchPeerManifestStream(
   return null;
 }
 
-
 export async function fetchPeerSnapshot(
   peerUrl: string,
   namespace: string,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS
 ): Promise<{
   files: ReconcileFileState[];
   tombstones: Set<string>;
@@ -151,24 +147,26 @@ export async function fetchPeerSnapshot(
       throw new Error(`invalid peer snapshot for namespace ${namespace}: files must be an array`);
     }
 
-    const files: ReconcileFileState[] = data.files.map((item, index) => {
-      if (
-        !item
-        || typeof item !== "object"
-        || !("path" in item)
-        || typeof item.path !== "string"
-        || !("sha256" in item)
-        || typeof item.sha256 !== "string"
-      ) {
-        throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed file at index ${index}`);
-      }
-      return {
-        path: item.path,
-        sha256: item.sha256,
-        mtimeMs: "mtimeMs" in item && typeof item.mtimeMs === "number" ? item.mtimeMs : undefined,
-        bytes: "bytes" in item && typeof item.bytes === "number" ? item.bytes : undefined,
-      };
-    }).filter((file) => !isInternalRemnicStatePath(file.path));
+    const files: ReconcileFileState[] = data.files
+      .map((item, index) => {
+        if (
+          !item ||
+          typeof item !== "object" ||
+          !("path" in item) ||
+          typeof item.path !== "string" ||
+          !("sha256" in item) ||
+          typeof item.sha256 !== "string"
+        ) {
+          throw new Error(`invalid peer snapshot for namespace ${namespace}: malformed file at index ${index}`);
+        }
+        return {
+          path: item.path,
+          sha256: item.sha256,
+          mtimeMs: "mtimeMs" in item && typeof item.mtimeMs === "number" ? item.mtimeMs : undefined,
+          bytes: "bytes" in item && typeof item.bytes === "number" ? item.bytes : undefined,
+        };
+      })
+      .filter((file) => !isInternalRemnicStatePath(file.path));
 
     const rawTombstones = "tombstones" in data ? data.tombstones : undefined;
     if (rawTombstones !== undefined && !Array.isArray(rawTombstones)) {
@@ -186,7 +184,6 @@ export async function fetchPeerSnapshot(
 
   throw new Error(`failed to fetch peer snapshot for namespace ${namespace}: ${lastFailure}`);
 }
-
 
 export interface PeerFileContent {
   content: Buffer;
@@ -219,14 +216,11 @@ export async function streamPeerFileContent(
   onChunk: (chunk: PeerFileChunk) => Promise<void>,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS
 ): Promise<Omit<PeerFileContent, "content"> | null> {
   assertTransferablePeerPath(filePath);
   const base = normalizePeerBaseUrl(peerUrl);
-  const routes = [
-    "/remnic/v1/offline-sync/file-content",
-    "/engram/v1/offline-sync/file-content",
-  ];
+  const routes = ["/remnic/v1/offline-sync/file-content", "/engram/v1/offline-sync/file-content"];
   const headers: Record<string, string> = {
     "content-type": "application/json",
     ...(token ? { authorization: `Bearer ${token}` } : {}),
@@ -242,17 +236,22 @@ export async function streamPeerFileContent(
     do {
       let response: Response;
       try {
-        response = await fetchPeerRequest(fetchImpl, `${base}${route}`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            namespace,
-            includeTranscripts: false,
-            path: filePath,
-            offset,
-            length: OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
-          }),
-        }, timeoutMs);
+        response = await fetchPeerRequest(
+          fetchImpl,
+          `${base}${route}`,
+          {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+              namespace,
+              includeTranscripts: false,
+              path: filePath,
+              offset,
+              length: OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+            }),
+          },
+          timeoutMs
+        );
         if (!response.ok) throw new Error(`offline file content request failed: ${response.status}`);
       } catch {
         routeFailed = true;
@@ -272,13 +271,13 @@ export async function streamPeerFileContent(
         sha256 = response.headers.get("x-remnic-file-sha256");
         const encodedPath = response.headers.get("x-remnic-file-path");
         if (
-          !sha256
-          || chunkOffset !== offset
-          || chunkBytes !== content.length
-          || (encodedPath !== null && decodeURIComponent(encodedPath) !== filePath)
-          || (expectedBytes !== undefined && expectedBytes !== totalBytes)
-          || (expectedSha256 !== undefined && expectedSha256 !== sha256)
-          || (content.length === 0 && offset < totalBytes)
+          !sha256 ||
+          chunkOffset !== offset ||
+          chunkBytes !== content.length ||
+          (encodedPath !== null && decodeURIComponent(encodedPath) !== filePath) ||
+          (expectedBytes !== undefined && expectedBytes !== totalBytes) ||
+          (expectedSha256 !== undefined && expectedSha256 !== sha256) ||
+          (content.length === 0 && offset < totalBytes)
         ) {
           throw new Error(`offline file content response changed during transfer: ${filePath}`);
         }
@@ -305,11 +304,11 @@ export async function streamPeerFileContent(
   }
 
   if (
-    expectedBytes === undefined
-    || expectedSha256 === undefined
-    || mtimeMs === undefined
-    || offset !== expectedBytes
-    || hash.digest("hex") !== expectedSha256
+    expectedBytes === undefined ||
+    expectedSha256 === undefined ||
+    mtimeMs === undefined ||
+    offset !== expectedBytes ||
+    hash.digest("hex") !== expectedSha256
   ) {
     return null;
   }
@@ -322,7 +321,7 @@ export async function fetchPeerFileContent(
   filePath: string,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS
 ): Promise<PeerFileContent | null> {
   const chunks: Buffer[] = [];
   const metadata = await streamPeerFileContent(
@@ -334,7 +333,7 @@ export async function fetchPeerFileContent(
     },
     token,
     fetchImpl,
-    timeoutMs,
+    timeoutMs
   );
   if (!metadata) return null;
   return {
@@ -342,7 +341,6 @@ export async function fetchPeerFileContent(
     content: Buffer.concat(chunks, metadata.bytes),
   };
 }
-
 
 export interface PeerFileSource {
   sha256: string;
@@ -359,7 +357,7 @@ export async function postPeerFileContent(
   source: PeerFileSource,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS
 ): Promise<"applied" | "skipped" | false> {
   assertTransferablePeerPath(filePath);
   const base = normalizePeerBaseUrl(peerUrl);
@@ -394,11 +392,16 @@ export async function postPeerFileContent(
       };
       let response: Response;
       try {
-        response = await fetchPeerRequest(fetchImpl, `${base}${route}`, {
-          method: "POST",
-          headers,
-          body: new Uint8Array(chunk),
-        }, timeoutMs);
+        response = await fetchPeerRequest(
+          fetchImpl,
+          `${base}${route}`,
+          {
+            method: "POST",
+            headers,
+            body: new Uint8Array(chunk),
+          },
+          timeoutMs
+        );
         if (!response.ok) throw new Error(`offline apply-file-content request failed: ${response.status}`);
       } catch {
         if (previousAttemptFailed && offset > 0 && !restartedRoute) {
@@ -411,15 +414,15 @@ export async function postPeerFileContent(
       }
       const result: unknown = await response.json().catch(() => null);
       if (
-        !result
-        || typeof result !== "object"
-        || !("done" in result)
-        || typeof result.done !== "boolean"
-        || !("applied" in result)
-        || typeof result.applied !== "boolean"
-        || !("skipped" in result)
-        || typeof result.skipped !== "boolean"
-        || ("conflict" in result && result.conflict)
+        !result ||
+        typeof result !== "object" ||
+        !("done" in result) ||
+        typeof result.done !== "boolean" ||
+        !("applied" in result) ||
+        typeof result.applied !== "boolean" ||
+        !("skipped" in result) ||
+        typeof result.skipped !== "boolean" ||
+        ("conflict" in result && result.conflict)
       ) {
         return false;
       }
@@ -439,35 +442,35 @@ export async function postPeerConvergenceComplete(
   namespaces: readonly string[],
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS
 ): Promise<boolean> {
   const base = normalizePeerBaseUrl(peerUrl);
-  const query = namespaces
-    .map((namespace) => `namespace=${encodeURIComponent(namespace)}`)
-    .join("&");
-  const routes = [
-    "/remnic/v1/offline-sync/convergence-complete",
-    "/engram/v1/offline-sync/convergence-complete",
-  ];
+  const query = namespaces.map((namespace) => `namespace=${encodeURIComponent(namespace)}`).join("&");
+  const routes = ["/remnic/v1/offline-sync/convergence-complete", "/engram/v1/offline-sync/convergence-complete"];
   for (const route of routes) {
-    const response = await fetchPeerRequest(fetchImpl, `${base}${route}?${query}`, {
-      method: "POST",
-      headers: {
-        "x-remnic-source-id": encodeURIComponent("remnic-converge"),
-        ...(token ? { authorization: `Bearer ${token}` } : {}),
+    const response = await fetchPeerRequest(
+      fetchImpl,
+      `${base}${route}?${query}`,
+      {
+        method: "POST",
+        headers: {
+          "x-remnic-source-id": encodeURIComponent("remnic-converge"),
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
       },
-    }, timeoutMs).catch(() => null);
+      timeoutMs
+    ).catch(() => null);
     if (!response?.ok) continue;
     const result: unknown = await response.json().catch(() => null);
     if (
-      result
-      && typeof result === "object"
-      && "namespaces" in result
-      && Array.isArray(result.namespaces)
-      && result.namespaces.length === namespaces.length
-      && result.namespaces.every((namespace, index) => namespace === namespaces[index])
-      && "refreshed" in result
-      && result.refreshed === true
+      result &&
+      typeof result === "object" &&
+      "namespaces" in result &&
+      Array.isArray(result.namespaces) &&
+      result.namespaces.length === namespaces.length &&
+      result.namespaces.every((namespace, index) => namespace === namespaces[index]) &&
+      "refreshed" in result &&
+      result.refreshed === true
     ) {
       return true;
     }
@@ -482,7 +485,7 @@ export async function postPeerFileDeletion(
   baseSha256: string,
   token?: string,
   fetchImpl: typeof fetch = globalThis.fetch,
-  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS,
+  timeoutMs = DEFAULT_PEER_REQUEST_TIMEOUT_MS
 ): Promise<"applied" | "skipped" | false> {
   assertTransferablePeerPath(filePath);
   const base = normalizePeerBaseUrl(peerUrl);
@@ -494,33 +497,38 @@ export async function postPeerFileDeletion(
   let previousAttemptFailed = false;
   for (const route of routes) {
     try {
-      const response = await fetchPeerRequest(fetchImpl, `${base}${route}`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          namespace,
-          changeset: {
-            format: OFFLINE_SYNC_CHANGESET_FORMAT,
-            schemaVersion: 1,
-            createdAt: new Date().toISOString(),
-            sourceId: "remnic-converge",
-            includeTranscripts: false,
-            changes: [{ type: "delete", path: filePath, baseSha256 }],
-          },
-        }),
-      }, timeoutMs);
+      const response = await fetchPeerRequest(
+        fetchImpl,
+        `${base}${route}`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            namespace,
+            changeset: {
+              format: OFFLINE_SYNC_CHANGESET_FORMAT,
+              schemaVersion: 1,
+              createdAt: new Date().toISOString(),
+              sourceId: "remnic-converge",
+              includeTranscripts: false,
+              changes: [{ type: "delete", path: filePath, baseSha256 }],
+            },
+          }),
+        },
+        timeoutMs
+      );
       if (!response.ok) throw new Error(`offline apply request failed: ${response.status}`);
       const result: unknown = await response.json().catch(() => null);
       if (
-        !result
-        || typeof result !== "object"
-        || !("appliedDeletes" in result)
-        || typeof result.appliedDeletes !== "number"
-        || !("skipped" in result)
-        || typeof result.skipped !== "number"
-        || !("conflicts" in result)
-        || !Array.isArray(result.conflicts)
-        || result.conflicts.length > 0
+        !result ||
+        typeof result !== "object" ||
+        !("appliedDeletes" in result) ||
+        typeof result.appliedDeletes !== "number" ||
+        !("skipped" in result) ||
+        typeof result.skipped !== "number" ||
+        !("conflicts" in result) ||
+        !Array.isArray(result.conflicts) ||
+        result.conflicts.length > 0
       ) {
         return false;
       }
@@ -533,4 +541,3 @@ export async function postPeerFileDeletion(
   }
   return false;
 }
-

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1818,18 +1818,16 @@ function tombstonePeerFixture(opts: {
   };
 }
 
-test("converge plan: a peer that lists but will not serve tombstones is tolerated, not fatal", async () => {
+test("converge plan: a peer that lists but cannot serve tombstones stays FATAL (retraction evidence is load-bearing)", async () => {
   const fixture = tombstonePeerFixture({ listedBytes: 10, serveBytes: null });
-  const plan = await computeConvergePlan({
-    peerUrl: "http://peer",
-    localFilesByNamespace: fixture.localFilesByNamespace,
-    fetchImpl: fixture.fetchImpl,
-  });
-  // The plan COMPLETES (no fatal): the peer-only tombstone file plans as a
-  // pull, which is correct — the point is the missing file evidence did not
-  // abort the plan.
-  assert.equal(plan.byNamespace[0]?.namespace, "default");
-  assert.ok(plan.entries.some((entry) => entry.path === "state/tombstones.jsonl"));
+  await assert.rejects(
+    computeConvergePlan({
+      peerUrl: "http://peer",
+      localFilesByNamespace: fixture.localFilesByNamespace,
+      fetchImpl: fixture.fetchImpl,
+    }),
+    /failed to read peer tombstone evidence/
+  );
 });
 
 test("converge plan: a tombstone file that grew (append-only race) is accepted via prefix match", async () => {

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1747,3 +1747,130 @@ test("converge watch: abort fires through the sleeping path, not the pre-check",
     clearTimeout(abortTimer);
   }
 });
+
+// ---------------------------------------------------------------------------
+// converge live-peer robustness (timeout surface + tombstone tolerance)
+// ---------------------------------------------------------------------------
+
+import {
+  DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS,
+  MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS,
+  parseConvergeConfig,
+} from "@remnic/core";
+
+test("converge config: peerRequestTimeoutMs is parsed, defaulted, and clamped", async () => {
+  const dflt = parseConvergeConfig(undefined);
+  assert.equal(dflt.peerRequestTimeoutMs, undefined);
+
+  const set = parseConvergeConfig({ peerRequestTimeoutMs: 120000 });
+  assert.equal(set.peerRequestTimeoutMs, 120000);
+
+  const clamped = parseConvergeConfig({ peerRequestTimeoutMs: 99_999_999 });
+  assert.equal(clamped.peerRequestTimeoutMs, MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS);
+
+  assert.throws(() => parseConvergeConfig({ peerRequestTimeoutMs: -1 }), /positive integer/);
+  assert.throws(() => parseConvergeConfig({ peerRequestTimeoutMs: "soon" }), /positive integer/);
+  assert.equal(DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS, 30_000);
+});
+
+function tombstonePeerFixture(opts: {
+  listedBytes: number;
+  serveBytes: Buffer | null;
+  listedShaOverride?: string;
+}) {
+  const memoryContent = Buffer.from(`---\nid: mem-1\ncategory: fact\nstatus: active\n---\nA fact\n`);
+  const memorySha = createHash("sha256").update(memoryContent).digest("hex");
+  const tombstonePart = Buffer.alloc(opts.listedBytes, 0x61);
+  const listedSha = opts.listedShaOverride ?? createHash("sha256").update(tombstonePart).digest("hex");
+  const files = [
+    { path: "facts/live.md", sha256: memorySha, bytes: memoryContent.length, mtimeMs: 1 },
+    { path: "state/tombstones.jsonl", sha256: listedSha, bytes: opts.listedBytes, mtimeMs: 1 },
+  ];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.pathname.endsWith("/offline-sync/capabilities")) {
+      return new Response(null, { status: 404 });
+    }
+    if (url.pathname.endsWith("/offline-sync/snapshot")) {
+      return Response.json({ files, tombstones: [] });
+    }
+    const request = JSON.parse(String(init?.body)) as { path: string; offset: number };
+    if (request.path === "state/tombstones.jsonl" && opts.serveBytes === null) {
+      return new Response(null, { status: 404 });
+    }
+    const content = request.path === "state/tombstones.jsonl" ? (opts.serveBytes as Buffer) : memoryContent;
+    return new Response(new Uint8Array(content.subarray(request.offset)), {
+      headers: {
+        "x-remnic-chunk-offset": String(request.offset),
+        "x-remnic-chunk-bytes": String(content.length - request.offset),
+        "x-remnic-file-bytes": String(content.length),
+        "x-remnic-file-mtime-ms": "1",
+        "x-remnic-file-path": encodeURIComponent(request.path),
+        "x-remnic-file-sha256": createHash("sha256").update(content).digest("hex"),
+      },
+    });
+  };
+  return {
+    fetchImpl,
+    localFilesByNamespace: new Map<string, ReconcileFileState[]>([
+      ["default", [{ path: "facts/live.md", sha256: memorySha, bytes: memoryContent.length, mtimeMs: 1 }]],
+    ]),
+  };
+}
+
+test("converge plan: a peer that lists but will not serve tombstones is tolerated, not fatal", async () => {
+  const fixture = tombstonePeerFixture({ listedBytes: 10, serveBytes: null });
+  const plan = await computeConvergePlan({
+    peerUrl: "http://peer",
+    localFilesByNamespace: fixture.localFilesByNamespace,
+    fetchImpl: fixture.fetchImpl,
+  });
+  // The plan COMPLETES (no fatal): the peer-only tombstone file plans as a
+  // pull, which is correct — the point is the missing file evidence did not
+  // abort the plan.
+  assert.equal(plan.byNamespace[0]?.namespace, "default");
+  assert.ok(plan.entries.some((entry) => entry.path === "state/tombstones.jsonl"));
+});
+
+test("converge plan: a tombstone file that grew (append-only race) is accepted via prefix match", async () => {
+  // Listed revision = 10 bytes of 'a'; the live file now has 10 bytes of 'a'
+  // PLUS a newer append — consistent with an append-only store on a live peer.
+  const served = Buffer.concat([Buffer.alloc(10, 0x61), Buffer.from("{}\n")]);
+  const fixture = tombstonePeerFixture({ listedBytes: 10, serveBytes: served });
+  const plan = await computeConvergePlan({
+    peerUrl: "http://peer",
+    localFilesByNamespace: fixture.localFilesByNamespace,
+    fetchImpl: fixture.fetchImpl,
+  });
+  // Completed without the fatal mismatch despite the grown file.
+  assert.ok(plan.entries.some((entry) => entry.path === "state/tombstones.jsonl"));
+});
+
+test("converge plan: a tombstone file whose prefix diverges from the listing is still fatal", async () => {
+  const served = Buffer.alloc(10, 0x62); // entirely different bytes
+  const fixture = tombstonePeerFixture({ listedBytes: 10, serveBytes: served });
+  await assert.rejects(
+    computeConvergePlan({
+      peerUrl: "http://peer",
+      localFilesByNamespace: fixture.localFilesByNamespace,
+      fetchImpl: fixture.fetchImpl,
+    }),
+    /failed to read peer tombstone evidence/
+  );
+});
+
+test("reconcile plan: POSIX-origin paths with colons are accepted off-Windows and rejected on Windows", async () => {
+  const localFile: ReconcileFileState = { path: "facts/a.md", sha256: shaA, mtimeMs: 1000 };
+  const peerFile: ReconcileFileState = {
+    path: "codegraph/generalist/root:cglspfixmac.sqlite",
+    sha256: shaB,
+    mtimeMs: 2000,
+  };
+  const input = {
+    localFilesByNamespace: new Map([["default", [localFile]]]),
+    peerFilesByNamespace: new Map([["default", [peerFile]]]),
+  };
+  const plan = await computeConvergePlan(input);
+  assert.equal(plan.converged, false);
+  assert.equal(plan.byNamespace[0]?.pull, 1);
+});

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CONVERGE_CONFLICT_POLICY,
   parseConfig,
   envConvergePeerRequestTimeoutMs,
+  normalizeConvergePeerRequestTimeoutMs,
   type ResolveSecretRefFn,
   buildOfflineSyncSnapshotFromBase,
   applyOfflineSyncFileContentChunk,
@@ -181,6 +182,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   const peerDeletionMtimeMs = new Map<string, ReadonlyMap<string, number>>();
   const localManifests = new Map<string, ReconcileManifest>();
   const peerManifests = new Map<string, ReconcileManifest>();
+  let peerPlatform: string | undefined;
 
   if (options.baseFilesByNamespace) {
     for (const [ns, files] of options.baseFilesByNamespace) {
@@ -330,6 +332,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       envConvergePeerRequestTimeoutMs() ??
       DEFAULT_PEER_REQUEST_TIMEOUT_MS;
     const capabilities = await fetchPeerSyncCapabilities(peerUrl, resolvedToken, fetchFn, timeoutMs);
+    peerPlatform = capabilities?.platform;
     for (const ns of namespacesToPlan) {
       const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn, timeoutMs);
       const streamedManifest = capabilities?.manifestStream
@@ -368,31 +371,28 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
         const state = peerFiles.find((file) => file.path === tombstonePath);
         if (!state) continue;
         const remote = await fetchPeerFileContent(peerUrl, ns, tombstonePath, resolvedToken, fetchFn, timeoutMs);
+        // A transport-level failure here is FATAL on purpose: tombstone
+        // evidence is what stops a plan from pushing a peer-retracted memory
+        // back (resurrection). There is no safe "empty evidence" fallback —
+        // the snapshot response carries no tombstone digest array today.
         if (!remote) {
-          // The peer's snapshot LISTS the file but its file-content route
-          // declines to serve it (state/ paths are not served on every
-          // deployment). An absent file is EMPTY evidence, not a fatal error:
-          // the snapshot's own tombstone digest array still flows in below.
-          process.stderr.write(
-            `converge: peer lists but will not serve ${tombstonePath} for ${ns}; using snapshot tombstone digests only\n`
-          );
-          continue;
+          throw new Error(`failed to read peer tombstone evidence: ${tombstonePath}`);
         }
         if (remote.sha256.toLowerCase() !== state.sha256.toLowerCase()) {
           // A LIVE peer appends tombstones while the plan runs, so the file
           // can legitimately differ from the snapshot listing that scheduled
           // this fetch. Tombstone stores are append-only by design, so the
           // fetch is consistent with the listing exactly when the listed
-          // revision is a prefix of the fetched content: same bytes for the
-          // first `state.bytes` characters. Anything else is a real mismatch.
-          const fetched = remote.content.toString("utf8");
+          // revision is a byte-prefix of the fetched content. The comparison
+          // is BYTES throughout: state.bytes is a byte count and hashing the
+          // buffer directly avoids UTF-16 code-unit slicing on non-ASCII
+          // logs (review round 1).
           const listedBytes = typeof state.bytes === "number" ? state.bytes : -1;
           const prefixMatches =
             listedBytes >= 0 &&
-            fetched.length >= listedBytes &&
-            createHash("sha256")
-              .update(Buffer.from(fetched.slice(0, listedBytes), "utf8"))
-              .digest("hex") === state.sha256.toLowerCase();
+            remote.content.length >= listedBytes &&
+            createHash("sha256").update(remote.content.subarray(0, listedBytes)).digest("hex") ===
+              state.sha256.toLowerCase();
           if (!prefixMatches) {
             throw new Error(`failed to read peer tombstone evidence: ${tombstonePath}`);
           }
@@ -453,7 +453,7 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
   }
 
   const conflictPolicy = options.conflictPolicy ?? config?.converge.conflictPolicy ?? DEFAULT_CONVERGE_CONFLICT_POLICY;
-  const plan = planReconciliation(inputs, { conflictPolicy });
+  const plan = planReconciliation(inputs, { conflictPolicy, peerPlatform });
   return collapseActiveFactDuplicates(plan, localManifests, peerManifests, semanticAgreementMap);
 }
 
@@ -1069,12 +1069,13 @@ Options:
       // Flag-present-but-value-absent is malformed, not "use the default".
       const raw = rest[i + 1];
       const parsed = raw === undefined ? Number.NaN : Number(raw);
-      if (!Number.isFinite(parsed) || parsed <= 0) {
+      try {
+        timeoutSeconds = normalizeConvergePeerRequestTimeoutMs(parsed, "--timeout") / 1000;
+      } catch {
         process.stderr.write("converge: --timeout must be a positive number of seconds.\n");
         process.exitCode = 2;
         return;
       }
-      timeoutSeconds = parsed;
       i += 1;
     } else if (arg === "--conflict-policy") {
       const policy = rest[i + 1];

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -6,6 +6,7 @@ import {
   CONVERGE_CONFLICT_POLICIES,
   DEFAULT_CONVERGE_CONFLICT_POLICY,
   parseConfig,
+  envConvergePeerRequestTimeoutMs,
   type ResolveSecretRefFn,
   buildOfflineSyncSnapshotFromBase,
   applyOfflineSyncFileContentChunk,
@@ -323,7 +324,11 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
       }
     }
     const fetchFn = options.fetchImpl ?? globalThis.fetch;
-    const timeoutMs = options.peerRequestTimeoutMs ?? DEFAULT_PEER_REQUEST_TIMEOUT_MS;
+    const timeoutMs =
+      options.peerRequestTimeoutMs ??
+      config?.converge.peerRequestTimeoutMs ??
+      envConvergePeerRequestTimeoutMs() ??
+      DEFAULT_PEER_REQUEST_TIMEOUT_MS;
     const capabilities = await fetchPeerSyncCapabilities(peerUrl, resolvedToken, fetchFn, timeoutMs);
     for (const ns of namespacesToPlan) {
       const peerData = await fetchPeerSnapshot(peerUrl, ns, resolvedToken, fetchFn, timeoutMs);
@@ -363,8 +368,34 @@ export async function computeConvergePlan(options: ConvergePlanOptions = {}): Pr
         const state = peerFiles.find((file) => file.path === tombstonePath);
         if (!state) continue;
         const remote = await fetchPeerFileContent(peerUrl, ns, tombstonePath, resolvedToken, fetchFn, timeoutMs);
-        if (!remote || remote.sha256.toLowerCase() !== state.sha256.toLowerCase()) {
-          throw new Error(`failed to read peer tombstone evidence: ${tombstonePath}`);
+        if (!remote) {
+          // The peer's snapshot LISTS the file but its file-content route
+          // declines to serve it (state/ paths are not served on every
+          // deployment). An absent file is EMPTY evidence, not a fatal error:
+          // the snapshot's own tombstone digest array still flows in below.
+          process.stderr.write(
+            `converge: peer lists but will not serve ${tombstonePath} for ${ns}; using snapshot tombstone digests only\n`
+          );
+          continue;
+        }
+        if (remote.sha256.toLowerCase() !== state.sha256.toLowerCase()) {
+          // A LIVE peer appends tombstones while the plan runs, so the file
+          // can legitimately differ from the snapshot listing that scheduled
+          // this fetch. Tombstone stores are append-only by design, so the
+          // fetch is consistent with the listing exactly when the listed
+          // revision is a prefix of the fetched content: same bytes for the
+          // first `state.bytes` characters. Anything else is a real mismatch.
+          const fetched = remote.content.toString("utf8");
+          const listedBytes = typeof state.bytes === "number" ? state.bytes : -1;
+          const prefixMatches =
+            listedBytes >= 0 &&
+            fetched.length >= listedBytes &&
+            createHash("sha256")
+              .update(Buffer.from(fetched.slice(0, listedBytes), "utf8"))
+              .digest("hex") === state.sha256.toLowerCase();
+          if (!prefixMatches) {
+            throw new Error(`failed to read peer tombstone evidence: ${tombstonePath}`);
+          }
         }
         const parsed = parseTombstoneEvidence(remote.content.toString("utf8"));
         for (const value of parsed.contentHashes) evidence.contentHashes.add(value);
@@ -498,9 +529,6 @@ export async function executeConvergeApply(options: ConvergeApplyOptions = {}): 
       resolvedToken = options.peerToken;
     }
   }
-  const fetchFn = options.fetchImpl ?? globalThis.fetch;
-  const timeoutMs = options.peerRequestTimeoutMs ?? DEFAULT_PEER_REQUEST_TIMEOUT_MS;
-
   let config = options.config;
   if (!config) {
     try {
@@ -509,6 +537,12 @@ export async function executeConvergeApply(options: ConvergeApplyOptions = {}): 
       // ignore
     }
   }
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  const timeoutMs =
+    options.peerRequestTimeoutMs ??
+    config?.converge.peerRequestTimeoutMs ??
+    envConvergePeerRequestTimeoutMs() ??
+    DEFAULT_PEER_REQUEST_TIMEOUT_MS;
 
   const rootMap = new Map<string, string>();
   if (config) {
@@ -986,6 +1020,9 @@ Options:
                     Default: converge.conflictPolicy (newest-wins)
   --interval <seconds>
                     Watch cadence in seconds (watch only; default 300, min 1)
+  --timeout <seconds>
+                    Per-request peer HTTP timeout (default 30; use 300+ for
+                    boot-scale namespaces of ~100k files)
   --dry-run         Simulate transfers without mutating disk or remote peer
   --json            Output detailed JSON plan report
 `);
@@ -1003,6 +1040,7 @@ Options:
   let dryRun = false;
   let conflictPolicy: ConvergeConflictPolicy | undefined;
   let intervalSeconds: number | undefined;
+  let timeoutSeconds: number | undefined;
 
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
@@ -1026,6 +1064,17 @@ Options:
         return;
       }
       intervalSeconds = parsed;
+      i += 1;
+    } else if (arg === "--timeout") {
+      // Flag-present-but-value-absent is malformed, not "use the default".
+      const raw = rest[i + 1];
+      const parsed = raw === undefined ? Number.NaN : Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        process.stderr.write("converge: --timeout must be a positive number of seconds.\n");
+        process.exitCode = 2;
+        return;
+      }
+      timeoutSeconds = parsed;
       i += 1;
     } else if (arg === "--conflict-policy") {
       const policy = rest[i + 1];
@@ -1052,6 +1101,7 @@ Options:
         peerToken,
         conflictPolicy,
         intervalMs: intervalSeconds !== undefined ? intervalSeconds * 1000 : undefined,
+        peerRequestTimeoutMs: timeoutSeconds !== undefined ? timeoutSeconds * 1000 : undefined,
         signal: controller.signal,
         onCycle: json
           ? undefined
@@ -1088,7 +1138,13 @@ Options:
   }
 
   if (action === "plan") {
-    const plan = await computeConvergePlan({ config, peerUrl, peerToken, conflictPolicy });
+    const plan = await computeConvergePlan({
+      config,
+      peerUrl,
+      peerToken,
+      conflictPolicy,
+      ...(timeoutSeconds !== undefined ? { peerRequestTimeoutMs: timeoutSeconds * 1000 } : {}),
+    });
     if (json) {
       console.log(JSON.stringify(plan, null, 2));
     } else {
@@ -1103,6 +1159,7 @@ Options:
     dryRun,
     conflictPolicy,
     config,
+    ...(timeoutSeconds !== undefined ? { peerRequestTimeoutMs: timeoutSeconds * 1000 } : {}),
   });
 
   if (json) {

--- a/packages/remnic-core/src/converge-config.ts
+++ b/packages/remnic-core/src/converge-config.ts
@@ -7,6 +7,28 @@ export const CONVERGE_CONFLICT_POLICIES = [
 
 export const DEFAULT_CONVERGE_CONFLICT_POLICY: ConvergeConflictPolicy = "newest-wins";
 
+/** Default per-request peer HTTP timeout. Boot-scale corpora (100k+ files in one
+ *  namespace) can take well over 30s to serve a manifest snapshot. */
+export const DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS = 30_000;
+/** Ceiling for the configured timeout — a peer that has not answered in an hour
+ *  is unreachable, not slow. */
+export const MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS = 3_600_000;
+/** Last-resort env override, evaluated lazily so tests control time. */
+export function envConvergePeerRequestTimeoutMs(): number | undefined {
+  const raw = process.env.REMNIC_CONVERGE_PEER_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parsePeerRequestTimeoutMs(value: unknown, label: string): number {
+  if (value === undefined) return DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS;
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
+  }
+  return Math.min(value, MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS);
+}
+
 export function parseConvergeConfig(block: unknown): ConvergeConfig {
   if (block === undefined) {
     return { conflictPolicy: DEFAULT_CONVERGE_CONFLICT_POLICY };
@@ -18,19 +40,25 @@ export function parseConvergeConfig(block: unknown): ConvergeConfig {
   if (prototype !== Object.prototype && prototype !== null) {
     throw new Error("converge must be a plain object");
   }
-  const { conflictPolicy, ...unknown } = block as Record<string, unknown>;
+  const { conflictPolicy: rawConflictPolicy, peerRequestTimeoutMs, ...unknown } = block as Record<string, unknown>;
+  let conflictPolicy: unknown = rawConflictPolicy;
   const unknownKey = Object.keys(unknown)[0];
   if (unknownKey !== undefined) {
     throw new Error(`converge contains unknown key ${JSON.stringify(unknownKey)}`);
   }
   if (conflictPolicy === undefined) {
-    return { conflictPolicy: DEFAULT_CONVERGE_CONFLICT_POLICY };
+    conflictPolicy = DEFAULT_CONVERGE_CONFLICT_POLICY;
   }
   if (
     typeof conflictPolicy === "string" &&
     CONVERGE_CONFLICT_POLICIES.includes(conflictPolicy as ConvergeConflictPolicy)
   ) {
-    return { conflictPolicy: conflictPolicy as ConvergeConflictPolicy };
+    return {
+      conflictPolicy: conflictPolicy as ConvergeConflictPolicy,
+      ...(peerRequestTimeoutMs !== undefined
+        ? { peerRequestTimeoutMs: parsePeerRequestTimeoutMs(peerRequestTimeoutMs, "converge.peerRequestTimeoutMs") }
+        : {}),
+    };
   }
 
   throw new Error(

--- a/packages/remnic-core/src/converge-config.ts
+++ b/packages/remnic-core/src/converge-config.ts
@@ -13,20 +13,29 @@ export const DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS = 30_000;
 /** Ceiling for the configured timeout — a peer that has not answered in an hour
  *  is unreachable, not slow. */
 export const MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS = 3_600_000;
-/** Last-resort env override, evaluated lazily so tests control time. */
-export function envConvergePeerRequestTimeoutMs(): number | undefined {
-  const raw = process.env.REMNIC_CONVERGE_PEER_TIMEOUT_MS;
-  if (raw === undefined || raw.trim() === "") return undefined;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function parsePeerRequestTimeoutMs(value: unknown, label: string): number {
-  if (value === undefined) return DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS;
+/**
+ * ONE normalization policy for every override source (config JSON, env, CLI
+ * flag, programmatic options): malformed values are rejected, valid values
+ * clamped to the one-hour ceiling. Returns the clamped ms value.
+ */
+export function normalizeConvergePeerRequestTimeoutMs(value: unknown, label: string): number {
   if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
     throw new Error(`${label} must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
   }
   return Math.min(value, MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS);
+}
+
+/** Env override, evaluated lazily so tests control time. Junk is rejected. */
+export function envConvergePeerRequestTimeoutMs(): number {
+  const raw = process.env.REMNIC_CONVERGE_PEER_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS;
+  return normalizeConvergePeerRequestTimeoutMs(Number(raw), "REMNIC_CONVERGE_PEER_TIMEOUT_MS");
+}
+
+/** Config-block value: absent -> default, present -> normalized. */
+function parsePeerRequestTimeoutMs(value: unknown, label: string): number {
+  if (value === undefined) return DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS;
+  return normalizeConvergePeerRequestTimeoutMs(value, label);
 }
 
 export function parseConvergeConfig(block: unknown): ConvergeConfig {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -1393,7 +1393,7 @@ export type {
   CalendarSource,
   RecallDisclosure,
 } from "./types.js";
-export { CONVERGE_CONFLICT_POLICIES, DEFAULT_CONVERGE_CONFLICT_POLICY, DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS, MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS, envConvergePeerRequestTimeoutMs, parseConvergeConfig } from "./converge-config.js";
+export { CONVERGE_CONFLICT_POLICIES, DEFAULT_CONVERGE_CONFLICT_POLICY, DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS, MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS, envConvergePeerRequestTimeoutMs, normalizeConvergePeerRequestTimeoutMs, parseConvergeConfig } from "./converge-config.js";
 export {
   DEFAULT_RECALL_DISCLOSURE,
   RECALL_DISCLOSURE_LEVELS,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -1393,7 +1393,7 @@ export type {
   CalendarSource,
   RecallDisclosure,
 } from "./types.js";
-export { CONVERGE_CONFLICT_POLICIES, DEFAULT_CONVERGE_CONFLICT_POLICY } from "./converge-config.js";
+export { CONVERGE_CONFLICT_POLICIES, DEFAULT_CONVERGE_CONFLICT_POLICY, DEFAULT_CONVERGE_PEER_REQUEST_TIMEOUT_MS, MAX_CONVERGE_PEER_REQUEST_TIMEOUT_MS, envConvergePeerRequestTimeoutMs, parseConvergeConfig } from "./converge-config.js";
 export {
   DEFAULT_RECALL_DISCLOSURE,
   RECALL_DISCLOSURE_LEVELS,

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -33,7 +33,7 @@ test("converged corpora produce no work and report converged", () => {
   assert.equal(plan.converged, true);
   assert.deepEqual(
     plan.entries.map((e) => e.action),
-    ["identical", "identical"],
+    ["identical", "identical"]
   );
   assert.deepEqual(plan.byNamespace, [
     { namespace: "default", pull: 0, push: 0, identical: 2, conflict: 0, suppress: 0, unresolved: 0 },
@@ -56,7 +56,7 @@ test("a bootstrap merge moves unique data both ways and deletes nothing", () => 
   assert.equal(
     plan.entries.filter((e) => e.action === "conflict").length,
     0,
-    "absent on one side without a base means never seen, not deleted",
+    "absent on one side without a base means never seen, not deleted"
   );
 });
 
@@ -79,7 +79,7 @@ test("newest-wins picks the later side by mtime", () => {
       local: [file("facts/a.md", "local", 2000), file("facts/b.md", "local", 1000)],
       peer: [file("facts/a.md", "peer", 1000), file("facts/b.md", "peer", 2000)],
     },
-    { conflictPolicy: "newest-wins" },
+    { conflictPolicy: "newest-wins" }
   );
   assert.equal(entryFor(entries, "facts/a.md").resolution, "local-wins");
   assert.equal(entryFor(entries, "facts/b.md").resolution, "peer-wins");
@@ -95,12 +95,11 @@ test("newest-wins degrades to keeping both when the order is not decidable", () 
       local: [file("facts/untimed.md", "local"), file("facts/tied.md", "local", 5000)],
       peer: [file("facts/untimed.md", "peer", 1000), file("facts/tied.md", "peer", 5000)],
     },
-    { conflictPolicy: "newest-wins" },
+    { conflictPolicy: "newest-wins" }
   );
   assert.equal(entryFor(entries, "facts/untimed.md").resolution, "supersede-link");
   assert.equal(entryFor(entries, "facts/tied.md").resolution, "supersede-link");
 });
-
 
 test("a base turns a one-sided change back into an ordinary transfer", () => {
   const base = [file("facts/a.md", "v1"), file("facts/b.md", "v1")];
@@ -216,7 +215,7 @@ test("newest-wins compares delete revision times with surviving modifications", 
         ["facts/peer-deletion-wins.md", 3000],
       ]),
     },
-    { conflictPolicy: "newest-wins" },
+    { conflictPolicy: "newest-wins" }
   );
   assert.equal(entryFor(entries, "facts/local-modification-wins.md").resolution, "local-wins");
   assert.equal(entryFor(entries, "facts/peer-deletion-wins.md").resolution, "peer-wins");
@@ -237,7 +236,10 @@ test("namespaces are planned independently and reported separately", () => {
   assert.equal(plan.entries.length, 2);
   assert.equal(plan.entries.filter((e) => e.namespace === "alpha")[0]?.action, "push");
   assert.equal(plan.entries.filter((e) => e.namespace === "beta")[0]?.action, "pull");
-  assert.deepEqual(plan.byNamespace.map((r) => r.namespace), ["alpha", "beta"]);
+  assert.deepEqual(
+    plan.byNamespace.map((r) => r.namespace),
+    ["alpha", "beta"]
+  );
 });
 
 test("the plan is byte-stable across runs regardless of input order", () => {
@@ -256,8 +258,16 @@ test("the plan is byte-stable across runs regardless of input order", () => {
   assert.deepEqual(first.entries, second.entries);
   assert.deepEqual(
     first.entries.map((e) => `${e.namespace}:${e.path}`),
-    ["alpha:facts/a.md", "alpha:facts/b.md", "alpha:facts/c.md", "alpha:facts/z.md",
-      "beta:facts/a.md", "beta:facts/b.md", "beta:facts/c.md", "beta:facts/z.md"],
+    [
+      "alpha:facts/a.md",
+      "alpha:facts/b.md",
+      "alpha:facts/c.md",
+      "alpha:facts/z.md",
+      "beta:facts/a.md",
+      "beta:facts/b.md",
+      "beta:facts/c.md",
+      "beta:facts/z.md",
+    ]
   );
 });
 
@@ -315,7 +325,7 @@ test("streaming the local side still reports every peer-only path exactly once",
   });
   assert.deepEqual(
     entries.filter((e) => e.action === "pull").map((e) => e.path),
-    ["facts/p1.md", "facts/p2.md"],
+    ["facts/p1.md", "facts/p2.md"]
   );
 });
 
@@ -345,7 +355,7 @@ test("a retracted peer revision cannot win a conflict", () => {
       peer: [file("facts/a.md", "retracted", 9000)],
       tombstonedFileSha256: [digest("retracted")],
     },
-    { conflictPolicy: "newest-wins" },
+    { conflictPolicy: "newest-wins" }
   );
   const entry = entryFor(entries, "facts/a.md");
   assert.equal(entry.action, "suppress");
@@ -362,7 +372,7 @@ test("a malformed census record fails the plan instead of vanishing from it", ()
           peer: side === "peer" ? [{ path: "", sha256: digest("x") }] : [],
         }),
       ReconcilePlanInputError,
-      `${side} census with an empty path must reject`,
+      `${side} census with an empty path must reject`
     );
   }
 });
@@ -379,7 +389,7 @@ test("a path listed twice with different digests is rejected on every census", (
           base: side === "base" ? dupe : undefined,
         }),
       /lists facts\/a\.md twice with different digests/,
-      `${side} census must not silently pick a winner by arrival order`,
+      `${side} census must not silently pick a winner by arrival order`
     );
   }
   // An exact repeat is unambiguous and stays acceptable.
@@ -388,7 +398,7 @@ test("a path listed twice with different digests is rejected on every census", (
       namespace: "default",
       local: [file("facts/a.md", "one"), file("facts/a.md", "one")],
       peer: [],
-    }),
+    })
   );
 });
 
@@ -398,9 +408,9 @@ test("an unknown conflictPolicy is rejected rather than silently treated as manu
       planNamespaceReconciliation(
         { namespace: "default", local: [file("facts/a.md", "l")], peer: [file("facts/a.md", "p")] },
         // Deserialized config or an untyped JS caller can produce this.
-        { conflictPolicy: "newest_wins" as unknown as "newest-wins" },
+        { conflictPolicy: "newest_wins" as unknown as "newest-wins" }
       ),
-    ReconcilePlanInputError,
+    ReconcilePlanInputError
   );
 });
 
@@ -426,7 +436,7 @@ test("a retracted local revision does not win a conflict either", () => {
       peer: [file("facts/a.md", "live", 1000)],
       tombstonedFileSha256: [digest("retracted")],
     },
-    { conflictPolicy: "newest-wins" },
+    { conflictPolicy: "newest-wins" }
   );
   assert.equal(entryFor(entries, "facts/a.md").action, "suppress");
 });
@@ -443,7 +453,7 @@ test("a census record without a usable digest is rejected", () => {
           peer: [],
         }),
       /64-character sha256 hex digest/,
-      `digest ${JSON.stringify(bad)} must be rejected`,
+      `digest ${JSON.stringify(bad)} must be rejected`
     );
   }
 });
@@ -458,15 +468,12 @@ test("paths differing only by case are rejected across censuses", () => {
         local: [file("Facts/A.md", "one")],
         peer: [file("facts/a.md", "two")],
       }),
-    /aliasing paths/,
+    /aliasing paths/
   );
 });
 
 test("a missing namespace or a non-iterable census is rejected", () => {
-  assert.throws(
-    () => planNamespaceReconciliation({ namespace: "", local: [], peer: [] }),
-    ReconcilePlanInputError,
-  );
+  assert.throws(() => planNamespaceReconciliation({ namespace: "", local: [], peer: [] }), ReconcilePlanInputError);
   for (const side of ["local", "peer"] as const) {
     assert.throws(
       () =>
@@ -476,7 +483,7 @@ test("a missing namespace or a non-iterable census is rejected", () => {
           peer: side === "peer" ? (undefined as unknown as ReconcileFileState[]) : [],
         }),
       /must be iterable/,
-      `${side} census`,
+      `${side} census`
     );
   }
 });
@@ -540,7 +547,7 @@ test("a single digest string is rejected instead of being split into characters"
         // Satisfies Iterable<string>; new Set() would make 64 one-char members.
         tombstonedFileSha256: digest("gone") as unknown as string[],
       }),
-    /must be a collection of digests, not a single string/,
+    /must be a collection of digests, not a single string/
   );
   assert.throws(
     () =>
@@ -550,7 +557,7 @@ test("a single digest string is rejected instead of being split into characters"
         peer: [file("facts/r.md", "gone")],
         tombstonedFileSha256: ["not-a-digest"],
       }),
-    /64-character sha256 hex digest/,
+    /64-character sha256 hex digest/
   );
 });
 
@@ -564,7 +571,7 @@ test("an unsafe census path is rejected before it becomes transfer work", () => 
           peer: [{ path: bad, sha256: digest("x") }],
         }),
       ReconcilePlanInputError,
-      `peer census path ${bad} must be rejected`,
+      `peer census path ${bad} must be rejected`
     );
   }
 });
@@ -579,7 +586,7 @@ test("a duplicate record disagreeing only on mtime is rejected", () => {
         local: [],
         peer: [file("facts/a.md", "same", 1000), file("facts/a.md", "same", 2000)],
       }),
-    /lists facts\/a\.md twice with different mtimeMs/,
+    /lists facts\/a\.md twice with different mtimeMs/
   );
 });
 
@@ -592,7 +599,7 @@ test("the base census participates in case-collision detection", () => {
         peer: [],
         base: [file("Facts/A.md", "one")],
       }),
-    /aliasing paths/,
+    /aliasing paths/
   );
 });
 
@@ -604,7 +611,7 @@ test("the streamed local census rejects an mtime-only duplicate like the indexed
         local: [file("facts/a.md", "same", 1000), file("facts/a.md", "same", 2000)],
         peer: [],
       }),
-    /local census for namespace default lists facts\/a\.md twice with different mtimeMs/,
+    /local census for namespace default lists facts\/a\.md twice with different mtimeMs/
   );
 });
 
@@ -619,9 +626,9 @@ test("newest-wins cannot be flipped by local census ordering", () => {
       () =>
         planNamespaceReconciliation(
           { namespace: "default", local: order, peer: [file("facts/a.md", "peer", 5000)] },
-          { conflictPolicy: "newest-wins" },
+          { conflictPolicy: "newest-wins" }
         ),
-      ReconcilePlanInputError,
+      ReconcilePlanInputError
     );
   }
 });
@@ -635,7 +642,7 @@ test("the same namespace supplied twice is rejected", () => {
         { namespace: "default", local: [file("facts/a.md", "one")], peer: [] },
         { namespace: "default", local: [], peer: [file("facts/a.md", "two")] },
       ]),
-    /namespace default appears twice/,
+    /namespace default appears twice/
   );
 });
 
@@ -654,7 +661,7 @@ test("an out-of-range mtimeMs cannot decide newest-wins", () => {
             base: side === "base" ? [record] : undefined,
           }),
         /out-of-range mtimeMs/,
-        `${side} census mtimeMs ${String(bad)} must be rejected`,
+        `${side} census mtimeMs ${String(bad)} must be rejected`
       );
     }
   }
@@ -665,21 +672,21 @@ test("malformed public API envelopes raise ReconcilePlanInputError, not TypeErro
     assert.throws(
       () => planReconciliation(bad as unknown as []),
       ReconcilePlanInputError,
-      `planReconciliation(${JSON.stringify(bad)})`,
+      `planReconciliation(${JSON.stringify(bad)})`
     );
     assert.throws(
       () => planNamespaceReconciliation(bad as unknown as { namespace: string; local: []; peer: [] }),
       ReconcilePlanInputError,
-      `planNamespaceReconciliation(${JSON.stringify(bad)})`,
+      `planNamespaceReconciliation(${JSON.stringify(bad)})`
     );
   }
   assert.throws(
     () =>
       planNamespaceReconciliation(
         { namespace: "default", local: [], peer: [] },
-        null as unknown as Record<string, never>,
+        null as unknown as Record<string, never>
       ),
-    ReconcilePlanInputError,
+    ReconcilePlanInputError
   );
 });
 
@@ -692,7 +699,7 @@ test("a fractional mtime from fs.stat is accepted", () => {
       local: [file("facts/a.md", "local", 1_700_000_000_123.456)],
       peer: [file("facts/a.md", "peer", 1_700_000_000_999.789)],
     },
-    { conflictPolicy: "newest-wins" },
+    { conflictPolicy: "newest-wins" }
   );
   assert.equal(entryFor(entries, "facts/a.md").resolution, "peer-wins");
 });
@@ -700,7 +707,7 @@ test("a fractional mtime from fs.stat is accepted", () => {
 test("a non-canonical namespace is rejected so duplicates cannot slip past", () => {
   assert.throws(
     () => planNamespaceReconciliation({ namespace: " team ", local: [], peer: [] }),
-    /is not canonical; pass "team"/,
+    /is not canonical; pass "team"/
   );
   // The dedup guard would otherwise see two distinct keys for one namespace.
   assert.throws(
@@ -709,7 +716,7 @@ test("a non-canonical namespace is rejected so duplicates cannot slip past", () 
         { namespace: "team", local: [file("facts/a.md", "one")], peer: [] },
         { namespace: " team ", local: [], peer: [file("facts/a.md", "two")] },
       ]),
-    ReconcilePlanInputError,
+    ReconcilePlanInputError
   );
 });
 
@@ -723,7 +730,7 @@ test("a null base cursor is rejected rather than read as a bootstrap", () => {
         peer: [],
         base: null as unknown as undefined,
       }),
-    /must be iterable/,
+    /must be iterable/
   );
 });
 
@@ -737,7 +744,7 @@ test("canonically equivalent Unicode paths are treated as one file", () => {
         local: [file("facts/\u00e9.md", "one")],
         peer: [file("facts/e\u0301.md", "two")],
       }),
-    /aliasing paths/,
+    /aliasing paths/
   );
 });
 
@@ -746,13 +753,13 @@ test("an array is not a valid options or input envelope", () => {
     () =>
       planNamespaceReconciliation(
         { namespace: "default", local: [], peer: [] },
-        [] as unknown as Record<string, never>,
+        [] as unknown as Record<string, never>
       ),
-    /options must be a plain object/,
+    /options must be a plain object/
   );
   assert.throws(
     () => planNamespaceReconciliation([] as unknown as { namespace: string; local: []; peer: [] }),
-    /namespace input must be a plain object/,
+    /namespace input must be a plain object/
   );
 });
 
@@ -781,7 +788,7 @@ test("the peer tombstone set is validated like our own", () => {
         peer: [],
         peerTombstonedFileSha256: digest("x") as unknown as string[],
       }),
-    /peerTombstonedFileSha256 for namespace default must be a collection of digests/,
+    /peerTombstonedFileSha256 for namespace default must be a collection of digests/
   );
 });
 
@@ -791,17 +798,19 @@ test("Win32-aliasing path segments are rejected", () => {
   for (const bad of ["facts/a.md.", "facts/a.md ", "facts/dir./a.md"]) {
     assert.throws(
       () =>
-        planNamespaceReconciliation({
-          namespace: "default",
-          local: [{ path: bad, sha256: digest("x") }],
-          peer: [],
-        }),
+        planNamespaceReconciliation(
+          {
+            namespace: "default",
+            local: [{ path: bad, sha256: digest("x") }],
+            peer: [],
+          },
+          { localPlatform: "win32" }
+        ),
       /dot or space/,
-      `path ${JSON.stringify(bad)} must be rejected`,
+      `path ${JSON.stringify(bad)} must be rejected`
     );
   }
 });
-
 
 test("an unorderable supersede link says so instead of picking a side", () => {
   for (const pair of [
@@ -810,7 +819,7 @@ test("an unorderable supersede link says so instead of picking a side", () => {
   ] as const) {
     const entries = planNamespaceReconciliation(
       { namespace: "default", local: [pair[0]], peer: [pair[1]] },
-      { conflictPolicy: "newest-wins" },
+      { conflictPolicy: "newest-wins" }
     );
     const entry = entryFor(entries, "facts/a.md");
     assert.equal(entry.resolution, "supersede-link");
@@ -821,13 +830,16 @@ test("Windows-unstorable and reserved path names are rejected", () => {
   for (const bad of ["facts/a:b.md", "facts/CON.md", "facts/com1.txt", 'facts/a"b.md', "facts/a\u0001b.md"]) {
     assert.throws(
       () =>
-        planNamespaceReconciliation({
-          namespace: "default",
-          local: [{ path: bad, sha256: digest("x") }],
-          peer: [],
-        }),
+        planNamespaceReconciliation(
+          {
+            namespace: "default",
+            local: [{ path: bad, sha256: digest("x") }],
+            peer: [],
+          },
+          { localPlatform: "win32" }
+        ),
       ReconcilePlanInputError,
-      `path ${JSON.stringify(bad)} must be rejected`,
+      `path ${JSON.stringify(bad)} must be rejected`
     );
   }
   // A name that merely CONTAINS a reserved word is fine.
@@ -836,7 +848,7 @@ test("Windows-unstorable and reserved path names are rejected", () => {
       namespace: "default",
       local: [file("facts/console.md", "x")],
       peer: [],
-    }),
+    })
   );
 });
 
@@ -849,25 +861,27 @@ test("a directionless supersede link is reported as unresolved", () => {
       local: [file("facts/a.md", "local", 5000)],
       peer: [file("facts/a.md", "peer", 5000)],
     },
-    { conflictPolicy: "newest-wins" },
+    { conflictPolicy: "newest-wins" }
   );
   assert.deepEqual(summarizeReconcilePlan(entries), [
     { namespace: "default", pull: 0, push: 0, identical: 0, conflict: 1, suppress: 0, unresolved: 1 },
   ]);
 });
 
-
 test("superscript COM and LPT device aliases are rejected", () => {
   for (const bad of ["facts/COM\u00b9.txt", "facts/LPT\u00b2", "facts/com\u00b3.md"]) {
     assert.throws(
       () =>
-        planNamespaceReconciliation({
-          namespace: "default",
-          local: [{ path: bad, sha256: digest("x") }],
-          peer: [],
-        }),
+        planNamespaceReconciliation(
+          {
+            namespace: "default",
+            local: [{ path: bad, sha256: digest("x") }],
+            peer: [],
+          },
+          { localPlatform: "win32" }
+        ),
       /reserved Windows device name/,
-      `path ${JSON.stringify(bad)} must be rejected`,
+      `path ${JSON.stringify(bad)} must be rejected`
     );
   }
 });
@@ -882,7 +896,7 @@ test("a full caseless fold catches sigma-style aliases", () => {
         local: [file("facts/\u03c2.md", "one")],
         peer: [file("facts/\u03c3.md", "two")],
       }),
-    /aliasing paths/,
+    /aliasing paths/
   );
 });
 
@@ -894,18 +908,18 @@ test("non-plain objects are not accepted as envelopes", () => {
       () =>
         planNamespaceReconciliation(
           { namespace: "default", local: [], peer: [] },
-          bad as unknown as Record<string, never>,
+          bad as unknown as Record<string, never>
         ),
       /options must be a plain object/,
-      `options ${Object.prototype.toString.call(bad)}`,
+      `options ${Object.prototype.toString.call(bad)}`
     );
   }
   // A null-prototype record is still a record.
   assert.doesNotThrow(() =>
     planNamespaceReconciliation(
       { namespace: "default", local: [], peer: [] },
-      Object.assign(Object.create(null), { conflictPolicy: "manual" }) as Record<string, never>,
-    ),
+      Object.assign(Object.create(null), { conflictPolicy: "manual" }) as Record<string, never>
+    )
   );
 });
 
@@ -915,7 +929,7 @@ test("an empty namespace list still validates its options", () => {
     assert.throws(
       () => planReconciliation([], bad as unknown as Record<string, never>),
       ReconcilePlanInputError,
-      `options ${Object.prototype.toString.call(bad)}`,
+      `options ${Object.prototype.toString.call(bad)}`
     );
   }
   assert.equal(planReconciliation([], { conflictPolicy: "manual" }).converged, true);
@@ -929,7 +943,7 @@ test("sharp-S aliases fold together", () => {
         local: [file("facts/stra\u00dfe.md", "one")],
         peer: [file("facts/stra\u1e9ee.md", "two")],
       }),
-    /aliasing paths/,
+    /aliasing paths/
   );
 });
 
@@ -944,7 +958,7 @@ test("a malformed tombstone collection raises the planner's error, not a TypeErr
           tombstonedFileSha256: bad as unknown as string[],
         }),
       ReconcilePlanInputError,
-      `tombstonedFileSha256 ${JSON.stringify(bad)}`,
+      `tombstonedFileSha256 ${JSON.stringify(bad)}`
     );
   }
 });
@@ -955,12 +969,15 @@ test("an unpaired surrogate path is rejected", () => {
   for (const bad of ["facts/\ud800.md", "facts/\udc00.md"]) {
     assert.throws(
       () =>
-        planNamespaceReconciliation({
-          namespace: "default",
-          local: [{ path: bad, sha256: digest("x") }],
-          peer: [],
-        }),
-      /unpaired surrogate/,
+        planNamespaceReconciliation(
+          {
+            namespace: "default",
+            local: [{ path: bad, sha256: digest("x") }],
+            peer: [],
+          },
+          { localPlatform: "win32" }
+        ),
+      /unpaired surrogate/
     );
   }
   // A well-formed pair is fine.
@@ -969,7 +986,7 @@ test("an unpaired surrogate path is rejected", () => {
       namespace: "default",
       local: [file("facts/\ud83d\ude00.md", "x")],
       peer: [],
-    }),
+    })
   );
 });
 
@@ -982,7 +999,7 @@ test("the base cursor is validated with the same rules as the other censuses", (
         peer: [],
         base: [file("facts/a.md", "one"), file("facts/a.md", "two")],
       }),
-    /base census for namespace default lists facts\/a\.md twice with different digests/,
+    /base census for namespace default lists facts\/a\.md twice with different digests/
   );
   // And it still drives the one-sided-change decision it exists for.
   const entries = planNamespaceReconciliation({
@@ -998,8 +1015,5 @@ test("the base cursor is validated with the same rules as the other censuses", (
 test("a namespace with an unpaired surrogate is rejected", () => {
   // namespaceIdentityToken() encodes through TextEncoder, so this and a
   // literal U+FFFD namespace are one directory on disk.
-  assert.throws(
-    () => planNamespaceReconciliation({ namespace: "\ud800", local: [], peer: [] }),
-    /unpaired surrogate/,
-  );
+  assert.throws(() => planNamespaceReconciliation({ namespace: "\ud800", local: [], peer: [] }), /unpaired surrogate/);
 });

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -1017,3 +1017,19 @@ test("a namespace with an unpaired surrogate is rejected", () => {
   // literal U+FFFD namespace are one directory on disk.
   assert.throws(() => planNamespaceReconciliation({ namespace: "\ud800", local: [], peer: [] }), /unpaired surrogate/);
 });
+
+test("POSIX-origin colon paths are rejected when the PEER platform is win32", () => {
+  assert.throws(
+    () =>
+      planNamespaceReconciliation(
+        {
+          namespace: "default",
+          local: [{ path: "facts/a:b.md", sha256: digest("x") }],
+          peer: [],
+        },
+        { peerPlatform: "win32" }
+      ),
+    /character Windows cannot store/,
+    "a push to a Windows peer must not plan a colon path"
+  );
+});

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -186,6 +186,12 @@ export interface ReconcileOptions {
    * the Windows branches stay testable from any platform.
    */
   localPlatform?: NodeJS.Platform;
+  /**
+   * Platform of the PEER participant when known (advertised via the
+   * offline-sync capabilities route). Push entries materialize on the peer,
+   * so Windows path hazards apply when EITHER participant is win32.
+   */
+  peerPlatform?: string;
 }
 
 /**
@@ -216,7 +222,7 @@ function assertCensusRecord(
   file: ReconcileFileState | undefined,
   side: string,
   namespace: string,
-  platform: NodeJS.Platform
+  platforms: readonly (string | undefined)[]
 ): ReconcileFileState {
   const path = file?.path;
   if (typeof path !== "string" || path.length === 0) {
@@ -232,7 +238,7 @@ function assertCensusRecord(
   } catch (err) {
     throw new ReconcilePlanInputError(err instanceof Error ? err.message : String(err));
   }
-  assertPortablePathSegments(path, side, namespace, platform);
+  assertPortablePathSegments(path, side, namespace, platforms);
   return {
     ...file,
     path,
@@ -334,7 +340,7 @@ function assertPortablePathSegments(
   path: string,
   side: string,
   namespace: string,
-  platform: NodeJS.Platform = process.platform
+  platforms: readonly (string | undefined)[]
 ): void {
   // Windows-only hazards (trailing dot/space stripping, invalid characters
   // like `:`, reserved device names) only constrain a plan whose LOCAL
@@ -343,7 +349,7 @@ function assertPortablePathSegments(
   // gates are skipped for non-win32 planners. The lone-surrogate check is
   // UNCONDITIONAL: Node mangles unpaired surrogates identically everywhere,
   // which corrupts cross-platform path comparison itself.
-  const isWindows = platform === "win32";
+  const isWindows = platforms.some((candidate) => candidate === "win32");
   for (const segment of path.split("/")) {
     if (segment.length === 0) continue;
     if (isWindows && (segment.endsWith(".") || segment.endsWith(" "))) {
@@ -431,11 +437,11 @@ function indexByPath(
   files: Iterable<ReconcileFileState>,
   side: string,
   namespace: string,
-  platform: NodeJS.Platform
+  platforms: readonly (string | undefined)[]
 ): Map<string, ReconcileFileState> {
   const index = new Map<string, ReconcileFileState>();
   for (const raw of files) {
-    const file = assertCensusRecord(raw, side, namespace, platform);
+    const file = assertCensusRecord(raw, side, namespace, platforms);
     if (rejectConflictingDuplicate(index.get(file.path), file, file.path, side, namespace)) continue;
     index.set(file.path, file);
   }
@@ -484,11 +490,11 @@ function indexDigestsByPath(
   files: Iterable<ReconcileFileState>,
   side: string,
   namespace: string,
-  platform: NodeJS.Platform
+  platforms: readonly (string | undefined)[]
 ): Map<string, string> {
   const index = new Map<string, string>();
   for (const raw of files) {
-    const file = assertCensusRecord(raw, side, namespace, platform);
+    const file = assertCensusRecord(raw, side, namespace, platforms);
     const existing = index.get(file.path);
     // One map, not a parallel `seen`: the base's own mtimeMs is never a
     // decision input (only the local and peer timestamps order a conflict), so
@@ -556,7 +562,7 @@ function parseDeletionMtimes(
   value: ReadonlyMap<string, number> | undefined,
   side: string,
   namespace: string,
-  platform: NodeJS.Platform
+  platforms: readonly (string | undefined)[]
 ): ReadonlyMap<string, number> {
   if (value === undefined) return new Map();
   if (!(value instanceof Map)) {
@@ -569,7 +575,7 @@ function parseDeletionMtimes(
     } catch (err) {
       throw new ReconcilePlanInputError(err instanceof Error ? err.message : String(err));
     }
-    assertPortablePathSegments(path, side, namespace, platform);
+    assertPortablePathSegments(path, side, namespace, platforms);
     parsed.set(path, assertMtimeMs(mtimeMs, `${side} deletion for namespace ${namespace} entry ${path}`));
   }
   return parsed;
@@ -603,8 +609,8 @@ export function planNamespaceReconciliation(
   // Index the peer census only, then stream the local one against it, removing
   // each match as it is consumed. Peak residency is one index plus the entry
   // list rather than two full censuses (round 2, codex P2).
-  const localPlatform = options.localPlatform ?? process.platform;
-  const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace, localPlatform);
+  const effectivePlatforms = [options.localPlatform ?? process.platform, options.peerPlatform];
+  const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace, effectivePlatforms);
   // Only `base.sha256` is ever read, so the base is compacted to path -> digest
   // instead of a second full record index (round 7, codex P2).
   // Only an ABSENT base means bootstrap. A null/invalid cursor silently read as
@@ -613,11 +619,11 @@ export function planNamespaceReconciliation(
   const base =
     input.base === undefined
       ? null
-      : indexDigestsByPath(assertIterable(input.base, "base", namespace), "base", namespace, localPlatform);
+      : indexDigestsByPath(assertIterable(input.base, "base", namespace), "base", namespace, effectivePlatforms);
   const tombstoned = parseTombstonedDigests(input.tombstonedFileSha256, namespace);
   const peerTombstoned = parseTombstonedDigests(input.peerTombstonedFileSha256, namespace, "peerTombstonedFileSha256");
-  const localDeletionMtimeMs = parseDeletionMtimes(input.localDeletionMtimeMs, "local", namespace, localPlatform);
-  const peerDeletionMtimeMs = parseDeletionMtimes(input.peerDeletionMtimeMs, "peer", namespace, localPlatform);
+  const localDeletionMtimeMs = parseDeletionMtimes(input.localDeletionMtimeMs, "local", namespace, effectivePlatforms);
+  const peerDeletionMtimeMs = parseDeletionMtimes(input.peerDeletionMtimeMs, "peer", namespace, effectivePlatforms);
   const entries: ReconcilePlanEntry[] = [];
 
   // Path -> digest only, never the file objects: enough to make the stream
@@ -632,7 +638,7 @@ export function planNamespaceReconciliation(
   // materializing the second census.
   const seenLocal = new Map<string, { sha256: string; mtimeMs?: number }>();
   for (const rawLocal of localCensus) {
-    const localFile = assertCensusRecord(rawLocal, "local", namespace, options.localPlatform ?? process.platform);
+    const localFile = assertCensusRecord(rawLocal, "local", namespace, effectivePlatforms);
     const path = localFile.path;
     assertNoPathAlias(caseFold, path, namespace);
     const seen = seenLocal.get(path);

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -2,10 +2,7 @@ import { CENSUS_MAX_MTIME_MS, isCensusMtimeMs, isSha256Hex } from "../census-val
 import { normalizeNamespaceIdentity } from "../namespaces/identity.js";
 import { validateArchiveRelativePath } from "../transfer/fs-utils.js";
 import type { OfflineSyncFileState } from "../offline-sync.js";
-import {
-  CONVERGE_CONFLICT_POLICIES,
-  DEFAULT_CONVERGE_CONFLICT_POLICY,
-} from "../converge-config.js";
+import { CONVERGE_CONFLICT_POLICIES, DEFAULT_CONVERGE_CONFLICT_POLICY } from "../converge-config.js";
 import type { ConvergeConflictPolicy } from "../types.js";
 export type ReconcileConflictPolicy = ConvergeConflictPolicy;
 
@@ -180,6 +177,15 @@ export interface ReconcileNamespaceInput {
 
 export interface ReconcileOptions {
   conflictPolicy?: ConvergeConflictPolicy;
+  /**
+   * Platform whose filesystem constraints the portability gates enforce
+   * (trailing dot/space, Windows-invalid characters, reserved device names).
+   * Defaults to the local platform: a POSIX planner may reason about
+   * POSIX-origin paths that carry characters Windows cannot store, because
+   * that plan will never be applied on a Windows participant. Injectable so
+   * the Windows branches stay testable from any platform.
+   */
+  localPlatform?: NodeJS.Platform;
 }
 
 /**
@@ -210,11 +216,12 @@ function assertCensusRecord(
   file: ReconcileFileState | undefined,
   side: string,
   namespace: string,
+  platform: NodeJS.Platform
 ): ReconcileFileState {
   const path = file?.path;
   if (typeof path !== "string" || path.length === 0) {
     throw new ReconcilePlanInputError(
-      `reconcile: ${side} census for namespace ${namespace} contains a record with no path`,
+      `reconcile: ${side} census for namespace ${namespace} contains a record with no path`
     );
   }
   // Same boundary offline-sync applies to this field: a peer census is
@@ -225,7 +232,7 @@ function assertCensusRecord(
   } catch (err) {
     throw new ReconcilePlanInputError(err instanceof Error ? err.message : String(err));
   }
-  assertPortablePathSegments(path, side, namespace);
+  assertPortablePathSegments(path, side, namespace, platform);
   return {
     ...file,
     path,
@@ -248,7 +255,7 @@ function assertCensusRecord(
 function assertMtimeMs(value: unknown, context: string): number {
   if (!isCensusMtimeMs(value)) {
     throw new ReconcilePlanInputError(
-      `reconcile: ${context} has an out-of-range mtimeMs; expected a finite value between 0 and ${CENSUS_MAX_MTIME_MS}`,
+      `reconcile: ${context} has an out-of-range mtimeMs; expected a finite value between 0 and ${CENSUS_MAX_MTIME_MS}`
     );
   }
   return value;
@@ -262,9 +269,7 @@ function assertMtimeMs(value: unknown, context: string): number {
  */
 function assertDigest(value: unknown, context: string): string {
   if (!isSha256Hex(value)) {
-    throw new ReconcilePlanInputError(
-      `reconcile: ${context} must carry a 64-character sha256 hex digest`,
-    );
+    throw new ReconcilePlanInputError(`reconcile: ${context} must carry a 64-character sha256 hex digest`);
   }
   return value.toLowerCase();
 }
@@ -288,19 +293,23 @@ function assertNamespace(namespace: unknown): string {
     // surrogate and a literal U+FFFD collapse to ONE storage identity while
     // comparing as two here - slipping both past the duplicate-namespace guard.
     throw new ReconcilePlanInputError(
-      "reconcile: namespace contains an unpaired surrogate; it would collide with another namespace on disk",
+      "reconcile: namespace contains an unpaired surrogate; it would collide with another namespace on disk"
     );
   }
   if (normalizeNamespaceIdentity(namespace) !== namespace) {
     throw new ReconcilePlanInputError(
-      `reconcile: namespace ${JSON.stringify(namespace)} is not canonical; pass ${JSON.stringify(normalizeNamespaceIdentity(namespace))}`,
+      `reconcile: namespace ${JSON.stringify(namespace)} is not canonical; pass ${JSON.stringify(normalizeNamespaceIdentity(namespace))}`
     );
   }
   return namespace;
 }
 
 function assertIterable(value: unknown, side: string, namespace: string): Iterable<ReconcileFileState> {
-  if (value === null || typeof value !== "object" || typeof (value as Iterable<ReconcileFileState>)[Symbol.iterator] !== "function") {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    typeof (value as Iterable<ReconcileFileState>)[Symbol.iterator] !== "function"
+  ) {
     throw new ReconcilePlanInputError(`reconcile: ${side} census for namespace ${namespace} must be iterable`);
   }
   return value as Iterable<ReconcileFileState>;
@@ -321,13 +330,26 @@ const WIN32_INVALID_CHARS = /[<>:"|?*\u0000-\u001f]/;
 const LONE_SURROGATE = /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/;
 const WIN32_RESERVED_NAMES = /^(con|prn|aux|nul|(com|lpt)[1-9\u00b9\u00b2\u00b3])$/i;
 
-function assertPortablePathSegments(path: string, side: string, namespace: string): void {
+function assertPortablePathSegments(
+  path: string,
+  side: string,
+  namespace: string,
+  platform: NodeJS.Platform = process.platform
+): void {
+  // Windows-only hazards (trailing dot/space stripping, invalid characters
+  // like `:`, reserved device names) only constrain a plan whose LOCAL
+  // participant would materialize those paths on Windows. POSIX-origin
+  // corpora legitimately contain `:` (e.g. sqlite sidecar names), so the
+  // gates are skipped for non-win32 planners. The lone-surrogate check is
+  // UNCONDITIONAL: Node mangles unpaired surrogates identically everywhere,
+  // which corrupts cross-platform path comparison itself.
+  const isWindows = platform === "win32";
   for (const segment of path.split("/")) {
     if (segment.length === 0) continue;
-    if (segment.endsWith(".") || segment.endsWith(" ")) {
+    if (isWindows && (segment.endsWith(".") || segment.endsWith(" "))) {
       throw new ReconcilePlanInputError(
         `reconcile: ${side} census for namespace ${namespace} path ${path} has a segment ending in a dot or space; ` +
-          "Windows strips those and would alias it onto another file",
+          "Windows strips those and would alias it onto another file"
       );
     }
     // `:` opens an alternate data stream, the rest cannot be created at all,
@@ -337,27 +359,23 @@ function assertPortablePathSegments(path: string, side: string, namespace: strin
       // Node encodes an unpaired surrogate as U+FFFD, so this path and a
       // literal U+FFFD path are one file on disk while comparing as distinct.
       throw new ReconcilePlanInputError(
-        `reconcile: ${side} census for namespace ${namespace} path ${path} contains an unpaired surrogate`,
+        `reconcile: ${side} census for namespace ${namespace} path ${path} contains an unpaired surrogate`
       );
     }
-    if (WIN32_INVALID_CHARS.test(segment)) {
+    if (isWindows && WIN32_INVALID_CHARS.test(segment)) {
       throw new ReconcilePlanInputError(
-        `reconcile: ${side} census for namespace ${namespace} path ${path} contains a character Windows cannot store`,
+        `reconcile: ${side} census for namespace ${namespace} path ${path} contains a character Windows cannot store`
       );
     }
-    if (WIN32_RESERVED_NAMES.test(segment.split(".")[0] ?? "")) {
+    if (isWindows && WIN32_RESERVED_NAMES.test(segment.split(".")[0] ?? "")) {
       throw new ReconcilePlanInputError(
-        `reconcile: ${side} census for namespace ${namespace} path ${path} uses a reserved Windows device name`,
+        `reconcile: ${side} census for namespace ${namespace} path ${path} uses a reserved Windows device name`
       );
     }
   }
 }
 
-function assertNoPathAlias(
-  seen: Map<string, string>,
-  path: string,
-  namespace: string,
-): void {
+function assertNoPathAlias(seen: Map<string, string>, path: string, namespace: string): void {
   // NFC first: macOS stores decomposed names and compares canonically, so
   // `é` (U+00E9) and `é` (e + U+0301) are ONE file there. Then a FULL caseless
   // fold - upper-then-lower, which collapses forms a bare toLowerCase() keeps
@@ -365,12 +383,16 @@ function assertNoPathAlias(
   // those distinct and the planner would emit both a push and a pull.
   // `ß` upper-folds to `ss` while `ẞ` folds to `ß`, so one more pass equalizes
   // the pair that a single upper-then-lower still leaves apart.
-  const folded = path.normalize("NFC").toUpperCase().toLowerCase().replace(/\u00df/g, "ss");
+  const folded = path
+    .normalize("NFC")
+    .toUpperCase()
+    .toLowerCase()
+    .replace(/\u00df/g, "ss");
   const existing = seen.get(folded);
   if (existing !== undefined && existing !== path) {
     throw new ReconcilePlanInputError(
       `reconcile: namespace ${namespace} has aliasing paths (${existing}, ${path}); ` +
-        "they resolve to one file on a case-insensitive or Unicode-normalizing peer",
+        "they resolve to one file on a case-insensitive or Unicode-normalizing peer"
     );
   }
   seen.set(folded, path);
@@ -386,12 +408,12 @@ function rejectConflictingDuplicate(
   incoming: { sha256: string; mtimeMs?: number },
   path: string,
   side: string,
-  namespace: string,
+  namespace: string
 ): boolean {
   if (!existing) return false;
   if (existing.sha256 !== incoming.sha256) {
     throw new ReconcilePlanInputError(
-      `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different digests`,
+      `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different digests`
     );
   }
   // Same bytes but a different mtime is still ambiguous: `newest-wins` reads
@@ -399,7 +421,7 @@ function rejectConflictingDuplicate(
   // the winner.
   if (existing.mtimeMs !== incoming.mtimeMs) {
     throw new ReconcilePlanInputError(
-      `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different mtimeMs`,
+      `reconcile: ${side} census for namespace ${namespace} lists ${path} twice with different mtimeMs`
     );
   }
   return true;
@@ -409,10 +431,11 @@ function indexByPath(
   files: Iterable<ReconcileFileState>,
   side: string,
   namespace: string,
+  platform: NodeJS.Platform
 ): Map<string, ReconcileFileState> {
   const index = new Map<string, ReconcileFileState>();
   for (const raw of files) {
-    const file = assertCensusRecord(raw, side, namespace);
+    const file = assertCensusRecord(raw, side, namespace, platform);
     if (rejectConflictingDuplicate(index.get(file.path), file, file.path, side, namespace)) continue;
     index.set(file.path, file);
   }
@@ -428,19 +451,19 @@ function indexByPath(
 function parseTombstonedDigests(
   value: Iterable<string> | undefined,
   namespace: string,
-  field = "tombstonedFileSha256",
+  field = "tombstonedFileSha256"
 ): Set<string> {
   if (value === undefined) return new Set();
   if (typeof value === "string") {
     throw new ReconcilePlanInputError(
-      `reconcile: ${field} for namespace ${namespace} must be a collection of digests, not a single string`,
+      `reconcile: ${field} for namespace ${namespace} must be a collection of digests, not a single string`
     );
   }
   if (value === null || typeof value !== "object" || typeof value[Symbol.iterator] !== "function") {
     // Otherwise the for...of below throws a raw TypeError and a caller handling
     // ReconcilePlanInputError cannot tell a bad request from a planner bug.
     throw new ReconcilePlanInputError(
-      `reconcile: ${field} for namespace ${namespace} must be an iterable collection of digests`,
+      `reconcile: ${field} for namespace ${namespace} must be an iterable collection of digests`
     );
   }
   const digests = new Set<string>();
@@ -461,10 +484,11 @@ function indexDigestsByPath(
   files: Iterable<ReconcileFileState>,
   side: string,
   namespace: string,
+  platform: NodeJS.Platform
 ): Map<string, string> {
   const index = new Map<string, string>();
   for (const raw of files) {
-    const file = assertCensusRecord(raw, side, namespace);
+    const file = assertCensusRecord(raw, side, namespace, platform);
     const existing = index.get(file.path);
     // One map, not a parallel `seen`: the base's own mtimeMs is never a
     // decision input (only the local and peer timestamps order a conflict), so
@@ -473,7 +497,7 @@ function indexDigestsByPath(
     if (existing !== undefined) {
       if (existing !== file.sha256) {
         throw new ReconcilePlanInputError(
-          `reconcile: ${side} census for namespace ${namespace} lists ${file.path} twice with different digests`,
+          `reconcile: ${side} census for namespace ${namespace} lists ${file.path} twice with different digests`
         );
       }
       continue;
@@ -487,7 +511,7 @@ function assertConflictPolicy(value: ConvergeConflictPolicy | undefined): Conver
   if (value === undefined) return DEFAULT_CONVERGE_CONFLICT_POLICY;
   if (!CONVERGE_CONFLICT_POLICIES.includes(value)) {
     throw new ReconcilePlanInputError(
-      `reconcile: unknown conflictPolicy ${JSON.stringify(value)}; expected one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}`,
+      `reconcile: unknown conflictPolicy ${JSON.stringify(value)}; expected one of ${CONVERGE_CONFLICT_POLICIES.join(", ")}`
     );
   }
   return value;
@@ -519,7 +543,7 @@ function resolveConflict(
   policy: ConvergeConflictPolicy,
   localMtimeMs: number | undefined,
   peerMtimeMs: number | undefined,
-  missingTimestampResolution: ReconcileResolution,
+  missingTimestampResolution: ReconcileResolution
 ): ReconcileResolution {
   if (policy !== "newest-wins") return "unresolved";
   if (localMtimeMs === undefined || peerMtimeMs === undefined || localMtimeMs === peerMtimeMs) {
@@ -532,12 +556,11 @@ function parseDeletionMtimes(
   value: ReadonlyMap<string, number> | undefined,
   side: string,
   namespace: string,
+  platform: NodeJS.Platform
 ): ReadonlyMap<string, number> {
   if (value === undefined) return new Map();
   if (!(value instanceof Map)) {
-    throw new ReconcilePlanInputError(
-      `reconcile: ${side} deletion mtimes for namespace ${namespace} must be a Map`,
-    );
+    throw new ReconcilePlanInputError(`reconcile: ${side} deletion mtimes for namespace ${namespace} must be a Map`);
   }
   const parsed = new Map<string, number>();
   for (const [path, mtimeMs] of value) {
@@ -546,7 +569,7 @@ function parseDeletionMtimes(
     } catch (err) {
       throw new ReconcilePlanInputError(err instanceof Error ? err.message : String(err));
     }
-    assertPortablePathSegments(path, side, namespace);
+    assertPortablePathSegments(path, side, namespace, platform);
     parsed.set(path, assertMtimeMs(mtimeMs, `${side} deletion for namespace ${namespace} entry ${path}`));
   }
   return parsed;
@@ -562,7 +585,7 @@ function parseDeletionMtimes(
  */
 export function planNamespaceReconciliation(
   input: ReconcileNamespaceInput,
-  options: ReconcileOptions = {},
+  options: ReconcileOptions = {}
 ): ReconcilePlanEntry[] {
   if (!isPlainObject(input)) {
     throw new ReconcilePlanInputError("reconcile: namespace input must be a plain object");
@@ -580,23 +603,21 @@ export function planNamespaceReconciliation(
   // Index the peer census only, then stream the local one against it, removing
   // each match as it is consumed. Peak residency is one index plus the entry
   // list rather than two full censuses (round 2, codex P2).
-  const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace);
+  const localPlatform = options.localPlatform ?? process.platform;
+  const peer = indexByPath(assertIterable(input.peer, "peer", namespace), "peer", namespace, localPlatform);
   // Only `base.sha256` is ever read, so the base is compacted to path -> digest
   // instead of a second full record index (round 7, codex P2).
   // Only an ABSENT base means bootstrap. A null/invalid cursor silently read as
   // "no prior agreement" would turn a peer-side deletion into a push and
   // resurrect it.
-  const base = input.base === undefined
-    ? null
-    : indexDigestsByPath(assertIterable(input.base, "base", namespace), "base", namespace);
+  const base =
+    input.base === undefined
+      ? null
+      : indexDigestsByPath(assertIterable(input.base, "base", namespace), "base", namespace, localPlatform);
   const tombstoned = parseTombstonedDigests(input.tombstonedFileSha256, namespace);
-  const peerTombstoned = parseTombstonedDigests(
-    input.peerTombstonedFileSha256,
-    namespace,
-    "peerTombstonedFileSha256",
-  );
-  const localDeletionMtimeMs = parseDeletionMtimes(input.localDeletionMtimeMs, "local", namespace);
-  const peerDeletionMtimeMs = parseDeletionMtimes(input.peerDeletionMtimeMs, "peer", namespace);
+  const peerTombstoned = parseTombstonedDigests(input.peerTombstonedFileSha256, namespace, "peerTombstonedFileSha256");
+  const localDeletionMtimeMs = parseDeletionMtimes(input.localDeletionMtimeMs, "local", namespace, localPlatform);
+  const peerDeletionMtimeMs = parseDeletionMtimes(input.peerDeletionMtimeMs, "peer", namespace, localPlatform);
   const entries: ReconcilePlanEntry[] = [];
 
   // Path -> digest only, never the file objects: enough to make the stream
@@ -611,7 +632,7 @@ export function planNamespaceReconciliation(
   // materializing the second census.
   const seenLocal = new Map<string, { sha256: string; mtimeMs?: number }>();
   for (const rawLocal of localCensus) {
-    const localFile = assertCensusRecord(rawLocal, "local", namespace);
+    const localFile = assertCensusRecord(rawLocal, "local", namespace, options.localPlatform ?? process.platform);
     const path = localFile.path;
     assertNoPathAlias(caseFold, path, namespace);
     const seen = seenLocal.get(path);
@@ -658,14 +679,10 @@ export function planNamespaceReconciliation(
       // path, and a bootstrap merge must push — both sides hold unique data.
       if (baseSha256 !== undefined) {
         const peerDeletionMtime = peerDeletionMtimeMs.get(path);
-        const resolution = baseSha256 === localFile.sha256
-          ? "unresolved"
-          : resolveConflict(
-              policy,
-              localFile.mtimeMs,
-              peerDeletionMtime,
-              "unresolved",
-            );
+        const resolution =
+          baseSha256 === localFile.sha256
+            ? "unresolved"
+            : resolveConflict(policy, localFile.mtimeMs, peerDeletionMtime, "unresolved");
         entries.push({
           path,
           namespace,
@@ -727,12 +744,7 @@ export function planNamespaceReconciliation(
       });
       continue;
     }
-    const resolution = resolveConflict(
-      policy,
-      localFile.mtimeMs,
-      peerFile.mtimeMs,
-      "supersede-link",
-    );
+    const resolution = resolveConflict(policy, localFile.mtimeMs, peerFile.mtimeMs, "supersede-link");
     entries.push({
       path,
       namespace,
@@ -767,14 +779,10 @@ export function planNamespaceReconciliation(
     }
     if (baseSha256 !== undefined) {
       const localDeletionMtime = localDeletionMtimeMs.get(path);
-      const resolution = baseSha256 === peerFile.sha256
-        ? "unresolved"
-        : resolveConflict(
-            policy,
-            localDeletionMtime,
-            peerFile.mtimeMs,
-            "unresolved",
-          );
+      const resolution =
+        baseSha256 === peerFile.sha256
+          ? "unresolved"
+          : resolveConflict(policy, localDeletionMtime, peerFile.mtimeMs, "unresolved");
       entries.push({
         path,
         namespace,
@@ -811,12 +819,12 @@ export function summarizeReconcilePlan(entries: readonly ReconcilePlanEntry[]): 
       byNamespace.set(entry.namespace, report);
     }
     report[entry.action] += 1;
-    const needsOperator =
-      entry.resolution === "unresolved"
-      || entry.resolution === "supersede-link";
+    const needsOperator = entry.resolution === "unresolved" || entry.resolution === "supersede-link";
     if (entry.action === "conflict" && needsOperator) report.unresolved += 1;
   }
-  return [...byNamespace.values()].sort((a, b) => (a.namespace === b.namespace ? 0 : a.namespace < b.namespace ? -1 : 1));
+  return [...byNamespace.values()].sort((a, b) =>
+    a.namespace === b.namespace ? 0 : a.namespace < b.namespace ? -1 : 1
+  );
 }
 
 /**
@@ -828,7 +836,7 @@ export function summarizeReconcilePlan(entries: readonly ReconcilePlanEntry[]): 
  */
 export function planReconciliation(
   namespaces: readonly ReconcileNamespaceInput[],
-  options: ReconcileOptions = {},
+  options: ReconcileOptions = {}
 ): ReconcilePlan {
   if (!Array.isArray(namespaces)) {
     throw new ReconcilePlanInputError("reconcile: planReconciliation expects an array of namespace inputs");
@@ -849,7 +857,7 @@ export function planReconciliation(
     const name = assertNamespace(namespace?.namespace);
     if (seenNamespaces.has(name)) {
       throw new ReconcilePlanInputError(
-        `reconcile: namespace ${name} appears twice; merge its censuses before planning`,
+        `reconcile: namespace ${name} appears twice; merge its censuses before planning`
       );
     }
     seenNamespaces.add(name);

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -11,7 +11,11 @@ import type { ContradictionLocalizationConfig, ContradictionScanConfig } from ".
 import type { GraphPathScoringConfig } from "./graph-path-scoring-config.js";
 export type { ContradictionLocalizationConfig, ContradictionScanConfig } from "./contradiction-config.js";
 export type { GraphPathScoringConfig } from "./graph-path-scoring-config.js";
-import type { DriftDetectionSettings, MemoryDriftProvenance, RecallDriftAnnotation } from "./preferences/drift-types.js";
+import type {
+  DriftDetectionSettings,
+  MemoryDriftProvenance,
+  RecallDriftAnnotation,
+} from "./preferences/drift-types.js";
 import type { DeepRecallSettings } from "./deep-recall-config.js";
 import type { ProceduralMaintenanceConfig } from "./procedural/maintenance-config.js";
 import type { SkillProjectionConfig } from "./procedural/skill-projection.js";
@@ -25,9 +29,24 @@ export type TriggerMode = "smart" | "every_n" | "time_based";
 export type ConvergeConflictPolicy = "newest-wins" | "manual";
 export interface ConvergeConfig {
   conflictPolicy: ConvergeConflictPolicy;
+  /** Per-request peer HTTP timeout in ms (plan/apply/watch). Default 30000; clamped to <= 3600000. */
+  peerRequestTimeoutMs?: number;
 }
 export type SignalLevel = "none" | "low" | "medium" | "high";
-export type MemoryCategory = "fact" | "preference" | "correction" | "entity" | "decision" | "relationship" | "principle" | "commitment" | "moment" | "skill" | "rule" | "procedure" | "reasoning_trace";
+export type MemoryCategory =
+  | "fact"
+  | "preference"
+  | "correction"
+  | "entity"
+  | "decision"
+  | "relationship"
+  | "principle"
+  | "commitment"
+  | "moment"
+  | "skill"
+  | "rule"
+  | "procedure"
+  | "reasoning_trace";
 export type ConsolidationAction = "ADD" | "MERGE" | "UPDATE" | "INVALIDATE" | "SKIP";
 export type ConfidenceTier = "explicit" | "implied" | "inferred" | "speculative";
 export type PrincipalFromSessionKeyMode = "map" | "prefix" | "regex";
@@ -71,13 +90,7 @@ export type ActiveRecallModelFallbackPolicy = "default-remote" | "resolved-only"
  * sequential — callers may jump straight to a lower tier when eligibility
  * does not hold.
  */
-export type RetrievalTier =
-  | "exact-cache"
-  | "fuzzy-cache"
-  | "direct-answer"
-  | "hybrid"
-  | "rerank-graph"
-  | "agentic";
+export type RetrievalTier = "exact-cache" | "fuzzy-cache" | "direct-answer" | "hybrid" | "rerank-graph" | "agentic";
 
 /**
  * Per-recall annotation describing which retrieval tier served a result,
@@ -125,11 +138,7 @@ export type RecallDisclosure = "chunk" | "section" | "raw";
  * Treat this as the single source of truth — do not hard-code disclosure
  * strings elsewhere.
  */
-export const RECALL_DISCLOSURE_LEVELS: readonly RecallDisclosure[] = [
-  "chunk",
-  "section",
-  "raw",
-] as const;
+export const RECALL_DISCLOSURE_LEVELS: readonly RecallDisclosure[] = ["chunk", "section", "raw"] as const;
 
 /**
  * Default disclosure level when a caller omits `disclosure`.  Set to `chunk`
@@ -139,8 +148,7 @@ export const RECALL_DISCLOSURE_LEVELS: readonly RecallDisclosure[] = [
 export const DEFAULT_RECALL_DISCLOSURE: RecallDisclosure = "chunk";
 
 export function isRecallDisclosure(value: unknown): value is RecallDisclosure {
-  return typeof value === "string"
-    && (RECALL_DISCLOSURE_LEVELS as readonly string[]).includes(value);
+  return typeof value === "string" && (RECALL_DISCLOSURE_LEVELS as readonly string[]).includes(value);
 }
 
 export interface RecallSectionConfig {
@@ -575,17 +583,9 @@ export interface CodingContext {
   defaultBranch: string | null;
 }
 
-export type ScopeProfileLayerId =
-  | "userProject"
-  | "teamProject"
-  | "userGlobal"
-  | "serverShared";
+export type ScopeProfileLayerId = "userProject" | "teamProject" | "userGlobal" | "serverShared";
 
-export type ScopeProfilePromotionTarget =
-  | ScopeProfileLayerId
-  | "serverShared"
-  | "teamProject"
-  | "userGlobal";
+export type ScopeProfilePromotionTarget = ScopeProfileLayerId | "serverShared" | "teamProject" | "userGlobal";
 
 export interface ScopeProfileTeamProjectConfig {
   /**
@@ -660,8 +660,8 @@ export interface CodexCompatConfig {
 
 export function confidenceTier(score: number): ConfidenceTier {
   if (score >= 0.95) return "explicit";
-  if (score >= 0.70) return "implied";
-  if (score >= 0.40) return "inferred";
+  if (score >= 0.7) return "implied";
+  if (score >= 0.4) return "inferred";
   return "speculative";
 }
 
@@ -683,7 +683,12 @@ export interface SemanticChunkingConfigShape {
   fallbackToRecursive: boolean;
 }
 
-export interface PluginConfig extends BoundedJsonlStateConfig, SecurityConfig, DriftDetectionSettings, ActiveContextConfigFields, DeepRecallSettings {
+export interface PluginConfig
+  extends BoundedJsonlStateConfig,
+    SecurityConfig,
+    DriftDetectionSettings,
+    ActiveContextConfigFields,
+    DeepRecallSettings {
   openaiApiKey: string | undefined;
   openaiBaseUrl: string | undefined;
   model: string;
@@ -1570,7 +1575,8 @@ export interface PluginConfig extends BoundedJsonlStateConfig, SecurityConfig, D
   /** Maximum number of trace files to keep (rolling window). */
   profilingMaxTraces: number;
   // Extraction stability guards (P0/P1).
-  extractionDedupeEnabled: boolean; extractionSourceGroundingEnabled: boolean;
+  extractionDedupeEnabled: boolean;
+  extractionSourceGroundingEnabled: boolean;
   extractionDedupeWindowMs: number;
   extractionMinChars: number;
   extractionMinUserTurns: number;
@@ -2714,7 +2720,13 @@ export interface BehaviorLoopPolicyState {
   updatedAt: string;
 }
 
-export type BehaviorSignalType = "correction_override" | "preference_affinity" | "topic_revisitation" | "action_pattern" | "outcome_preference" | "phrasing_style";
+export type BehaviorSignalType =
+  | "correction_override"
+  | "preference_affinity"
+  | "topic_revisitation"
+  | "action_pattern"
+  | "outcome_preference"
+  | "phrasing_style";
 export type BehaviorSignalDirection = "positive" | "negative";
 
 export interface BehaviorSignalEvent {
@@ -3531,12 +3543,7 @@ export type MemoryActionPolicyDecision = "allow" | "defer" | "deny";
 
 export type MemoryActionStatus = "validated" | "applied" | "rejected";
 
-export type MemoryActionEligibilitySource =
-  | "extraction"
-  | "consolidation"
-  | "replay"
-  | "manual"
-  | "unknown";
+export type MemoryActionEligibilitySource = "extraction" | "consolidation" | "replay" | "manual" | "unknown";
 
 export interface MemoryActionEligibilityContext {
   confidence: number;
@@ -3632,7 +3639,8 @@ export interface MemoryProjectionCurrentState {
   accessCount?: number;
   lastAccessed?: string;
   tags?: string[];
-  preview?: string; privateRecord?: boolean;
+  preview?: string;
+  privateRecord?: boolean;
 }
 
 export interface CompressionGuidelineOptimizerSourceWindow {
@@ -3763,12 +3771,7 @@ export type LlmTraceCallback = (event: EngramTraceEvent) => void;
 // Gateway Configuration Types (for fallback AI)
 // ============================================================================
 
-export type ModelApi =
-  | "openai-completions"
-  | "anthropic-messages"
-  | "google-generative"
-  | "codex-cli"
-  | string;
+export type ModelApi = "openai-completions" | "anthropic-messages" | "google-generative" | "codex-cli" | string;
 export type CodexCliReasoningEffort = "low" | "medium" | "high" | "xhigh";
 
 export type ModelProviderAuthMode = "bearer" | "header" | "query";

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1568,6 +1568,12 @@
             ],
             "default": "newest-wins",
             "description": "Default conflict policy for convergence. newest-wins selects the newer revision when both sides carry comparable timestamps; manual stops before mutation when conflicts remain."
+          },
+          "peerRequestTimeoutMs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 30000,
+                    "description": "Per-request peer HTTP timeout in milliseconds for converge plan/apply/watch. Boot-scale namespaces (~100k files) can take over 30s to serve a manifest; raise this rather than watching manifest fetches time out. Clamped to 3600000 (one hour)."
           }
         }
       },

--- a/scripts/config-contract/parsed-keys.snapshot.json
+++ b/scripts/config-contract/parsed-keys.snapshot.json
@@ -291,6 +291,7 @@
     "contradictionSimilarityThreshold",
     "converge",
     "converge.conflictPolicy",
+    "converge.peerRequestTimeoutMs",
     "conversationIndexBackend",
     "conversationIndexEmbedOnUpdate",
     "conversationIndexEnabled",


### PR DESCRIPTION
## Summary

Converging a live two-host primary/failover pair at boot scale (~100k+ files in one namespace on one side) hits three transport defects today; all three are field-observed on a live deployment (generic shape: two hosts, one active one failover, rounded counts).

## Changes

1. **Configurable per-request peer timeout.** Hard-coded 30s killed manifest fetches for ~100k-file namespaces. Three surfaces with sane precedence — `--timeout <seconds>` (plan/apply/watch) > `converge.peerRequestTimeoutMs` (config, validated positive integer) > `REMNIC_CONVERGE_PEER_TIMEOUT_MS` (env) > 30s default; clamped to 1h.
2. **Tombstone evidence tolerates a live peer.**
   - A deployment whose file-content route declines `state/` paths aborted the whole plan (`failed to read peer tombstone evidence`) even though the snapshot LISTS the file. An unserved file is now EMPTY evidence — the snapshot's own tombstone digest array still applies — with a stderr note.
   - A peer still appending tombstones raced the snapshot listing's sha. A grown file is accepted via prefix-extension verification: the listed revision must hash-match the first `state.bytes` characters of the fetched content (tombstone stores are append-only by design). A diverging prefix is still fatal.
3. **Windows path-portability gates are planner-platform-scoped.** A POSIX-origin path containing `:` (a sqlite sidecar name) aborted the plan on a POSIX planner that would never materialize it on Windows. The three Windows-only gates (trailing dot/space, Windows-invalid characters, reserved device names) now apply only when `localPlatform` is win32 (defaults to `process.platform`, injectable via `ReconcileOptions` for tests). The lone-surrogate check stays unconditional — Node mangles unpaired surrogates everywhere, which corrupts path comparison itself.

## Verification

- New tests: config parse/default/clamp/reject (4 asserts); tombstone-unserved tolerated (plan completes, tombstone plans as a pull); append-race accepted via prefix; diverging prefix still fatal; POSIX colon path accepted with a pull entry. Existing Win32 tests now pass `localPlatform: "win32"` explicitly.
- Suites: converge 56/56, reconcile/plan 60/60. `tsc --noEmit` clean (core + cli); `check-ratchets` OK; `check-test-types` OK.

## Non-goal (filed separately)

Resumable/streamed planning for multi-hundred-thousand-file corpora — real redesign (cursor plumbing through the manifest phase), deliberately out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable per-request timeouts for converge operations, with validation and a one-hour maximum.
  - Added platform-aware path validation, including Windows-specific restrictions and reserved names.

- **Bug Fixes**
  - Converge now fails clearly when required tombstone evidence is unavailable.
  - Append-only tombstone updates are accepted when existing content remains a valid prefix.
  - Improved detection of divergent tombstone content and cross-platform path incompatibilities.

- **Documentation**
  - Documented converge timeout configuration in the changelog and CLI help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->