### PR TITLE
fix(converge): --timeout seconds-to-milliseconds conversion (#2802 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `remnic converge --timeout <seconds>` converts seconds to milliseconds in the correct order (#2802 round-1 regression: `--timeout 3600` produced a 3.6-second timeout because the raw seconds value was normalized as milliseconds and then divided by 1000).
 - `planReconciliation` spread-pushed each namespace's entries (`entries.push(...nsEntries)`); a boot-scale namespace (~100k entries) exceeds the call-stack argument limit and the plan dies with `RangeError: Maximum call stack size exceeded`. Entries are pushed per element now.
 
 ## [v9.69.18] — 2026-08-22

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1872,3 +1872,14 @@ test("reconcile plan: POSIX-origin paths with colons are accepted off-Windows an
   assert.equal(plan.converged, false);
   assert.equal(plan.byNamespace[0]?.pull, 1);
 });
+
+test("converge --timeout seconds convert to milliseconds before normalization (#2802 follow-up)", async () => {
+  const { convergeTimeoutFlagToMs } = await import("./converge.js");
+  // The round-1 form produced 3600 (ms) for `--timeout 3600` — 3.6 seconds.
+  assert.equal(convergeTimeoutFlagToMs(3600), 3_600_000);
+  assert.equal(convergeTimeoutFlagToMs(30), 30_000);
+  assert.equal(convergeTimeoutFlagToMs(0.5), 500);
+  // The one-hour ceiling still clamps.
+  assert.equal(convergeTimeoutFlagToMs(7_200), 3_600_000);
+  assert.throws(() => convergeTimeoutFlagToMs(Number.NaN), /--timeout/);
+});

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1883,3 +1883,10 @@ test("converge --timeout seconds convert to milliseconds before normalization (#
   assert.equal(convergeTimeoutFlagToMs(7_200), 3_600_000);
   assert.throws(() => convergeTimeoutFlagToMs(Number.NaN), /--timeout/);
 });
+
+test("converge --timeout rounds fractional seconds before integer normalization (#2804 round 1)", async () => {
+  const { convergeTimeoutFlagToMs } = await import("./converge.js");
+  assert.equal(convergeTimeoutFlagToMs(1.001), 1001);
+  // Sub-millisecond values normalize-reject (positive integer required).
+  assert.throws(() => convergeTimeoutFlagToMs(0.0001), /--timeout/);
+});

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -998,6 +998,17 @@ export function formatConvergeApplyReport(result: ConvergeApplyResult): string {
   return lines.join("\n");
 }
 
+/**
+ * Convert the `--timeout <seconds>` flag to normalized milliseconds. The
+ * flag is SECONDS and normalization validates/clamps MILLISECONDS — the
+ * conversion must happen BETWEEN them. Normalizing the raw seconds and
+ * dividing by 1000 (the #2802 round-1 form) turned `--timeout 3600` into a
+ * 3.6-second timeout.
+ */
+export function convergeTimeoutFlagToMs(seconds: number): number {
+  return normalizeConvergePeerRequestTimeoutMs(seconds * 1000, "--timeout");
+}
+
 export async function cmdConverge(
   action: string,
   rest: string[],
@@ -1040,7 +1051,7 @@ Options:
   let dryRun = false;
   let conflictPolicy: ConvergeConflictPolicy | undefined;
   let intervalSeconds: number | undefined;
-  let timeoutSeconds: number | undefined;
+  let timeoutMsFlag: number | undefined;
 
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
@@ -1069,13 +1080,12 @@ Options:
       // Flag-present-but-value-absent is malformed, not "use the default".
       const raw = rest[i + 1];
       const parsed = raw === undefined ? Number.NaN : Number(raw);
-      try {
-        timeoutSeconds = normalizeConvergePeerRequestTimeoutMs(parsed, "--timeout") / 1000;
-      } catch {
+      if (!Number.isFinite(parsed) || parsed <= 0) {
         process.stderr.write("converge: --timeout must be a positive number of seconds.\n");
         process.exitCode = 2;
         return;
       }
+      timeoutMsFlag = convergeTimeoutFlagToMs(parsed);
       i += 1;
     } else if (arg === "--conflict-policy") {
       const policy = rest[i + 1];
@@ -1102,7 +1112,7 @@ Options:
         peerToken,
         conflictPolicy,
         intervalMs: intervalSeconds !== undefined ? intervalSeconds * 1000 : undefined,
-        peerRequestTimeoutMs: timeoutSeconds !== undefined ? timeoutSeconds * 1000 : undefined,
+        ...(timeoutMsFlag !== undefined ? { peerRequestTimeoutMs: timeoutMsFlag } : {}),
         signal: controller.signal,
         onCycle: json
           ? undefined
@@ -1144,7 +1154,7 @@ Options:
       peerUrl,
       peerToken,
       conflictPolicy,
-      ...(timeoutSeconds !== undefined ? { peerRequestTimeoutMs: timeoutSeconds * 1000 } : {}),
+      ...(timeoutMsFlag !== undefined ? { peerRequestTimeoutMs: timeoutMsFlag } : {}),
     });
     if (json) {
       console.log(JSON.stringify(plan, null, 2));
@@ -1160,7 +1170,7 @@ Options:
     dryRun,
     conflictPolicy,
     config,
-    ...(timeoutSeconds !== undefined ? { peerRequestTimeoutMs: timeoutSeconds * 1000 } : {}),
+    ...(timeoutMsFlag !== undefined ? { peerRequestTimeoutMs: timeoutMsFlag } : {}),
   });
 
   if (json) {

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1006,7 +1006,9 @@ export function formatConvergeApplyReport(result: ConvergeApplyResult): string {
  * 3.6-second timeout.
  */
 export function convergeTimeoutFlagToMs(seconds: number): number {
-  return normalizeConvergePeerRequestTimeoutMs(seconds * 1000, "--timeout");
+  // Round before normalization: IEEE-754 can turn 1.001 into
+  // 1000.9999999999999, which the integer-only normalizer would reject.
+  return normalizeConvergePeerRequestTimeoutMs(Math.round(seconds * 1000), "--timeout");
 }
 
 export async function cmdConverge(


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #2802 round 1. The `--timeout <seconds>` flag was normalized as if the value were already milliseconds and then divided by 1000, so `--timeout 3600` produced a **3.6-second** timeout — observed live when a boot-scale (~100k-file) namespace snapshot aborted exactly at the mis-converted value.

## Change

Convert seconds → milliseconds BEFORE normalization (`convergeTimeoutFlagToMs`, exported for tests). All three dispatch spreads now carry the pre-computed ms value directly. Regression test pins `3600 → 3,600,000`, `30 → 30,000`, `0.5 → 500`, the one-hour clamp, and NaN rejection.

## Verification

converge suite 57/57 (one new test); `tsc --noEmit` clean; ratchets + test-typecheck OK. The live failure that exposed it (field deployment, generic two-host pair): plan aborted with `failed to fetch peer snapshot` at ~3.6s per route; the diagnostic run showed `timeoutMs=3600` reaching the fetch for `--timeout 3600`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `remnic converge --timeout` handling so seconds are converted to milliseconds accurately.
  - Added appropriate rounding for fractional-second values.
  - Preserved validation for positive, finite timeout values and existing error behavior.
  - Timeout values remain capped at one hour, with sub-millisecond values rejected.

- **Documentation**
  - Added an unreleased changelog entry describing the timeout correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->