### PR TITLE
fix(offline-sync): plain-file content chunks carry the full-file sha256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Plain-file offline-sync content chunks now carry the full-file sha256 (`x-remnic-file-sha256`), matching the secure-store branch: peer transports reject chunk responses without it ("response changed during transfer"), so converge plans against real deployments died fetching plain-file tombstone evidence.
 - `remnic converge --timeout <seconds>` converts seconds to milliseconds in the correct order (#2802 round-1 regression: `--timeout 3600` produced a 3.6-second timeout because the raw seconds value was normalized as milliseconds and then divided by 1000).
 - `planReconciliation` spread-pushed each namespace's entries (`entries.push(...nsEntries)`); a boot-scale namespace (~100k entries) exceeds the call-stack argument limit and the plan dies with `RangeError: Maximum call stack size exceeded`. Entries are pushed per element now.
 

--- a/packages/remnic-core/src/offline-sync-file-io.ts
+++ b/packages/remnic-core/src/offline-sync-file-io.ts
@@ -67,33 +67,16 @@ export async function readPlainOfflineSyncFileChunk(options: {
   }
 }
 
-/** Bounded digest cache for plain-file chunk reads: key is the file identity
- * (path + size + mtimeMs), value the streamed whole-file sha256. Capped so a
- * churning corpus cannot grow it unbounded. Exported for the chunk reader in
- * offline-sync.ts, which must attach the full-file sha to every response. */
-const PLAIN_FILE_DIGEST_CACHE_MAX = 64;
-const plainFileDigestCache = new Map<string, string>();
-
-export async function plainFileDigest(
-  filePath: string,
-  st: { size: number; mtimeMs: number },
-): Promise<string> {
-  const key = `${filePath}\0${st.size}\0${st.mtimeMs}`;
-  const cached = plainFileDigestCache.get(key);
-  if (cached !== undefined) {
-    plainFileDigestCache.delete(key);
-    plainFileDigestCache.set(key, cached);
-    return cached;
-  }
+/** Streamed whole-file sha256 for plain-file chunk reads — the value the
+ * file-content response contract exposes as x-remnic-file-sha256. Deliberately
+ * UNCACHED: identity keys like (path, size, mtimeMs) are spoofable (a rewrite
+ * that preserves size and mtime would serve a stale digest, defeating the
+ * uploader's verify-before-idempotent-skip check). One bounded-memory hash
+ * pass per chunk request; content reads stay windowed. */
+export async function plainFileDigest(filePath: string): Promise<string> {
   const hash = createHash("sha256");
   for await (const piece of createReadStream(filePath)) {
     hash.update(piece as Buffer);
   }
-  const digest = hash.digest("hex");
-  plainFileDigestCache.set(key, digest);
-  if (plainFileDigestCache.size > PLAIN_FILE_DIGEST_CACHE_MAX) {
-    const oldest = plainFileDigestCache.keys().next().value;
-    if (typeof oldest === "string") plainFileDigestCache.delete(oldest);
-  }
-  return digest;
+  return hash.digest("hex");
 }

--- a/packages/remnic-core/src/offline-sync-file-io.ts
+++ b/packages/remnic-core/src/offline-sync-file-io.ts
@@ -66,3 +66,34 @@ export async function readPlainOfflineSyncFileChunk(options: {
     await handle.close();
   }
 }
+
+/** Bounded digest cache for plain-file chunk reads: key is the file identity
+ * (path + size + mtimeMs), value the streamed whole-file sha256. Capped so a
+ * churning corpus cannot grow it unbounded. Exported for the chunk reader in
+ * offline-sync.ts, which must attach the full-file sha to every response. */
+const PLAIN_FILE_DIGEST_CACHE_MAX = 64;
+const plainFileDigestCache = new Map<string, string>();
+
+export async function plainFileDigest(
+  filePath: string,
+  st: { size: number; mtimeMs: number },
+): Promise<string> {
+  const key = `${filePath}\0${st.size}\0${st.mtimeMs}`;
+  const cached = plainFileDigestCache.get(key);
+  if (cached !== undefined) {
+    plainFileDigestCache.delete(key);
+    plainFileDigestCache.set(key, cached);
+    return cached;
+  }
+  const hash = createHash("sha256");
+  for await (const piece of createReadStream(filePath)) {
+    hash.update(piece as Buffer);
+  }
+  const digest = hash.digest("hex");
+  plainFileDigestCache.set(key, digest);
+  if (plainFileDigestCache.size > PLAIN_FILE_DIGEST_CACHE_MAX) {
+    const oldest = plainFileDigestCache.keys().next().value;
+    if (typeof oldest === "string") plainFileDigestCache.delete(oldest);
+  }
+  return digest;
+}

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -80,7 +80,7 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
         "state/last_qmd_recall.json",
         "state/last_recall.json",
         "transcripts/session.jsonl",
-      ]
+      ],
     );
     const binary = snapshot.files.find((file) => file.path === "assets/blob.bin");
     assert.equal(Buffer.from(binary?.contentBase64 ?? "", "base64")[3], 255);
@@ -103,7 +103,7 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
         "state/last_intent.json",
         "state/last_qmd_recall.json",
         "state/last_recall.json",
-      ]
+      ],
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -208,6 +208,7 @@ test("offline apply relays known deletion metadata when the target is already ab
   }
 });
 
+
 test("offline sync excludes the internal Remnic tree from snapshots and file transfer", async () => {
   const root = await tempDir("remnic-offline-internal-state");
   const internalPaths = [
@@ -232,43 +233,37 @@ test("offline sync excludes the internal Remnic tree from snapshots and file tra
       sourceId: "local",
       includeContent: false,
     });
-    assert.deepEqual(
-      snapshot.files.map((file) => file.path),
-      [corpusPath]
-    );
+    assert.deepEqual(snapshot.files.map((file) => file.path), [corpusPath]);
 
     await assert.rejects(
-      () =>
-        buildOfflineSyncSnapshotForPaths({
-          root,
-          sourceId: "local",
-          paths: [internalPaths[0]!],
-        }),
-      /offline sync snapshot path is excluded/
+      () => buildOfflineSyncSnapshotForPaths({
+        root,
+        sourceId: "local",
+        paths: [internalPaths[0]!],
+      }),
+      /offline sync snapshot path is excluded/,
     );
     await assert.rejects(
-      () =>
-        readOfflineSyncFileContentChunk({
-          root,
-          path: internalPaths[0]!,
-        }),
-      /offline sync file content path is excluded/
+      () => readOfflineSyncFileContentChunk({
+        root,
+        path: internalPaths[0]!,
+      }),
+      /offline sync file content path is excluded/,
     );
 
     const cursorContent = Buffer.from(internalPaths[0]!);
     await assert.rejects(
-      () =>
-        applyOfflineSyncFileContentChunk({
-          root,
-          sourceId: "peer",
-          path: internalPaths[0]!,
-          sha256: createHash("sha256").update(cursorContent).digest("hex"),
-          bytes: cursorContent.length,
-          mtimeMs: Date.now(),
-          offset: 0,
-          content: cursorContent,
-        }),
-      /offline sync file content path is excluded/
+      () => applyOfflineSyncFileContentChunk({
+        root,
+        sourceId: "peer",
+        path: internalPaths[0]!,
+        sha256: createHash("sha256").update(cursorContent).digest("hex"),
+        bytes: cursorContent.length,
+        mtimeMs: Date.now(),
+        offset: 0,
+        content: cursorContent,
+      }),
+      /offline sync file content path is excluded/,
     );
     const writes: string[] = [];
     const applyResult = await applyOfflineSyncSnapshot({
@@ -279,15 +274,13 @@ test("offline sync excludes the internal Remnic tree from snapshots and file tra
         createdAt: new Date().toISOString(),
         sourceId: "peer",
         includeTranscripts: true,
-        files: [
-          {
-            path: internalPaths[0]!,
-            sha256: createHash("sha256").update(cursorContent).digest("hex"),
-            bytes: cursorContent.length,
-            mtimeMs: Date.now(),
-            contentBase64: cursorContent.toString("base64"),
-          },
-        ],
+        files: [{
+          path: internalPaths[0]!,
+          sha256: createHash("sha256").update(cursorContent).digest("hex"),
+          bytes: cursorContent.length,
+          mtimeMs: Date.now(),
+          contentBase64: cursorContent.toString("base64"),
+        }],
       },
       baseFiles: [],
       currentFiles: [],
@@ -327,7 +320,7 @@ test("offline snapshot abort signal stops filesystem snapshot work", async () =>
           };
         },
       }),
-      /offline sync request aborted/
+      /offline sync request aborted/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -349,26 +342,20 @@ test("offline sync includes retrieval debug snapshots for full-fidelity offline 
       includeContent: true,
     });
 
-    assert.deepEqual(
-      snapshot.files.map((file) => file.path),
-      [
-        "facts/a.md",
-        "state/last_graph_recall.json",
-        "state/last_intent.json",
-        "state/last_qmd_recall.json",
-        "state/last_recall.json",
-      ]
-    );
+    assert.deepEqual(snapshot.files.map((file) => file.path), [
+      "facts/a.md",
+      "state/last_graph_recall.json",
+      "state/last_intent.json",
+      "state/last_qmd_recall.json",
+      "state/last_recall.json",
+    ]);
     const focused = await buildOfflineSyncSnapshotForPaths({
       root,
       sourceId: "remote",
       paths: ["state/last_graph_recall.json"],
       includeContent: true,
     });
-    assert.deepEqual(
-      focused.files.map((file) => file.path),
-      ["state/last_graph_recall.json"]
-    );
+    assert.deepEqual(focused.files.map((file) => file.path), ["state/last_graph_recall.json"]);
     const chunk = await readOfflineSyncFileContentChunk({
       root,
       path: "state/last_graph_recall.json",
@@ -379,14 +366,12 @@ test("offline sync includes retrieval debug snapshots for full-fidelity offline 
     const pull = await applyOfflineSyncSnapshot({
       root,
       snapshot,
-      baseFiles: [
-        {
-          path: "state/last_graph_recall.json",
-          sha256: createHash("sha256").update(oldGraph).digest("hex"),
-          bytes: oldGraph.byteLength,
-          mtimeMs: 0,
-        },
-      ],
+      baseFiles: [{
+        path: "state/last_graph_recall.json",
+        sha256: createHash("sha256").update(oldGraph).digest("hex"),
+        bytes: oldGraph.byteLength,
+        mtimeMs: 0,
+      }],
     });
 
     assert.equal(pull.skipped, 5);
@@ -412,10 +397,7 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
       includeContent: true,
     });
 
-    assert.deepEqual(
-      snapshot.files.map((file) => file.path),
-      ["facts/a.md"]
-    );
+    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-shm"), true);
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-wal"), true);
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/last_qmd_recall.json"), true);
@@ -430,7 +412,7 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
           paths: ["state/lcm.sqlite"],
           includeContent: true,
         }),
-      /offline sync snapshot path is excluded/
+      /offline sync snapshot path is excluded/,
     );
 
     // Apply-side: the remote is authoritative for lcm.sqlite and we must
@@ -442,28 +424,24 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
       createdAt: new Date().toISOString(),
       sourceId: "remote",
       includeTranscripts: true,
-      files: [
-        {
-          path: "state/lcm.sqlite",
-          sha256: createHash("sha256").update("live db").digest("hex"),
-          bytes: Buffer.byteLength("live db"),
-          mtimeMs: 0,
-          contentBase64: Buffer.from("live db").toString("base64"),
-        },
-      ],
+      files: [{
+        path: "state/lcm.sqlite",
+        sha256: createHash("sha256").update("live db").digest("hex"),
+        bytes: Buffer.byteLength("live db"),
+        mtimeMs: 0,
+        contentBase64: Buffer.from("live db").toString("base64"),
+      }],
     };
     const oldDb = Buffer.from("old live db");
     const pull = await applyOfflineSyncSnapshot({
       root,
       snapshot: remoteSnapshot,
-      baseFiles: [
-        {
-          path: "state/lcm.sqlite",
-          sha256: createHash("sha256").update(oldDb).digest("hex"),
-          bytes: oldDb.byteLength,
-          mtimeMs: 0,
-        },
-      ],
+      baseFiles: [{
+        path: "state/lcm.sqlite",
+        sha256: createHash("sha256").update(oldDb).digest("hex"),
+        bytes: oldDb.byteLength,
+        mtimeMs: 0,
+      }],
     });
 
     // Corrected apply contract (#1793 review): the apply-side view SEES the
@@ -481,19 +459,14 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
     const changeset = await buildOfflineSyncChangeset({
       root,
       sourceId: "laptop",
-      baseFiles: [
-        {
-          path: "facts/a.md",
-          sha256: createHash("sha256").update("alpha").digest("hex"),
-          bytes: Buffer.byteLength("alpha"),
-          mtimeMs: 0,
-        },
-      ],
+      baseFiles: [{
+        path: "facts/a.md",
+        sha256: createHash("sha256").update("alpha").digest("hex"),
+        bytes: Buffer.byteLength("alpha"),
+        mtimeMs: 0,
+      }],
     });
-    assert.deepEqual(
-      changeset.changes.map((change) => change.path),
-      []
-    );
+    assert.deepEqual(changeset.changes.map((change) => change.path), []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -523,7 +496,11 @@ test("offline sync includes durable runtime state and excludes only transient sy
     await write(root, "state/recall_impressions.jsonl.1", "rotated-impressions");
     // Node-local lifecycle coordination files must never cross offline sync.
     await write(root, "state/memory-lifecycle-ledger.jsonl.lock", "lock");
-    await write(root, "state/memory-lifecycle-ledger.jsonl.pending.d/event-1.json", "pending");
+    await write(
+      root,
+      "state/memory-lifecycle-ledger.jsonl.pending.d/event-1.json",
+      "pending",
+    );
     await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json", "intent");
     await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/entity-mention-index.json", "entities");
     await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/.memory-status-version.log", "version");
@@ -539,40 +516,34 @@ test("offline sync includes durable runtime state and excludes only transient sy
     // push-side enumeration. Durableremote-authoritative runtime files
     // (last_intent.json, .artifact-write-version.log, etc.) and namespace
     // state still ship so the remote can merge.
-    assert.deepEqual(
-      snapshot.files.map((file) => file.path),
-      [
-        "assets/state/fact-hashes.txt",
-        "facts/a.md",
-        "namespaces/generalist-project-origin-6ebeaa54/state/.memory-status-version.log",
-        "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
-        "state/.artifact-write-version.log",
-        "state/.memory-status-version.log",
-        "state/buffer-surprise-ledger.jsonl",
-        "state/buffer.json",
-        "state/embeddings.json",
-        "state/index_time.json",
-        "state/memory-lifecycle-ledger.jsonl",
-        "state/recall_impressions.jsonl",
-      ]
-    );
+    assert.deepEqual(snapshot.files.map((file) => file.path), [
+      "assets/state/fact-hashes.txt",
+      "facts/a.md",
+      "namespaces/generalist-project-origin-6ebeaa54/state/.memory-status-version.log",
+      "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
+      "state/.artifact-write-version.log",
+      "state/.memory-status-version.log",
+      "state/buffer-surprise-ledger.jsonl",
+      "state/buffer.json",
+      "state/embeddings.json",
+      "state/index_time.json",
+      "state/memory-lifecycle-ledger.jsonl",
+      "state/recall_impressions.jsonl",
+    ]);
     const focused = await buildOfflineSyncSnapshotForPaths({
       root,
       sourceId: "remote",
       paths: ["state/memory-lifecycle-ledger.jsonl"],
       includeContent: true,
     });
-    assert.deepEqual(
-      focused.files.map((file) => file.path),
-      ["state/memory-lifecycle-ledger.jsonl"]
-    );
+    assert.deepEqual(focused.files.map((file) => file.path), ["state/memory-lifecycle-ledger.jsonl"]);
     await assert.rejects(
       () =>
         readOfflineSyncFileContentChunk({
           root,
           path: "state/buffer.json.tmp-123-456",
         }),
-      /offline sync file content path is excluded: state\/buffer\.json\.tmp-123-456/
+      /offline sync file content path is excluded: state\/buffer\.json\.tmp-123-456/,
     );
     await assert.rejects(
       () =>
@@ -580,7 +551,7 @@ test("offline sync includes durable runtime state and excludes only transient sy
           root,
           path: "state/memory-lifecycle-ledger.jsonl.lock",
         }),
-      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.lock/
+      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.lock/,
     );
     await assert.rejects(
       () =>
@@ -588,7 +559,7 @@ test("offline sync includes durable runtime state and excludes only transient sy
           root,
           path: "state/memory-lifecycle-ledger.jsonl.pending.d/event-1.json",
         }),
-      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.pending\.d\/event-1\.json/
+      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.pending\.d\/event-1\.json/,
     );
     const namespaced = await buildOfflineSyncSnapshotForPaths({
       root,
@@ -596,23 +567,20 @@ test("offline sync includes durable runtime state and excludes only transient sy
       paths: ["namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"],
       includeContent: true,
     });
-    assert.deepEqual(
-      namespaced.files.map((file) => file.path),
-      ["namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"]
-    );
+    assert.deepEqual(namespaced.files.map((file) => file.path), [
+      "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
+    ]);
 
     const oldLedger = Buffer.from("old ledger");
     const pull = await applyOfflineSyncSnapshot({
       root,
       snapshot,
-      baseFiles: [
-        {
-          path: "state/memory-lifecycle-ledger.jsonl",
-          sha256: createHash("sha256").update(oldLedger).digest("hex"),
-          bytes: oldLedger.byteLength,
-          mtimeMs: 0,
-        },
-      ],
+      baseFiles: [{
+        path: "state/memory-lifecycle-ledger.jsonl",
+        sha256: createHash("sha256").update(oldLedger).digest("hex"),
+        bytes: oldLedger.byteLength,
+        mtimeMs: 0,
+      }],
     });
 
     // 21 = the 13 durable local-only files plus the 8 node-local excluded
@@ -668,10 +636,7 @@ test("offline snapshot from base avoids rehashing unchanged files", async () => 
     });
 
     assert.equal(readCount, 1);
-    assert.deepEqual(
-      changed.files.map((file) => file.path),
-      ["facts/a.md", "facts/b.md"]
-    );
+    assert.deepEqual(changed.files.map((file) => file.path), ["facts/a.md", "facts/b.md"]);
 
     let digestReadCount = 0;
     const digestSnapshot = await buildOfflineSyncSnapshotFromBase({
@@ -694,10 +659,7 @@ test("offline snapshot from base avoids rehashing unchanged files", async () => 
     });
 
     assert.equal(digestReadCount, 1);
-    assert.deepEqual(
-      digestSnapshot.files.map((file) => file.path),
-      ["facts/a.md", "facts/b.md"]
-    );
+    assert.deepEqual(digestSnapshot.files.map((file) => file.path), ["facts/a.md", "facts/b.md"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -875,15 +837,13 @@ test("offline snapshot apply preserves incoming mtime for future fast-base reuse
       createdAt: new Date(capturedAtMs).toISOString(),
       sourceId: "remote",
       includeTranscripts: true,
-      files: [
-        {
-          path: "facts/a.md",
-          sha256: createHash("sha256").update(content).digest("hex"),
-          bytes: content.byteLength,
-          mtimeMs: remoteMtimeMs,
-          contentBase64: content.toString("base64"),
-        },
-      ],
+      files: [{
+        path: "facts/a.md",
+        sha256: createHash("sha256").update(content).digest("hex"),
+        bytes: content.byteLength,
+        mtimeMs: remoteMtimeMs,
+        contentBase64: content.toString("base64"),
+      }],
     } as const;
 
     const applied = await applyOfflineSyncSnapshot({
@@ -965,22 +925,18 @@ test("offline changeset rewrites a same-hash file that vanished before mtime ali
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [
-          {
-            type: "upsert",
-            path: file.path,
-            file,
-          },
-        ],
-      },
-      currentFiles: [
-        {
+        changes: [{
+          type: "upsert",
           path: file.path,
-          sha256: file.sha256,
-          bytes: file.bytes,
-          mtimeMs: file.mtimeMs,
-        },
-      ],
+          file,
+        }],
+      },
+      currentFiles: [{
+        path: file.path,
+        sha256: file.sha256,
+        bytes: file.bytes,
+        mtimeMs: file.mtimeMs,
+      }],
     });
 
     assert.equal(applied.appliedUpserts, 1);
@@ -1055,9 +1011,12 @@ test("offline sync accepts durable runtime records from older peers", async () =
     assert.equal(await readUtf8(root, "state/buffer.json"), "legacy runtime");
     assert.equal(
       await readUtf8(root, "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"),
-      "legacy runtime"
+      "legacy runtime",
     );
-    await assert.rejects(() => readFile(path.join(root, "state", "buffer.json.tmp-123-456")), /ENOENT/);
+    await assert.rejects(
+      () => readFile(path.join(root, "state", "buffer.json.tmp-123-456")),
+      /ENOENT/,
+    );
 
     const remote = await tempDir("remnic-offline-legacy-runtime-remote");
     try {
@@ -1132,12 +1091,18 @@ test("offline sync accepts durable runtime records from older peers", async () =
       assert.equal(push.appliedUpserts, 4);
       assert.equal(await readUtf8(remote, "facts/a.md"), "alpha");
       assert.equal(await readUtf8(remote, "assets/state/fact-hashes.txt"), "durable asset");
-      assert.equal(await readUtf8(remote, "state/memory-lifecycle-ledger.jsonl"), "legacy runtime");
+      assert.equal(
+        await readUtf8(remote, "state/memory-lifecycle-ledger.jsonl"),
+        "legacy runtime",
+      );
       assert.equal(
         await readUtf8(remote, "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"),
-        "legacy runtime"
+        "legacy runtime",
       );
-      await assert.rejects(() => readFile(path.join(remote, "state", "buffer.json.tmp-123-456")), /ENOENT/);
+      await assert.rejects(
+        () => readFile(path.join(remote, "state", "buffer.json.tmp-123-456")),
+        /ENOENT/,
+      );
     } finally {
       await rm(remote, { recursive: true, force: true });
     }
@@ -1202,7 +1167,7 @@ test("offline sync reads bounded file content chunks with metadata", async () =>
           root,
           path: "state/lcm.sqlite",
         }),
-      /offline sync file content path is excluded: state\/lcm\.sqlite/
+      /offline sync file content path is excluded: state\/lcm\.sqlite/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1440,9 +1405,13 @@ test("offline sync stages chunked uploads through storage hooks", async () => {
     assert.equal(uploadEntries.length, 1);
     const uploadChunkEntries = await readdir(path.join(root, ".offline-sync", "uploads", uploadEntries[0]));
     assert.deepEqual(uploadChunkEntries, ["00000000000000000000.part"]);
-    const rawUpload = await readFile(
-      path.join(root, ".offline-sync", "uploads", uploadEntries[0], uploadChunkEntries[0])
-    );
+    const rawUpload = await readFile(path.join(
+      root,
+      ".offline-sync",
+      "uploads",
+      uploadEntries[0],
+      uploadChunkEntries[0],
+    ));
     assert.match(rawUpload.toString("utf-8"), /^ENC:/);
     assert.equal(rawUpload.includes(next.subarray(0, 8)), false);
 
@@ -1510,8 +1479,8 @@ test("offline snapshot apply follows remote deletions for remote-authoritative r
   const root = await tempDir("remnic-offline-runtime-delete");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from('{"turns":[]}');
-    const localContent = Buffer.from('{"turns":["local"]}');
+    const baseContent = Buffer.from("{\"turns\":[]}");
+    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
     await write(root, relPath, localContent);
 
     const pull = await applyOfflineSyncSnapshot({
@@ -1524,20 +1493,21 @@ test("offline snapshot apply follows remote deletions for remote-authoritative r
         includeTranscripts: true,
         files: [],
       },
-      baseFiles: [
-        {
-          path: relPath,
-          sha256: createHash("sha256").update(baseContent).digest("hex"),
-          bytes: baseContent.byteLength,
-          mtimeMs: 0,
-        },
-      ],
+      baseFiles: [{
+        path: relPath,
+        sha256: createHash("sha256").update(baseContent).digest("hex"),
+        bytes: baseContent.byteLength,
+        mtimeMs: 0,
+      }],
     });
 
     assert.equal(pull.deleted, 1);
     assert.equal(pull.conflicts.length, 0);
     assert.deepEqual(pull.nextBaseFiles, []);
-    await assert.rejects(() => readFile(path.join(root, relPath)), /ENOENT/);
+    await assert.rejects(
+      () => readFile(path.join(root, relPath)),
+      /ENOENT/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1547,7 +1517,7 @@ test("offline snapshot apply preserves new local runtime files without a base", 
   const root = await tempDir("remnic-offline-runtime-local-create");
   try {
     const relPath = "state/buffer.json";
-    const localContent = '{"turns":["local"]}';
+    const localContent = "{\"turns\":[\"local\"]}";
     await write(root, relPath, localContent);
 
     const pull = await applyOfflineSyncSnapshot({
@@ -1620,7 +1590,7 @@ test("offline snapshot apply restores locally deleted remote-authoritative runti
   const root = await tempDir("remnic-offline-runtime-local-delete-restore");
   try {
     const relPath = "state/buffer.json";
-    const remoteContent = Buffer.from('{"turns":[]}');
+    const remoteContent = Buffer.from("{\"turns\":[]}");
     const remoteFile = {
       path: relPath,
       sha256: createHash("sha256").update(remoteContent).digest("hex"),
@@ -1639,27 +1609,23 @@ test("offline snapshot apply restores locally deleted remote-authoritative runti
         includeTranscripts: true,
         files: [remoteFile],
       },
-      baseFiles: [
-        {
-          path: remoteFile.path,
-          sha256: remoteFile.sha256,
-          bytes: remoteFile.bytes,
-          mtimeMs: remoteFile.mtimeMs,
-        },
-      ],
+      baseFiles: [{
+        path: remoteFile.path,
+        sha256: remoteFile.sha256,
+        bytes: remoteFile.bytes,
+        mtimeMs: remoteFile.mtimeMs,
+      }],
     });
 
     assert.equal(pull.upserted, 1);
     assert.equal(pull.conflicts.length, 0);
     assert.equal(await readUtf8(root, relPath), remoteContent.toString("utf-8"));
-    assert.deepEqual(pull.nextBaseFiles, [
-      {
-        path: remoteFile.path,
-        sha256: remoteFile.sha256,
-        bytes: remoteFile.bytes,
-        mtimeMs: remoteFile.mtimeMs,
-      },
-    ]);
+    assert.deepEqual(pull.nextBaseFiles, [{
+      path: remoteFile.path,
+      sha256: remoteFile.sha256,
+      bytes: remoteFile.bytes,
+      mtimeMs: remoteFile.mtimeMs,
+    }]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1725,7 +1691,7 @@ test("offline changeset only carries content for changed local files", async () 
 
     assert.deepEqual(
       changeset.changes.map((change) => change.path),
-      ["facts/changed.md", "facts/empty.md"]
+      ["facts/changed.md", "facts/empty.md"],
     );
     const empty = changeset.changes.find((change) => change.path === "facts/empty.md");
     assert.equal(empty?.type, "upsert");
@@ -1758,10 +1724,7 @@ test("offline changeset can exclude directly pushed large files without reading 
       excludePaths: ["state/lcm.sqlite"],
     });
 
-    assert.deepEqual(
-      changeset.changes.map((change) => change.path),
-      ["facts/small.md"]
-    );
+    assert.deepEqual(changeset.changes.map((change) => change.path), ["facts/small.md"]);
   } finally {
     await rm(local, { recursive: true, force: true });
   }
@@ -1771,8 +1734,8 @@ test("offline changeset skips local edits to remote-authoritative runtime state"
   const local = await tempDir("remnic-offline-runtime-authoritative-push");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from('{"turns":[]}');
-    const localContent = Buffer.from('{"turns":["local"]}');
+    const baseContent = Buffer.from("{\"turns\":[]}");
+    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
     await write(local, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -1788,14 +1751,12 @@ test("offline changeset skips local edits to remote-authoritative runtime state"
     };
 
     assert.equal(
-      (
-        await summarizeOfflineSyncPendingChanges({
-          root: local,
-          sourceId: "laptop",
-          baseFiles: [baseFile],
-        })
-      ).total,
-      0
+      (await summarizeOfflineSyncPendingChanges({
+        root: local,
+        sourceId: "laptop",
+        baseFiles: [baseFile],
+      })).total,
+      0,
     );
 
     const changeset = await buildOfflineSyncChangesetFromSnapshot({
@@ -1814,7 +1775,7 @@ test("offline changeset skips local edits to remote-authoritative runtime state"
         baseFiles: [baseFile],
         currentFiles: [],
       }).total,
-      0
+      0,
     );
     const deleteChangeset = await buildOfflineSyncChangesetFromSnapshot({
       root: local,
@@ -1870,9 +1831,9 @@ test("offline pull lets incoming runtime state replace local runtime conflicts",
   const root = await tempDir("remnic-offline-runtime-authoritative-pull");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from('{"turns":[]}');
-    const localContent = Buffer.from('{"turns":["local"]}');
-    const remoteContent = Buffer.from('{"turns":["remote"]}');
+    const baseContent = Buffer.from("{\"turns\":[]}");
+    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
+    const remoteContent = Buffer.from("{\"turns\":[\"remote\"]}");
     await write(root, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -1904,14 +1865,12 @@ test("offline pull lets incoming runtime state replace local runtime conflicts",
     assert.equal(pull.upserted, 1);
     assert.equal(pull.conflicts.length, 0);
     assert.equal(await readUtf8(root, relPath), remoteContent.toString("utf-8"));
-    assert.deepEqual(pull.nextBaseFiles, [
-      {
-        path: relPath,
-        sha256: incomingFile.sha256,
-        bytes: incomingFile.bytes,
-        mtimeMs: incomingFile.mtimeMs,
-      },
-    ]);
+    assert.deepEqual(pull.nextBaseFiles, [{
+      path: relPath,
+      sha256: incomingFile.sha256,
+      bytes: incomingFile.bytes,
+      mtimeMs: incomingFile.mtimeMs,
+    }]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1921,8 +1880,8 @@ test("offline pull skips local runtime drift when remote still matches base", as
   const root = await tempDir("remnic-offline-runtime-authoritative-base");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from('{"turns":[]}');
-    const localContent = Buffer.from('{"turns":["local"]}');
+    const baseContent = Buffer.from("{\"turns\":[]}");
+    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
     await write(root, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -1958,9 +1917,9 @@ test("offline pull treats last intent as remote-authoritative runtime state", as
   const root = await tempDir("remnic-offline-runtime-last-intent");
   try {
     const relPath = "state/last_intent.json";
-    const baseContent = Buffer.from('{"intent":"base"}');
-    const localContent = Buffer.from('{"intent":"local"}');
-    const remoteContent = Buffer.from('{"intent":"remote"}');
+    const baseContent = Buffer.from("{\"intent\":\"base\"}");
+    const localContent = Buffer.from("{\"intent\":\"local\"}");
+    const remoteContent = Buffer.from("{\"intent\":\"remote\"}");
     await write(root, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -2026,7 +1985,9 @@ test("offline pull applies snapshots with content only for remote-changed files"
       paths: ["facts/shared.md"],
       includeContent: true,
     });
-    const contentByPath = new Map(changedContent.files.map((file) => [file.path, file.contentBase64]));
+    const contentByPath = new Map(
+      changedContent.files.map((file) => [file.path, file.contentBase64]),
+    );
     const hydrated = {
       ...metadataOnly,
       files: metadataOnly.files.map((file) => {
@@ -2207,7 +2168,10 @@ test("offline pull applies remote deletion when the local file is unchanged", as
     });
 
     assert.equal(secondPull.deleted, 1);
-    await assert.rejects(() => readFile(path.join(local, "facts/deleted.md")), /ENOENT/);
+    await assert.rejects(
+      () => readFile(path.join(local, "facts/deleted.md")),
+      /ENOENT/,
+    );
   } finally {
     await rm(remote, { recursive: true, force: true });
     await rm(local, { recursive: true, force: true });
@@ -2254,22 +2218,20 @@ test("offline changeset rejects transcript changes when transcripts are excluded
             createdAt: new Date().toISOString(),
             sourceId: "laptop",
             includeTranscripts: false,
-            changes: [
-              {
-                type: "upsert",
+            changes: [{
+              type: "upsert",
+              path: "transcripts/session.jsonl",
+              file: {
                 path: "transcripts/session.jsonl",
-                file: {
-                  path: "transcripts/session.jsonl",
-                  sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-                  bytes: transcript.byteLength,
-                  mtimeMs: 0,
-                  contentBase64: transcript.toString("base64"),
-                },
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                bytes: transcript.byteLength,
+                mtimeMs: 0,
+                contentBase64: transcript.toString("base64"),
               },
-            ],
+            }],
           },
         }),
-      /offline sync changeset includeTranscripts is false but contains transcript path/
+      /offline sync changeset includeTranscripts is false but contains transcript path/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2290,18 +2252,16 @@ test("offline snapshot rejects transcript records when transcripts are excluded"
             createdAt: new Date().toISOString(),
             sourceId: "remote",
             includeTranscripts: false,
-            files: [
-              {
-                path: "transcripts/session.jsonl",
-                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-                bytes: transcript.byteLength,
-                mtimeMs: 0,
-                contentBase64: transcript.toString("base64"),
-              },
-            ],
+            files: [{
+              path: "transcripts/session.jsonl",
+              sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+              bytes: transcript.byteLength,
+              mtimeMs: 0,
+              contentBase64: transcript.toString("base64"),
+            }],
           },
         }),
-      /offline sync snapshot includeTranscripts is false but contains transcript path/
+      /offline sync snapshot includeTranscripts is false but contains transcript path/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2323,7 +2283,7 @@ test("offline payloads require explicit includeTranscripts booleans", async () =
             files: [],
           },
         }),
-      /includeTranscripts must be a boolean/
+      /includeTranscripts must be a boolean/,
     );
 
     await assert.rejects(
@@ -2339,7 +2299,7 @@ test("offline payloads require explicit includeTranscripts booleans", async () =
             changes: [],
           },
         }),
-      /includeTranscripts must be a boolean/
+      /includeTranscripts must be a boolean/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2363,18 +2323,16 @@ test("offline payloads reject mtimes outside JavaScript Date range", async () =>
             createdAt: new Date().toISOString(),
             sourceId: "remote",
             includeTranscripts: true,
-            files: [
-              {
-                path: "facts/remote.md",
-                sha256,
-                bytes: content.byteLength,
-                mtimeMs,
-                contentBase64: content.toString("base64"),
-              },
-            ],
+            files: [{
+              path: "facts/remote.md",
+              sha256,
+              bytes: content.byteLength,
+              mtimeMs,
+              contentBase64: content.toString("base64"),
+            }],
           },
         }),
-      /files\[0\]\.mtimeMs must be within JavaScript Date range/
+      /files\[0\]\.mtimeMs must be within JavaScript Date range/,
     );
 
     await assert.rejects(
@@ -2387,22 +2345,20 @@ test("offline payloads reject mtimes outside JavaScript Date range", async () =>
             createdAt: new Date().toISOString(),
             sourceId: "laptop",
             includeTranscripts: true,
-            changes: [
-              {
-                type: "upsert",
+            changes: [{
+              type: "upsert",
+              path: "facts/remote.md",
+              file: {
                 path: "facts/remote.md",
-                file: {
-                  path: "facts/remote.md",
-                  sha256,
-                  bytes: content.byteLength,
-                  mtimeMs,
-                  contentBase64: content.toString("base64"),
-                },
+                sha256,
+                bytes: content.byteLength,
+                mtimeMs,
+                contentBase64: content.toString("base64"),
               },
-            ],
+            }],
           },
         }),
-      /offline sync changeset invalid: changes\[0\]\.file\.mtimeMs must be within JavaScript Date range/
+      /offline sync changeset invalid: changes\[0\]\.file\.mtimeMs must be within JavaScript Date range/,
     );
 
     await assert.rejects(
@@ -2417,7 +2373,7 @@ test("offline payloads reject mtimes outside JavaScript Date range", async () =>
           offset: 0,
           content,
         }),
-      /mtimeMs must be within JavaScript Date range/
+      /mtimeMs must be within JavaScript Date range/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2438,18 +2394,16 @@ test("offline payloads reject excluded internal paths", async () => {
             createdAt: new Date().toISOString(),
             sourceId: "remote",
             includeTranscripts: true,
-            files: [
-              {
-                path: ".secure-store/header.json",
-                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-                bytes: header.byteLength,
-                mtimeMs: 0,
-                contentBase64: header.toString("base64"),
-              },
-            ],
+            files: [{
+              path: ".secure-store/header.json",
+              sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+              bytes: header.byteLength,
+              mtimeMs: 0,
+              contentBase64: header.toString("base64"),
+            }],
           },
         }),
-      /offline sync snapshot contains excluded path: \.secure-store\/header\.json/
+      /offline sync snapshot contains excluded path: \.secure-store\/header\.json/,
     );
 
     await assert.rejects(
@@ -2462,22 +2416,20 @@ test("offline payloads reject excluded internal paths", async () => {
             createdAt: new Date().toISOString(),
             sourceId: "laptop",
             includeTranscripts: true,
-            changes: [
-              {
-                type: "upsert",
+            changes: [{
+              type: "upsert",
+              path: ".secure-store/header.json",
+              file: {
                 path: ".secure-store/header.json",
-                file: {
-                  path: ".secure-store/header.json",
-                  sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-                  bytes: header.byteLength,
-                  mtimeMs: 0,
-                  contentBase64: header.toString("base64"),
-                },
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                bytes: header.byteLength,
+                mtimeMs: 0,
+                contentBase64: header.toString("base64"),
               },
-            ],
+            }],
           },
         }),
-      /offline sync changeset contains excluded path: \.secure-store\/header\.json/
+      /offline sync changeset contains excluded path: \.secure-store\/header\.json/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2510,12 +2462,15 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
     assert.equal(isEncryptedFile(raw), true);
     assert.equal(
       (await storage.readOfflineSyncFile(path.join(root, "facts", "secure.md"))).toString("utf8"),
-      "secret fact"
+      "secret fact",
     );
-    assert.deepEqual(await storage.digestOfflineSyncFile(path.join(root, "facts", "secure.md")), {
-      sha256: createHash("sha256").update("secret fact").digest("hex"),
-      bytes: Buffer.byteLength("secret fact"),
-    });
+    assert.deepEqual(
+      await storage.digestOfflineSyncFile(path.join(root, "facts", "secure.md")),
+      {
+        sha256: createHash("sha256").update("secret fact").digest("hex"),
+        bytes: Buffer.byteLength("secret fact"),
+      },
+    );
 
     const snapshot = await buildOfflineSyncSnapshot({
       root,
@@ -2523,7 +2478,10 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
       includeContent: true,
       readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
     });
-    assert.equal(Buffer.from(snapshot.files[0]?.contentBase64 ?? "", "base64").toString("utf8"), "secret fact");
+    assert.equal(
+      Buffer.from(snapshot.files[0]?.contentBase64 ?? "", "base64").toString("utf8"),
+      "secret fact",
+    );
     assert.equal(snapshot.files[0]?.bytes, Buffer.byteLength("secret fact"));
     const encryptedStat = await stat(path.join(root, "facts", "secure.md"));
     assert.notEqual(snapshot.files[0]?.bytes, encryptedStat.size);
@@ -2539,10 +2497,7 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
       },
     });
     assert.equal(digestReads, 1);
-    assert.deepEqual(
-      fastBase.files,
-      snapshot.files.map(({ contentBase64: _contentBase64, ...file }) => file)
-    );
+    assert.deepEqual(fastBase.files, snapshot.files.map(({ contentBase64: _contentBase64, ...file }) => file));
 
     const sqlite = Buffer.from("streamed durable sqlite content");
     const sqliteSha = createHash("sha256").update(sqlite).digest("hex");
@@ -2582,7 +2537,7 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
     assert.equal(isEncryptedFile(rawSqlite), true);
     assert.equal(
       (await storage.readOfflineSyncFile(path.join(root, "state", "lcm.sqlite"))).toString("utf8"),
-      "streamed durable sqlite content"
+      "streamed durable sqlite content",
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2641,14 +2596,12 @@ test("offline snapshot fast-base does not probe file headers for trusted metadat
     const snapshot = await buildOfflineSyncSnapshotFromBase({
       root,
       sourceId: "remote",
-      baseFiles: [
-        {
-          path: relPath,
-          sha256: createHash("sha256").update(content).digest("hex"),
-          bytes: content.byteLength,
-          mtimeMs: st.mtimeMs,
-        },
-      ],
+      baseFiles: [{
+        path: relPath,
+        sha256: createHash("sha256").update(content).digest("hex"),
+        bytes: content.byteLength,
+        mtimeMs: st.mtimeMs,
+      }],
       baseCapturedAt: new Date(Date.now() + 60_000),
       readFileDigest: async ({ path: targetPath, filePath: targetFilePath }) => {
         assert.equal(targetPath, relPath);
@@ -2684,7 +2637,7 @@ test("offline storage writes invalidate fact hash readiness for rebuild", async 
 
     assert.equal(
       sourceChangeset.changes.some((change) => change.path.startsWith("state/fact-hashes")),
-      true
+      true,
     );
 
     const factChangeset = {
@@ -2724,20 +2677,18 @@ test("offline changeset apply fingerprints only changed paths when current files
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [
-          {
-            type: "upsert",
+        changes: [{
+          type: "upsert",
+          path: "facts/target.md",
+          baseSha256: createHash("sha256").update(oldContent).digest("hex"),
+          file: {
             path: "facts/target.md",
-            baseSha256: createHash("sha256").update(oldContent).digest("hex"),
-            file: {
-              path: "facts/target.md",
-              sha256: createHash("sha256").update(newContent).digest("hex"),
-              bytes: newContent.byteLength,
-              mtimeMs: Date.now(),
-              contentBase64: newContent.toString("base64"),
-            },
+            sha256: createHash("sha256").update(newContent).digest("hex"),
+            bytes: newContent.byteLength,
+            mtimeMs: Date.now(),
+            contentBase64: newContent.toString("base64"),
           },
-        ],
+        }],
       },
       returnCurrentFiles: false,
       readFileDigest: async ({ path: relPath, filePath }) => {
@@ -2779,27 +2730,25 @@ test("offline changeset apply returns full current files by default", async () =
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [
-          {
-            type: "upsert",
+        changes: [{
+          type: "upsert",
+          path: "facts/target.md",
+          baseSha256: createHash("sha256").update(oldContent).digest("hex"),
+          file: {
             path: "facts/target.md",
-            baseSha256: createHash("sha256").update(oldContent).digest("hex"),
-            file: {
-              path: "facts/target.md",
-              sha256: createHash("sha256").update(newContent).digest("hex"),
-              bytes: newContent.byteLength,
-              mtimeMs: Date.now(),
-              contentBase64: newContent.toString("base64"),
-            },
+            sha256: createHash("sha256").update(newContent).digest("hex"),
+            bytes: newContent.byteLength,
+            mtimeMs: Date.now(),
+            contentBase64: newContent.toString("base64"),
           },
-        ],
+        }],
       },
     });
 
     assert.equal(apply.currentFilesComplete, undefined);
     assert.deepEqual(
       apply.currentFiles.map((entry) => entry.path),
-      ["facts/target.md", "facts/unrelated.md"]
+      ["facts/target.md", "facts/unrelated.md"],
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2816,41 +2765,37 @@ test("offline changeset apply refreshes full current files when caller supplied 
 
     const apply = await applyOfflineSyncChangeset({
       root,
-      currentFiles: [
-        {
-          path: "facts/target.md",
-          sha256: createHash("sha256").update(oldContent).digest("hex"),
-          bytes: oldContent.byteLength,
-          mtimeMs: 0,
-        },
-      ],
+      currentFiles: [{
+        path: "facts/target.md",
+        sha256: createHash("sha256").update(oldContent).digest("hex"),
+        bytes: oldContent.byteLength,
+        mtimeMs: 0,
+      }],
       changeset: {
         format: "remnic.offline-sync.changeset.v1",
         schemaVersion: 1,
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [
-          {
-            type: "upsert",
+        changes: [{
+          type: "upsert",
+          path: "facts/target.md",
+          baseSha256: createHash("sha256").update(oldContent).digest("hex"),
+          file: {
             path: "facts/target.md",
-            baseSha256: createHash("sha256").update(oldContent).digest("hex"),
-            file: {
-              path: "facts/target.md",
-              sha256: createHash("sha256").update(newContent).digest("hex"),
-              bytes: newContent.byteLength,
-              mtimeMs: Date.now(),
-              contentBase64: newContent.toString("base64"),
-            },
+            sha256: createHash("sha256").update(newContent).digest("hex"),
+            bytes: newContent.byteLength,
+            mtimeMs: Date.now(),
+            contentBase64: newContent.toString("base64"),
           },
-        ],
+        }],
       },
     });
 
     assert.equal(apply.currentFilesComplete, undefined);
     assert.deepEqual(
       apply.currentFiles.map((entry) => entry.path),
-      ["facts/target.md", "facts/unrelated.md"]
+      ["facts/target.md", "facts/unrelated.md"],
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2917,28 +2862,24 @@ test("offline snapshot apply does not churn metadata for equivalent mtimes", asy
 
     const pull = await applyOfflineSyncSnapshot({
       root,
-      currentFiles: [
-        {
-          path: relPath,
-          sha256,
-          bytes: content.byteLength,
-          mtimeMs: before.mtimeMs,
-        },
-      ],
+      currentFiles: [{
+        path: relPath,
+        sha256,
+        bytes: content.byteLength,
+        mtimeMs: before.mtimeMs,
+      }],
       snapshot: {
         format: "remnic.offline-sync.snapshot.v1",
         schemaVersion: 1,
         createdAt: new Date().toISOString(),
         sourceId: "remote",
         includeTranscripts: true,
-        files: [
-          {
-            path: relPath,
-            sha256,
-            bytes: content.byteLength,
-            mtimeMs: incomingMtimeMs,
-          },
-        ],
+        files: [{
+          path: relPath,
+          sha256,
+          bytes: content.byteLength,
+          mtimeMs: incomingMtimeMs,
+        }],
       },
       baseFiles: [],
     });
@@ -2947,14 +2888,12 @@ test("offline snapshot apply does not churn metadata for equivalent mtimes", asy
     assert.equal(pull.upserted, 0);
     assert.equal(pull.deleted, 0);
     assert.equal(pull.skipped, 1);
-    assert.deepEqual(pull.nextBaseFiles, [
-      {
-        path: relPath,
-        sha256,
-        bytes: content.byteLength,
-        mtimeMs: incomingMtimeMs,
-      },
-    ]);
+    assert.deepEqual(pull.nextBaseFiles, [{
+      path: relPath,
+      sha256,
+      bytes: content.byteLength,
+      mtimeMs: incomingMtimeMs,
+    }]);
     assert.equal(after.mtimeMs, before.mtimeMs);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2977,7 +2916,7 @@ test("offline changeset validation reports client input errors with an offline s
             changes: [{ type: "delete", path: "../escape", baseSha256: "nope" }],
           },
         }),
-      /offline sync changeset invalid:/
+      /offline sync changeset invalid:/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -3054,20 +2993,14 @@ test("apply-side local enumeration sees node-local state via excludeNodeLocalSta
     await write(root, "facts/a.md", "alpha");
     await write(root, "state/lcm.sqlite", "live db");
     const pushView = await buildOfflineSyncSnapshot({ root, sourceId: "local", includeContent: false });
-    assert.deepEqual(
-      pushView.files.map((f) => f.path),
-      ["facts/a.md"]
-    );
+    assert.deepEqual(pushView.files.map((f) => f.path), ["facts/a.md"]);
     const applyView = await buildOfflineSyncSnapshot({
       root,
       sourceId: "local",
       includeContent: false,
       excludeNodeLocalState: false,
     });
-    assert.deepEqual(
-      applyView.files.map((f) => f.path),
-      ["facts/a.md", "state/lcm.sqlite"]
-    );
+    assert.deepEqual(applyView.files.map((f) => f.path), ["facts/a.md", "state/lcm.sqlite"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3124,10 +3057,7 @@ test("buildOfflineSyncChangesetFromSnapshot honors excludePaths for 3-strikes sk
       excludePaths: ["facts/huge.md"],
     });
     // The skipped file must not ride the inline changeset path.
-    assert.deepEqual(
-      changeset.changes.map((c) => c.path),
-      ["facts/a.md"]
-    );
+    assert.deepEqual(changeset.changes.map((c) => c.path), ["facts/a.md"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3146,10 +3076,7 @@ test("buildOfflineSyncSnapshotForPaths deduplicates repeated request paths (#178
     // Duplicate entries in paths[] must yield exactly one record —
     // the seen-set add was dropped in an earlier refactor (Cursor
     // review, PR #1793) and produced duplicate file records.
-    assert.deepEqual(
-      snapshot.files.map((file) => file.path),
-      ["facts/a.md"]
-    );
+    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3211,10 +3138,7 @@ test("buildOfflineSyncSnapshot honors userExcludeRegexps additively over default
       userExcludeRegexps: compileOfflineSyncExcludeGlobs(["notes/**"]),
     });
 
-    assert.deepEqual(
-      snapshot.files.map((file) => file.path),
-      ["facts/a.md"]
-    );
+    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3241,10 +3165,7 @@ test("buildOfflineSyncSnapshotFromBase honors userExcludeRegexps on the fast-bas
       userExcludeRegexps: compileOfflineSyncExcludeGlobs(["notes/**"]),
     });
 
-    assert.deepEqual(
-      next.files.map((file) => file.path),
-      ["facts/a.md"]
-    );
+    assert.deepEqual(next.files.map((file) => file.path), ["facts/a.md"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -80,7 +80,7 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
         "state/last_qmd_recall.json",
         "state/last_recall.json",
         "transcripts/session.jsonl",
-      ],
+      ]
     );
     const binary = snapshot.files.find((file) => file.path === "assets/blob.bin");
     assert.equal(Buffer.from(binary?.contentBase64 ?? "", "base64")[3], 255);
@@ -103,7 +103,7 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
         "state/last_intent.json",
         "state/last_qmd_recall.json",
         "state/last_recall.json",
-      ],
+      ]
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -208,7 +208,6 @@ test("offline apply relays known deletion metadata when the target is already ab
   }
 });
 
-
 test("offline sync excludes the internal Remnic tree from snapshots and file transfer", async () => {
   const root = await tempDir("remnic-offline-internal-state");
   const internalPaths = [
@@ -233,37 +232,43 @@ test("offline sync excludes the internal Remnic tree from snapshots and file tra
       sourceId: "local",
       includeContent: false,
     });
-    assert.deepEqual(snapshot.files.map((file) => file.path), [corpusPath]);
+    assert.deepEqual(
+      snapshot.files.map((file) => file.path),
+      [corpusPath]
+    );
 
     await assert.rejects(
-      () => buildOfflineSyncSnapshotForPaths({
-        root,
-        sourceId: "local",
-        paths: [internalPaths[0]!],
-      }),
-      /offline sync snapshot path is excluded/,
+      () =>
+        buildOfflineSyncSnapshotForPaths({
+          root,
+          sourceId: "local",
+          paths: [internalPaths[0]!],
+        }),
+      /offline sync snapshot path is excluded/
     );
     await assert.rejects(
-      () => readOfflineSyncFileContentChunk({
-        root,
-        path: internalPaths[0]!,
-      }),
-      /offline sync file content path is excluded/,
+      () =>
+        readOfflineSyncFileContentChunk({
+          root,
+          path: internalPaths[0]!,
+        }),
+      /offline sync file content path is excluded/
     );
 
     const cursorContent = Buffer.from(internalPaths[0]!);
     await assert.rejects(
-      () => applyOfflineSyncFileContentChunk({
-        root,
-        sourceId: "peer",
-        path: internalPaths[0]!,
-        sha256: createHash("sha256").update(cursorContent).digest("hex"),
-        bytes: cursorContent.length,
-        mtimeMs: Date.now(),
-        offset: 0,
-        content: cursorContent,
-      }),
-      /offline sync file content path is excluded/,
+      () =>
+        applyOfflineSyncFileContentChunk({
+          root,
+          sourceId: "peer",
+          path: internalPaths[0]!,
+          sha256: createHash("sha256").update(cursorContent).digest("hex"),
+          bytes: cursorContent.length,
+          mtimeMs: Date.now(),
+          offset: 0,
+          content: cursorContent,
+        }),
+      /offline sync file content path is excluded/
     );
     const writes: string[] = [];
     const applyResult = await applyOfflineSyncSnapshot({
@@ -274,13 +279,15 @@ test("offline sync excludes the internal Remnic tree from snapshots and file tra
         createdAt: new Date().toISOString(),
         sourceId: "peer",
         includeTranscripts: true,
-        files: [{
-          path: internalPaths[0]!,
-          sha256: createHash("sha256").update(cursorContent).digest("hex"),
-          bytes: cursorContent.length,
-          mtimeMs: Date.now(),
-          contentBase64: cursorContent.toString("base64"),
-        }],
+        files: [
+          {
+            path: internalPaths[0]!,
+            sha256: createHash("sha256").update(cursorContent).digest("hex"),
+            bytes: cursorContent.length,
+            mtimeMs: Date.now(),
+            contentBase64: cursorContent.toString("base64"),
+          },
+        ],
       },
       baseFiles: [],
       currentFiles: [],
@@ -320,7 +327,7 @@ test("offline snapshot abort signal stops filesystem snapshot work", async () =>
           };
         },
       }),
-      /offline sync request aborted/,
+      /offline sync request aborted/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -342,20 +349,26 @@ test("offline sync includes retrieval debug snapshots for full-fidelity offline 
       includeContent: true,
     });
 
-    assert.deepEqual(snapshot.files.map((file) => file.path), [
-      "facts/a.md",
-      "state/last_graph_recall.json",
-      "state/last_intent.json",
-      "state/last_qmd_recall.json",
-      "state/last_recall.json",
-    ]);
+    assert.deepEqual(
+      snapshot.files.map((file) => file.path),
+      [
+        "facts/a.md",
+        "state/last_graph_recall.json",
+        "state/last_intent.json",
+        "state/last_qmd_recall.json",
+        "state/last_recall.json",
+      ]
+    );
     const focused = await buildOfflineSyncSnapshotForPaths({
       root,
       sourceId: "remote",
       paths: ["state/last_graph_recall.json"],
       includeContent: true,
     });
-    assert.deepEqual(focused.files.map((file) => file.path), ["state/last_graph_recall.json"]);
+    assert.deepEqual(
+      focused.files.map((file) => file.path),
+      ["state/last_graph_recall.json"]
+    );
     const chunk = await readOfflineSyncFileContentChunk({
       root,
       path: "state/last_graph_recall.json",
@@ -366,12 +379,14 @@ test("offline sync includes retrieval debug snapshots for full-fidelity offline 
     const pull = await applyOfflineSyncSnapshot({
       root,
       snapshot,
-      baseFiles: [{
-        path: "state/last_graph_recall.json",
-        sha256: createHash("sha256").update(oldGraph).digest("hex"),
-        bytes: oldGraph.byteLength,
-        mtimeMs: 0,
-      }],
+      baseFiles: [
+        {
+          path: "state/last_graph_recall.json",
+          sha256: createHash("sha256").update(oldGraph).digest("hex"),
+          bytes: oldGraph.byteLength,
+          mtimeMs: 0,
+        },
+      ],
     });
 
     assert.equal(pull.skipped, 5);
@@ -397,7 +412,10 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
       includeContent: true,
     });
 
-    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
+    assert.deepEqual(
+      snapshot.files.map((file) => file.path),
+      ["facts/a.md"]
+    );
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-shm"), true);
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-wal"), true);
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/last_qmd_recall.json"), true);
@@ -412,7 +430,7 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
           paths: ["state/lcm.sqlite"],
           includeContent: true,
         }),
-      /offline sync snapshot path is excluded/,
+      /offline sync snapshot path is excluded/
     );
 
     // Apply-side: the remote is authoritative for lcm.sqlite and we must
@@ -424,24 +442,28 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
       createdAt: new Date().toISOString(),
       sourceId: "remote",
       includeTranscripts: true,
-      files: [{
-        path: "state/lcm.sqlite",
-        sha256: createHash("sha256").update("live db").digest("hex"),
-        bytes: Buffer.byteLength("live db"),
-        mtimeMs: 0,
-        contentBase64: Buffer.from("live db").toString("base64"),
-      }],
+      files: [
+        {
+          path: "state/lcm.sqlite",
+          sha256: createHash("sha256").update("live db").digest("hex"),
+          bytes: Buffer.byteLength("live db"),
+          mtimeMs: 0,
+          contentBase64: Buffer.from("live db").toString("base64"),
+        },
+      ],
     };
     const oldDb = Buffer.from("old live db");
     const pull = await applyOfflineSyncSnapshot({
       root,
       snapshot: remoteSnapshot,
-      baseFiles: [{
-        path: "state/lcm.sqlite",
-        sha256: createHash("sha256").update(oldDb).digest("hex"),
-        bytes: oldDb.byteLength,
-        mtimeMs: 0,
-      }],
+      baseFiles: [
+        {
+          path: "state/lcm.sqlite",
+          sha256: createHash("sha256").update(oldDb).digest("hex"),
+          bytes: oldDb.byteLength,
+          mtimeMs: 0,
+        },
+      ],
     });
 
     // Corrected apply contract (#1793 review): the apply-side view SEES the
@@ -459,14 +481,19 @@ test("offline sync push-side default excludes live LCM sqlite but apply-side sti
     const changeset = await buildOfflineSyncChangeset({
       root,
       sourceId: "laptop",
-      baseFiles: [{
-        path: "facts/a.md",
-        sha256: createHash("sha256").update("alpha").digest("hex"),
-        bytes: Buffer.byteLength("alpha"),
-        mtimeMs: 0,
-      }],
+      baseFiles: [
+        {
+          path: "facts/a.md",
+          sha256: createHash("sha256").update("alpha").digest("hex"),
+          bytes: Buffer.byteLength("alpha"),
+          mtimeMs: 0,
+        },
+      ],
     });
-    assert.deepEqual(changeset.changes.map((change) => change.path), []);
+    assert.deepEqual(
+      changeset.changes.map((change) => change.path),
+      []
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -496,11 +523,7 @@ test("offline sync includes durable runtime state and excludes only transient sy
     await write(root, "state/recall_impressions.jsonl.1", "rotated-impressions");
     // Node-local lifecycle coordination files must never cross offline sync.
     await write(root, "state/memory-lifecycle-ledger.jsonl.lock", "lock");
-    await write(
-      root,
-      "state/memory-lifecycle-ledger.jsonl.pending.d/event-1.json",
-      "pending",
-    );
+    await write(root, "state/memory-lifecycle-ledger.jsonl.pending.d/event-1.json", "pending");
     await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json", "intent");
     await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/entity-mention-index.json", "entities");
     await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/.memory-status-version.log", "version");
@@ -516,34 +539,40 @@ test("offline sync includes durable runtime state and excludes only transient sy
     // push-side enumeration. Durableremote-authoritative runtime files
     // (last_intent.json, .artifact-write-version.log, etc.) and namespace
     // state still ship so the remote can merge.
-    assert.deepEqual(snapshot.files.map((file) => file.path), [
-      "assets/state/fact-hashes.txt",
-      "facts/a.md",
-      "namespaces/generalist-project-origin-6ebeaa54/state/.memory-status-version.log",
-      "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
-      "state/.artifact-write-version.log",
-      "state/.memory-status-version.log",
-      "state/buffer-surprise-ledger.jsonl",
-      "state/buffer.json",
-      "state/embeddings.json",
-      "state/index_time.json",
-      "state/memory-lifecycle-ledger.jsonl",
-      "state/recall_impressions.jsonl",
-    ]);
+    assert.deepEqual(
+      snapshot.files.map((file) => file.path),
+      [
+        "assets/state/fact-hashes.txt",
+        "facts/a.md",
+        "namespaces/generalist-project-origin-6ebeaa54/state/.memory-status-version.log",
+        "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
+        "state/.artifact-write-version.log",
+        "state/.memory-status-version.log",
+        "state/buffer-surprise-ledger.jsonl",
+        "state/buffer.json",
+        "state/embeddings.json",
+        "state/index_time.json",
+        "state/memory-lifecycle-ledger.jsonl",
+        "state/recall_impressions.jsonl",
+      ]
+    );
     const focused = await buildOfflineSyncSnapshotForPaths({
       root,
       sourceId: "remote",
       paths: ["state/memory-lifecycle-ledger.jsonl"],
       includeContent: true,
     });
-    assert.deepEqual(focused.files.map((file) => file.path), ["state/memory-lifecycle-ledger.jsonl"]);
+    assert.deepEqual(
+      focused.files.map((file) => file.path),
+      ["state/memory-lifecycle-ledger.jsonl"]
+    );
     await assert.rejects(
       () =>
         readOfflineSyncFileContentChunk({
           root,
           path: "state/buffer.json.tmp-123-456",
         }),
-      /offline sync file content path is excluded: state\/buffer\.json\.tmp-123-456/,
+      /offline sync file content path is excluded: state\/buffer\.json\.tmp-123-456/
     );
     await assert.rejects(
       () =>
@@ -551,7 +580,7 @@ test("offline sync includes durable runtime state and excludes only transient sy
           root,
           path: "state/memory-lifecycle-ledger.jsonl.lock",
         }),
-      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.lock/,
+      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.lock/
     );
     await assert.rejects(
       () =>
@@ -559,7 +588,7 @@ test("offline sync includes durable runtime state and excludes only transient sy
           root,
           path: "state/memory-lifecycle-ledger.jsonl.pending.d/event-1.json",
         }),
-      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.pending\.d\/event-1\.json/,
+      /offline sync file content path is excluded: state\/memory-lifecycle-ledger\.jsonl\.pending\.d\/event-1\.json/
     );
     const namespaced = await buildOfflineSyncSnapshotForPaths({
       root,
@@ -567,20 +596,23 @@ test("offline sync includes durable runtime state and excludes only transient sy
       paths: ["namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"],
       includeContent: true,
     });
-    assert.deepEqual(namespaced.files.map((file) => file.path), [
-      "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
-    ]);
+    assert.deepEqual(
+      namespaced.files.map((file) => file.path),
+      ["namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"]
+    );
 
     const oldLedger = Buffer.from("old ledger");
     const pull = await applyOfflineSyncSnapshot({
       root,
       snapshot,
-      baseFiles: [{
-        path: "state/memory-lifecycle-ledger.jsonl",
-        sha256: createHash("sha256").update(oldLedger).digest("hex"),
-        bytes: oldLedger.byteLength,
-        mtimeMs: 0,
-      }],
+      baseFiles: [
+        {
+          path: "state/memory-lifecycle-ledger.jsonl",
+          sha256: createHash("sha256").update(oldLedger).digest("hex"),
+          bytes: oldLedger.byteLength,
+          mtimeMs: 0,
+        },
+      ],
     });
 
     // 21 = the 13 durable local-only files plus the 8 node-local excluded
@@ -636,7 +668,10 @@ test("offline snapshot from base avoids rehashing unchanged files", async () => 
     });
 
     assert.equal(readCount, 1);
-    assert.deepEqual(changed.files.map((file) => file.path), ["facts/a.md", "facts/b.md"]);
+    assert.deepEqual(
+      changed.files.map((file) => file.path),
+      ["facts/a.md", "facts/b.md"]
+    );
 
     let digestReadCount = 0;
     const digestSnapshot = await buildOfflineSyncSnapshotFromBase({
@@ -659,7 +694,10 @@ test("offline snapshot from base avoids rehashing unchanged files", async () => 
     });
 
     assert.equal(digestReadCount, 1);
-    assert.deepEqual(digestSnapshot.files.map((file) => file.path), ["facts/a.md", "facts/b.md"]);
+    assert.deepEqual(
+      digestSnapshot.files.map((file) => file.path),
+      ["facts/a.md", "facts/b.md"]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -837,13 +875,15 @@ test("offline snapshot apply preserves incoming mtime for future fast-base reuse
       createdAt: new Date(capturedAtMs).toISOString(),
       sourceId: "remote",
       includeTranscripts: true,
-      files: [{
-        path: "facts/a.md",
-        sha256: createHash("sha256").update(content).digest("hex"),
-        bytes: content.byteLength,
-        mtimeMs: remoteMtimeMs,
-        contentBase64: content.toString("base64"),
-      }],
+      files: [
+        {
+          path: "facts/a.md",
+          sha256: createHash("sha256").update(content).digest("hex"),
+          bytes: content.byteLength,
+          mtimeMs: remoteMtimeMs,
+          contentBase64: content.toString("base64"),
+        },
+      ],
     } as const;
 
     const applied = await applyOfflineSyncSnapshot({
@@ -925,18 +965,22 @@ test("offline changeset rewrites a same-hash file that vanished before mtime ali
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [{
-          type: "upsert",
-          path: file.path,
-          file,
-        }],
+        changes: [
+          {
+            type: "upsert",
+            path: file.path,
+            file,
+          },
+        ],
       },
-      currentFiles: [{
-        path: file.path,
-        sha256: file.sha256,
-        bytes: file.bytes,
-        mtimeMs: file.mtimeMs,
-      }],
+      currentFiles: [
+        {
+          path: file.path,
+          sha256: file.sha256,
+          bytes: file.bytes,
+          mtimeMs: file.mtimeMs,
+        },
+      ],
     });
 
     assert.equal(applied.appliedUpserts, 1);
@@ -1011,12 +1055,9 @@ test("offline sync accepts durable runtime records from older peers", async () =
     assert.equal(await readUtf8(root, "state/buffer.json"), "legacy runtime");
     assert.equal(
       await readUtf8(root, "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"),
-      "legacy runtime",
+      "legacy runtime"
     );
-    await assert.rejects(
-      () => readFile(path.join(root, "state", "buffer.json.tmp-123-456")),
-      /ENOENT/,
-    );
+    await assert.rejects(() => readFile(path.join(root, "state", "buffer.json.tmp-123-456")), /ENOENT/);
 
     const remote = await tempDir("remnic-offline-legacy-runtime-remote");
     try {
@@ -1091,18 +1132,12 @@ test("offline sync accepts durable runtime records from older peers", async () =
       assert.equal(push.appliedUpserts, 4);
       assert.equal(await readUtf8(remote, "facts/a.md"), "alpha");
       assert.equal(await readUtf8(remote, "assets/state/fact-hashes.txt"), "durable asset");
-      assert.equal(
-        await readUtf8(remote, "state/memory-lifecycle-ledger.jsonl"),
-        "legacy runtime",
-      );
+      assert.equal(await readUtf8(remote, "state/memory-lifecycle-ledger.jsonl"), "legacy runtime");
       assert.equal(
         await readUtf8(remote, "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"),
-        "legacy runtime",
+        "legacy runtime"
       );
-      await assert.rejects(
-        () => readFile(path.join(remote, "state", "buffer.json.tmp-123-456")),
-        /ENOENT/,
-      );
+      await assert.rejects(() => readFile(path.join(remote, "state", "buffer.json.tmp-123-456")), /ENOENT/);
     } finally {
       await rm(remote, { recursive: true, force: true });
     }
@@ -1167,7 +1202,7 @@ test("offline sync reads bounded file content chunks with metadata", async () =>
           root,
           path: "state/lcm.sqlite",
         }),
-      /offline sync file content path is excluded: state\/lcm\.sqlite/,
+      /offline sync file content path is excluded: state\/lcm\.sqlite/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -1405,13 +1440,9 @@ test("offline sync stages chunked uploads through storage hooks", async () => {
     assert.equal(uploadEntries.length, 1);
     const uploadChunkEntries = await readdir(path.join(root, ".offline-sync", "uploads", uploadEntries[0]));
     assert.deepEqual(uploadChunkEntries, ["00000000000000000000.part"]);
-    const rawUpload = await readFile(path.join(
-      root,
-      ".offline-sync",
-      "uploads",
-      uploadEntries[0],
-      uploadChunkEntries[0],
-    ));
+    const rawUpload = await readFile(
+      path.join(root, ".offline-sync", "uploads", uploadEntries[0], uploadChunkEntries[0])
+    );
     assert.match(rawUpload.toString("utf-8"), /^ENC:/);
     assert.equal(rawUpload.includes(next.subarray(0, 8)), false);
 
@@ -1479,8 +1510,8 @@ test("offline snapshot apply follows remote deletions for remote-authoritative r
   const root = await tempDir("remnic-offline-runtime-delete");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from("{\"turns\":[]}");
-    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
+    const baseContent = Buffer.from('{"turns":[]}');
+    const localContent = Buffer.from('{"turns":["local"]}');
     await write(root, relPath, localContent);
 
     const pull = await applyOfflineSyncSnapshot({
@@ -1493,21 +1524,20 @@ test("offline snapshot apply follows remote deletions for remote-authoritative r
         includeTranscripts: true,
         files: [],
       },
-      baseFiles: [{
-        path: relPath,
-        sha256: createHash("sha256").update(baseContent).digest("hex"),
-        bytes: baseContent.byteLength,
-        mtimeMs: 0,
-      }],
+      baseFiles: [
+        {
+          path: relPath,
+          sha256: createHash("sha256").update(baseContent).digest("hex"),
+          bytes: baseContent.byteLength,
+          mtimeMs: 0,
+        },
+      ],
     });
 
     assert.equal(pull.deleted, 1);
     assert.equal(pull.conflicts.length, 0);
     assert.deepEqual(pull.nextBaseFiles, []);
-    await assert.rejects(
-      () => readFile(path.join(root, relPath)),
-      /ENOENT/,
-    );
+    await assert.rejects(() => readFile(path.join(root, relPath)), /ENOENT/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1517,7 +1547,7 @@ test("offline snapshot apply preserves new local runtime files without a base", 
   const root = await tempDir("remnic-offline-runtime-local-create");
   try {
     const relPath = "state/buffer.json";
-    const localContent = "{\"turns\":[\"local\"]}";
+    const localContent = '{"turns":["local"]}';
     await write(root, relPath, localContent);
 
     const pull = await applyOfflineSyncSnapshot({
@@ -1590,7 +1620,7 @@ test("offline snapshot apply restores locally deleted remote-authoritative runti
   const root = await tempDir("remnic-offline-runtime-local-delete-restore");
   try {
     const relPath = "state/buffer.json";
-    const remoteContent = Buffer.from("{\"turns\":[]}");
+    const remoteContent = Buffer.from('{"turns":[]}');
     const remoteFile = {
       path: relPath,
       sha256: createHash("sha256").update(remoteContent).digest("hex"),
@@ -1609,23 +1639,27 @@ test("offline snapshot apply restores locally deleted remote-authoritative runti
         includeTranscripts: true,
         files: [remoteFile],
       },
-      baseFiles: [{
-        path: remoteFile.path,
-        sha256: remoteFile.sha256,
-        bytes: remoteFile.bytes,
-        mtimeMs: remoteFile.mtimeMs,
-      }],
+      baseFiles: [
+        {
+          path: remoteFile.path,
+          sha256: remoteFile.sha256,
+          bytes: remoteFile.bytes,
+          mtimeMs: remoteFile.mtimeMs,
+        },
+      ],
     });
 
     assert.equal(pull.upserted, 1);
     assert.equal(pull.conflicts.length, 0);
     assert.equal(await readUtf8(root, relPath), remoteContent.toString("utf-8"));
-    assert.deepEqual(pull.nextBaseFiles, [{
-      path: remoteFile.path,
-      sha256: remoteFile.sha256,
-      bytes: remoteFile.bytes,
-      mtimeMs: remoteFile.mtimeMs,
-    }]);
+    assert.deepEqual(pull.nextBaseFiles, [
+      {
+        path: remoteFile.path,
+        sha256: remoteFile.sha256,
+        bytes: remoteFile.bytes,
+        mtimeMs: remoteFile.mtimeMs,
+      },
+    ]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1691,7 +1725,7 @@ test("offline changeset only carries content for changed local files", async () 
 
     assert.deepEqual(
       changeset.changes.map((change) => change.path),
-      ["facts/changed.md", "facts/empty.md"],
+      ["facts/changed.md", "facts/empty.md"]
     );
     const empty = changeset.changes.find((change) => change.path === "facts/empty.md");
     assert.equal(empty?.type, "upsert");
@@ -1724,7 +1758,10 @@ test("offline changeset can exclude directly pushed large files without reading 
       excludePaths: ["state/lcm.sqlite"],
     });
 
-    assert.deepEqual(changeset.changes.map((change) => change.path), ["facts/small.md"]);
+    assert.deepEqual(
+      changeset.changes.map((change) => change.path),
+      ["facts/small.md"]
+    );
   } finally {
     await rm(local, { recursive: true, force: true });
   }
@@ -1734,8 +1771,8 @@ test("offline changeset skips local edits to remote-authoritative runtime state"
   const local = await tempDir("remnic-offline-runtime-authoritative-push");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from("{\"turns\":[]}");
-    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
+    const baseContent = Buffer.from('{"turns":[]}');
+    const localContent = Buffer.from('{"turns":["local"]}');
     await write(local, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -1751,12 +1788,14 @@ test("offline changeset skips local edits to remote-authoritative runtime state"
     };
 
     assert.equal(
-      (await summarizeOfflineSyncPendingChanges({
-        root: local,
-        sourceId: "laptop",
-        baseFiles: [baseFile],
-      })).total,
-      0,
+      (
+        await summarizeOfflineSyncPendingChanges({
+          root: local,
+          sourceId: "laptop",
+          baseFiles: [baseFile],
+        })
+      ).total,
+      0
     );
 
     const changeset = await buildOfflineSyncChangesetFromSnapshot({
@@ -1775,7 +1814,7 @@ test("offline changeset skips local edits to remote-authoritative runtime state"
         baseFiles: [baseFile],
         currentFiles: [],
       }).total,
-      0,
+      0
     );
     const deleteChangeset = await buildOfflineSyncChangesetFromSnapshot({
       root: local,
@@ -1831,9 +1870,9 @@ test("offline pull lets incoming runtime state replace local runtime conflicts",
   const root = await tempDir("remnic-offline-runtime-authoritative-pull");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from("{\"turns\":[]}");
-    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
-    const remoteContent = Buffer.from("{\"turns\":[\"remote\"]}");
+    const baseContent = Buffer.from('{"turns":[]}');
+    const localContent = Buffer.from('{"turns":["local"]}');
+    const remoteContent = Buffer.from('{"turns":["remote"]}');
     await write(root, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -1865,12 +1904,14 @@ test("offline pull lets incoming runtime state replace local runtime conflicts",
     assert.equal(pull.upserted, 1);
     assert.equal(pull.conflicts.length, 0);
     assert.equal(await readUtf8(root, relPath), remoteContent.toString("utf-8"));
-    assert.deepEqual(pull.nextBaseFiles, [{
-      path: relPath,
-      sha256: incomingFile.sha256,
-      bytes: incomingFile.bytes,
-      mtimeMs: incomingFile.mtimeMs,
-    }]);
+    assert.deepEqual(pull.nextBaseFiles, [
+      {
+        path: relPath,
+        sha256: incomingFile.sha256,
+        bytes: incomingFile.bytes,
+        mtimeMs: incomingFile.mtimeMs,
+      },
+    ]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1880,8 +1921,8 @@ test("offline pull skips local runtime drift when remote still matches base", as
   const root = await tempDir("remnic-offline-runtime-authoritative-base");
   try {
     const relPath = "state/buffer.json";
-    const baseContent = Buffer.from("{\"turns\":[]}");
-    const localContent = Buffer.from("{\"turns\":[\"local\"]}");
+    const baseContent = Buffer.from('{"turns":[]}');
+    const localContent = Buffer.from('{"turns":["local"]}');
     await write(root, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -1917,9 +1958,9 @@ test("offline pull treats last intent as remote-authoritative runtime state", as
   const root = await tempDir("remnic-offline-runtime-last-intent");
   try {
     const relPath = "state/last_intent.json";
-    const baseContent = Buffer.from("{\"intent\":\"base\"}");
-    const localContent = Buffer.from("{\"intent\":\"local\"}");
-    const remoteContent = Buffer.from("{\"intent\":\"remote\"}");
+    const baseContent = Buffer.from('{"intent":"base"}');
+    const localContent = Buffer.from('{"intent":"local"}');
+    const remoteContent = Buffer.from('{"intent":"remote"}');
     await write(root, relPath, localContent);
     const baseFile = {
       path: relPath,
@@ -1985,9 +2026,7 @@ test("offline pull applies snapshots with content only for remote-changed files"
       paths: ["facts/shared.md"],
       includeContent: true,
     });
-    const contentByPath = new Map(
-      changedContent.files.map((file) => [file.path, file.contentBase64]),
-    );
+    const contentByPath = new Map(changedContent.files.map((file) => [file.path, file.contentBase64]));
     const hydrated = {
       ...metadataOnly,
       files: metadataOnly.files.map((file) => {
@@ -2168,10 +2207,7 @@ test("offline pull applies remote deletion when the local file is unchanged", as
     });
 
     assert.equal(secondPull.deleted, 1);
-    await assert.rejects(
-      () => readFile(path.join(local, "facts/deleted.md")),
-      /ENOENT/,
-    );
+    await assert.rejects(() => readFile(path.join(local, "facts/deleted.md")), /ENOENT/);
   } finally {
     await rm(remote, { recursive: true, force: true });
     await rm(local, { recursive: true, force: true });
@@ -2218,20 +2254,22 @@ test("offline changeset rejects transcript changes when transcripts are excluded
             createdAt: new Date().toISOString(),
             sourceId: "laptop",
             includeTranscripts: false,
-            changes: [{
-              type: "upsert",
-              path: "transcripts/session.jsonl",
-              file: {
+            changes: [
+              {
+                type: "upsert",
                 path: "transcripts/session.jsonl",
-                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-                bytes: transcript.byteLength,
-                mtimeMs: 0,
-                contentBase64: transcript.toString("base64"),
+                file: {
+                  path: "transcripts/session.jsonl",
+                  sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                  bytes: transcript.byteLength,
+                  mtimeMs: 0,
+                  contentBase64: transcript.toString("base64"),
+                },
               },
-            }],
+            ],
           },
         }),
-      /offline sync changeset includeTranscripts is false but contains transcript path/,
+      /offline sync changeset includeTranscripts is false but contains transcript path/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2252,16 +2290,18 @@ test("offline snapshot rejects transcript records when transcripts are excluded"
             createdAt: new Date().toISOString(),
             sourceId: "remote",
             includeTranscripts: false,
-            files: [{
-              path: "transcripts/session.jsonl",
-              sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-              bytes: transcript.byteLength,
-              mtimeMs: 0,
-              contentBase64: transcript.toString("base64"),
-            }],
+            files: [
+              {
+                path: "transcripts/session.jsonl",
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                bytes: transcript.byteLength,
+                mtimeMs: 0,
+                contentBase64: transcript.toString("base64"),
+              },
+            ],
           },
         }),
-      /offline sync snapshot includeTranscripts is false but contains transcript path/,
+      /offline sync snapshot includeTranscripts is false but contains transcript path/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2283,7 +2323,7 @@ test("offline payloads require explicit includeTranscripts booleans", async () =
             files: [],
           },
         }),
-      /includeTranscripts must be a boolean/,
+      /includeTranscripts must be a boolean/
     );
 
     await assert.rejects(
@@ -2299,7 +2339,7 @@ test("offline payloads require explicit includeTranscripts booleans", async () =
             changes: [],
           },
         }),
-      /includeTranscripts must be a boolean/,
+      /includeTranscripts must be a boolean/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2323,16 +2363,18 @@ test("offline payloads reject mtimes outside JavaScript Date range", async () =>
             createdAt: new Date().toISOString(),
             sourceId: "remote",
             includeTranscripts: true,
-            files: [{
-              path: "facts/remote.md",
-              sha256,
-              bytes: content.byteLength,
-              mtimeMs,
-              contentBase64: content.toString("base64"),
-            }],
+            files: [
+              {
+                path: "facts/remote.md",
+                sha256,
+                bytes: content.byteLength,
+                mtimeMs,
+                contentBase64: content.toString("base64"),
+              },
+            ],
           },
         }),
-      /files\[0\]\.mtimeMs must be within JavaScript Date range/,
+      /files\[0\]\.mtimeMs must be within JavaScript Date range/
     );
 
     await assert.rejects(
@@ -2345,20 +2387,22 @@ test("offline payloads reject mtimes outside JavaScript Date range", async () =>
             createdAt: new Date().toISOString(),
             sourceId: "laptop",
             includeTranscripts: true,
-            changes: [{
-              type: "upsert",
-              path: "facts/remote.md",
-              file: {
+            changes: [
+              {
+                type: "upsert",
                 path: "facts/remote.md",
-                sha256,
-                bytes: content.byteLength,
-                mtimeMs,
-                contentBase64: content.toString("base64"),
+                file: {
+                  path: "facts/remote.md",
+                  sha256,
+                  bytes: content.byteLength,
+                  mtimeMs,
+                  contentBase64: content.toString("base64"),
+                },
               },
-            }],
+            ],
           },
         }),
-      /offline sync changeset invalid: changes\[0\]\.file\.mtimeMs must be within JavaScript Date range/,
+      /offline sync changeset invalid: changes\[0\]\.file\.mtimeMs must be within JavaScript Date range/
     );
 
     await assert.rejects(
@@ -2373,7 +2417,7 @@ test("offline payloads reject mtimes outside JavaScript Date range", async () =>
           offset: 0,
           content,
         }),
-      /mtimeMs must be within JavaScript Date range/,
+      /mtimeMs must be within JavaScript Date range/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2394,16 +2438,18 @@ test("offline payloads reject excluded internal paths", async () => {
             createdAt: new Date().toISOString(),
             sourceId: "remote",
             includeTranscripts: true,
-            files: [{
-              path: ".secure-store/header.json",
-              sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-              bytes: header.byteLength,
-              mtimeMs: 0,
-              contentBase64: header.toString("base64"),
-            }],
+            files: [
+              {
+                path: ".secure-store/header.json",
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                bytes: header.byteLength,
+                mtimeMs: 0,
+                contentBase64: header.toString("base64"),
+              },
+            ],
           },
         }),
-      /offline sync snapshot contains excluded path: \.secure-store\/header\.json/,
+      /offline sync snapshot contains excluded path: \.secure-store\/header\.json/
     );
 
     await assert.rejects(
@@ -2416,20 +2462,22 @@ test("offline payloads reject excluded internal paths", async () => {
             createdAt: new Date().toISOString(),
             sourceId: "laptop",
             includeTranscripts: true,
-            changes: [{
-              type: "upsert",
-              path: ".secure-store/header.json",
-              file: {
+            changes: [
+              {
+                type: "upsert",
                 path: ".secure-store/header.json",
-                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-                bytes: header.byteLength,
-                mtimeMs: 0,
-                contentBase64: header.toString("base64"),
+                file: {
+                  path: ".secure-store/header.json",
+                  sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                  bytes: header.byteLength,
+                  mtimeMs: 0,
+                  contentBase64: header.toString("base64"),
+                },
               },
-            }],
+            ],
           },
         }),
-      /offline sync changeset contains excluded path: \.secure-store\/header\.json/,
+      /offline sync changeset contains excluded path: \.secure-store\/header\.json/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2462,15 +2510,12 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
     assert.equal(isEncryptedFile(raw), true);
     assert.equal(
       (await storage.readOfflineSyncFile(path.join(root, "facts", "secure.md"))).toString("utf8"),
-      "secret fact",
+      "secret fact"
     );
-    assert.deepEqual(
-      await storage.digestOfflineSyncFile(path.join(root, "facts", "secure.md")),
-      {
-        sha256: createHash("sha256").update("secret fact").digest("hex"),
-        bytes: Buffer.byteLength("secret fact"),
-      },
-    );
+    assert.deepEqual(await storage.digestOfflineSyncFile(path.join(root, "facts", "secure.md")), {
+      sha256: createHash("sha256").update("secret fact").digest("hex"),
+      bytes: Buffer.byteLength("secret fact"),
+    });
 
     const snapshot = await buildOfflineSyncSnapshot({
       root,
@@ -2478,10 +2523,7 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
       includeContent: true,
       readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
     });
-    assert.equal(
-      Buffer.from(snapshot.files[0]?.contentBase64 ?? "", "base64").toString("utf8"),
-      "secret fact",
-    );
+    assert.equal(Buffer.from(snapshot.files[0]?.contentBase64 ?? "", "base64").toString("utf8"), "secret fact");
     assert.equal(snapshot.files[0]?.bytes, Buffer.byteLength("secret fact"));
     const encryptedStat = await stat(path.join(root, "facts", "secure.md"));
     assert.notEqual(snapshot.files[0]?.bytes, encryptedStat.size);
@@ -2497,7 +2539,10 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
       },
     });
     assert.equal(digestReads, 1);
-    assert.deepEqual(fastBase.files, snapshot.files.map(({ contentBase64: _contentBase64, ...file }) => file));
+    assert.deepEqual(
+      fastBase.files,
+      snapshot.files.map(({ contentBase64: _contentBase64, ...file }) => file)
+    );
 
     const sqlite = Buffer.from("streamed durable sqlite content");
     const sqliteSha = createHash("sha256").update(sqlite).digest("hex");
@@ -2537,7 +2582,7 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
     assert.equal(isEncryptedFile(rawSqlite), true);
     assert.equal(
       (await storage.readOfflineSyncFile(path.join(root, "state", "lcm.sqlite"))).toString("utf8"),
-      "streamed durable sqlite content",
+      "streamed durable sqlite content"
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2596,12 +2641,14 @@ test("offline snapshot fast-base does not probe file headers for trusted metadat
     const snapshot = await buildOfflineSyncSnapshotFromBase({
       root,
       sourceId: "remote",
-      baseFiles: [{
-        path: relPath,
-        sha256: createHash("sha256").update(content).digest("hex"),
-        bytes: content.byteLength,
-        mtimeMs: st.mtimeMs,
-      }],
+      baseFiles: [
+        {
+          path: relPath,
+          sha256: createHash("sha256").update(content).digest("hex"),
+          bytes: content.byteLength,
+          mtimeMs: st.mtimeMs,
+        },
+      ],
       baseCapturedAt: new Date(Date.now() + 60_000),
       readFileDigest: async ({ path: targetPath, filePath: targetFilePath }) => {
         assert.equal(targetPath, relPath);
@@ -2637,7 +2684,7 @@ test("offline storage writes invalidate fact hash readiness for rebuild", async 
 
     assert.equal(
       sourceChangeset.changes.some((change) => change.path.startsWith("state/fact-hashes")),
-      true,
+      true
     );
 
     const factChangeset = {
@@ -2677,18 +2724,20 @@ test("offline changeset apply fingerprints only changed paths when current files
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [{
-          type: "upsert",
-          path: "facts/target.md",
-          baseSha256: createHash("sha256").update(oldContent).digest("hex"),
-          file: {
+        changes: [
+          {
+            type: "upsert",
             path: "facts/target.md",
-            sha256: createHash("sha256").update(newContent).digest("hex"),
-            bytes: newContent.byteLength,
-            mtimeMs: Date.now(),
-            contentBase64: newContent.toString("base64"),
+            baseSha256: createHash("sha256").update(oldContent).digest("hex"),
+            file: {
+              path: "facts/target.md",
+              sha256: createHash("sha256").update(newContent).digest("hex"),
+              bytes: newContent.byteLength,
+              mtimeMs: Date.now(),
+              contentBase64: newContent.toString("base64"),
+            },
           },
-        }],
+        ],
       },
       returnCurrentFiles: false,
       readFileDigest: async ({ path: relPath, filePath }) => {
@@ -2730,25 +2779,27 @@ test("offline changeset apply returns full current files by default", async () =
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [{
-          type: "upsert",
-          path: "facts/target.md",
-          baseSha256: createHash("sha256").update(oldContent).digest("hex"),
-          file: {
+        changes: [
+          {
+            type: "upsert",
             path: "facts/target.md",
-            sha256: createHash("sha256").update(newContent).digest("hex"),
-            bytes: newContent.byteLength,
-            mtimeMs: Date.now(),
-            contentBase64: newContent.toString("base64"),
+            baseSha256: createHash("sha256").update(oldContent).digest("hex"),
+            file: {
+              path: "facts/target.md",
+              sha256: createHash("sha256").update(newContent).digest("hex"),
+              bytes: newContent.byteLength,
+              mtimeMs: Date.now(),
+              contentBase64: newContent.toString("base64"),
+            },
           },
-        }],
+        ],
       },
     });
 
     assert.equal(apply.currentFilesComplete, undefined);
     assert.deepEqual(
       apply.currentFiles.map((entry) => entry.path),
-      ["facts/target.md", "facts/unrelated.md"],
+      ["facts/target.md", "facts/unrelated.md"]
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2765,37 +2816,41 @@ test("offline changeset apply refreshes full current files when caller supplied 
 
     const apply = await applyOfflineSyncChangeset({
       root,
-      currentFiles: [{
-        path: "facts/target.md",
-        sha256: createHash("sha256").update(oldContent).digest("hex"),
-        bytes: oldContent.byteLength,
-        mtimeMs: 0,
-      }],
+      currentFiles: [
+        {
+          path: "facts/target.md",
+          sha256: createHash("sha256").update(oldContent).digest("hex"),
+          bytes: oldContent.byteLength,
+          mtimeMs: 0,
+        },
+      ],
       changeset: {
         format: "remnic.offline-sync.changeset.v1",
         schemaVersion: 1,
         createdAt: new Date().toISOString(),
         sourceId: "laptop",
         includeTranscripts: true,
-        changes: [{
-          type: "upsert",
-          path: "facts/target.md",
-          baseSha256: createHash("sha256").update(oldContent).digest("hex"),
-          file: {
+        changes: [
+          {
+            type: "upsert",
             path: "facts/target.md",
-            sha256: createHash("sha256").update(newContent).digest("hex"),
-            bytes: newContent.byteLength,
-            mtimeMs: Date.now(),
-            contentBase64: newContent.toString("base64"),
+            baseSha256: createHash("sha256").update(oldContent).digest("hex"),
+            file: {
+              path: "facts/target.md",
+              sha256: createHash("sha256").update(newContent).digest("hex"),
+              bytes: newContent.byteLength,
+              mtimeMs: Date.now(),
+              contentBase64: newContent.toString("base64"),
+            },
           },
-        }],
+        ],
       },
     });
 
     assert.equal(apply.currentFilesComplete, undefined);
     assert.deepEqual(
       apply.currentFiles.map((entry) => entry.path),
-      ["facts/target.md", "facts/unrelated.md"],
+      ["facts/target.md", "facts/unrelated.md"]
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2862,24 +2917,28 @@ test("offline snapshot apply does not churn metadata for equivalent mtimes", asy
 
     const pull = await applyOfflineSyncSnapshot({
       root,
-      currentFiles: [{
-        path: relPath,
-        sha256,
-        bytes: content.byteLength,
-        mtimeMs: before.mtimeMs,
-      }],
+      currentFiles: [
+        {
+          path: relPath,
+          sha256,
+          bytes: content.byteLength,
+          mtimeMs: before.mtimeMs,
+        },
+      ],
       snapshot: {
         format: "remnic.offline-sync.snapshot.v1",
         schemaVersion: 1,
         createdAt: new Date().toISOString(),
         sourceId: "remote",
         includeTranscripts: true,
-        files: [{
-          path: relPath,
-          sha256,
-          bytes: content.byteLength,
-          mtimeMs: incomingMtimeMs,
-        }],
+        files: [
+          {
+            path: relPath,
+            sha256,
+            bytes: content.byteLength,
+            mtimeMs: incomingMtimeMs,
+          },
+        ],
       },
       baseFiles: [],
     });
@@ -2888,12 +2947,14 @@ test("offline snapshot apply does not churn metadata for equivalent mtimes", asy
     assert.equal(pull.upserted, 0);
     assert.equal(pull.deleted, 0);
     assert.equal(pull.skipped, 1);
-    assert.deepEqual(pull.nextBaseFiles, [{
-      path: relPath,
-      sha256,
-      bytes: content.byteLength,
-      mtimeMs: incomingMtimeMs,
-    }]);
+    assert.deepEqual(pull.nextBaseFiles, [
+      {
+        path: relPath,
+        sha256,
+        bytes: content.byteLength,
+        mtimeMs: incomingMtimeMs,
+      },
+    ]);
     assert.equal(after.mtimeMs, before.mtimeMs);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2916,7 +2977,7 @@ test("offline changeset validation reports client input errors with an offline s
             changes: [{ type: "delete", path: "../escape", baseSha256: "nope" }],
           },
         }),
-      /offline sync changeset invalid:/,
+      /offline sync changeset invalid:/
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -2993,14 +3054,20 @@ test("apply-side local enumeration sees node-local state via excludeNodeLocalSta
     await write(root, "facts/a.md", "alpha");
     await write(root, "state/lcm.sqlite", "live db");
     const pushView = await buildOfflineSyncSnapshot({ root, sourceId: "local", includeContent: false });
-    assert.deepEqual(pushView.files.map((f) => f.path), ["facts/a.md"]);
+    assert.deepEqual(
+      pushView.files.map((f) => f.path),
+      ["facts/a.md"]
+    );
     const applyView = await buildOfflineSyncSnapshot({
       root,
       sourceId: "local",
       includeContent: false,
       excludeNodeLocalState: false,
     });
-    assert.deepEqual(applyView.files.map((f) => f.path), ["facts/a.md", "state/lcm.sqlite"]);
+    assert.deepEqual(
+      applyView.files.map((f) => f.path),
+      ["facts/a.md", "state/lcm.sqlite"]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3057,7 +3124,10 @@ test("buildOfflineSyncChangesetFromSnapshot honors excludePaths for 3-strikes sk
       excludePaths: ["facts/huge.md"],
     });
     // The skipped file must not ride the inline changeset path.
-    assert.deepEqual(changeset.changes.map((c) => c.path), ["facts/a.md"]);
+    assert.deepEqual(
+      changeset.changes.map((c) => c.path),
+      ["facts/a.md"]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3076,7 +3146,10 @@ test("buildOfflineSyncSnapshotForPaths deduplicates repeated request paths (#178
     // Duplicate entries in paths[] must yield exactly one record —
     // the seen-set add was dropped in an earlier refactor (Cursor
     // review, PR #1793) and produced duplicate file records.
-    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
+    assert.deepEqual(
+      snapshot.files.map((file) => file.path),
+      ["facts/a.md"]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3138,7 +3211,10 @@ test("buildOfflineSyncSnapshot honors userExcludeRegexps additively over default
       userExcludeRegexps: compileOfflineSyncExcludeGlobs(["notes/**"]),
     });
 
-    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
+    assert.deepEqual(
+      snapshot.files.map((file) => file.path),
+      ["facts/a.md"]
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -3165,7 +3241,44 @@ test("buildOfflineSyncSnapshotFromBase honors userExcludeRegexps on the fast-bas
       userExcludeRegexps: compileOfflineSyncExcludeGlobs(["notes/**"]),
     });
 
-    assert.deepEqual(next.files.map((file) => file.path), ["facts/a.md"]);
+    assert.deepEqual(
+      next.files.map((file) => file.path),
+      ["facts/a.md"]
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("plain-file content chunks carry the full-file sha256 (file-content response contract)", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-plain-sha-"));
+  try {
+    const body = Buffer.from(JSON.stringify({ contentHash: "c".repeat(64) }) + "\n");
+    await mkdir(path.join(root, "state"), { recursive: true });
+    await writeFile(path.join(root, "state", "tombstones.jsonl"), body);
+
+    const first = await readOfflineSyncFileContentChunk({
+      root,
+      path: "state/tombstones.jsonl",
+      offset: 0,
+      length: 4,
+    });
+    assert.equal(
+      first.sha256,
+      createHash("sha256").update(body).digest("hex"),
+      "first chunk must carry the whole-file sha the x-remnic-file-sha256 header exposes"
+    );
+    assert.equal(first.bytes, body.length);
+    assert.equal(first.chunkBytes, 4);
+
+    const tail = await readOfflineSyncFileContentChunk({
+      root,
+      path: "state/tombstones.jsonl",
+      offset: body.length - 2,
+      length: 4,
+    });
+    assert.equal(tail.sha256, first.sha256, "every chunk carries the same whole-file sha");
+    assert.equal(tail.chunkBytes, 2);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -1,21 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
-import {
-  lstat,
-  mkdir,
-  open,
-  readdir,
-  readFile,
-  rename,
-  rm,
-  stat,
-  unlink,
-  utimes,
-  writeFile,
-} from "node:fs/promises";
+import { lstat, mkdir, open, readdir, readFile, rename, rm, stat, unlink, utimes, writeFile } from "node:fs/promises";
 import path from "node:path";
-import {
-  DEFAULT_TRANSFER_EXCLUDE_DIRS,
-} from "./transfer/exclusions.js";
+import { DEFAULT_TRANSFER_EXCLUDE_DIRS } from "./transfer/exclusions.js";
 import {
   prepareSafeArchiveRoot,
   resolveSafeArchiveTarget,
@@ -154,7 +140,7 @@ export interface OfflineSyncFileDeleteTarget extends OfflineSyncFileTarget {
 }
 
 export type OfflineSyncRecordDeletionRevision = (
-  target: OfflineSyncFileDeleteTarget & { mtimeMs: number },
+  target: OfflineSyncFileDeleteTarget & { mtimeMs: number }
 ) => Promise<void>;
 
 export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
@@ -208,14 +194,9 @@ const SYNC_INTERNAL_DIR = ".offline-sync";
 const OFFLINE_SYNC_UPLOAD_STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const OFFLINE_SYNC_FAST_BASE_MTIME_TOLERANCE_MS = 1_000;
 const OFFLINE_SYNC_FAST_BASE_CTIME_TOLERANCE_MS = 1;
-const EXCLUDED_FILE_NAMES = new Set([
-  ".sync-state.json",
-]);
+const EXCLUDED_FILE_NAMES = new Set([".sync-state.json"]);
 
-const EXCLUDED_FILE_PREFIXES = [
-  ".remnic-sync.",
-  ".remnic-sync-state.",
-];
+const EXCLUDED_FILE_PREFIXES = [".remnic-sync.", ".remnic-sync-state."];
 
 /**
  * Convert a tiny subset of glob syntax (`*`, `**`, `?`, literal text) into a
@@ -295,12 +276,7 @@ function assertSha256(value: unknown, field: string): string {
 }
 
 function assertNonNegativeInteger(value: unknown, field: string): number {
-  if (
-    typeof value !== "number" ||
-    !Number.isFinite(value) ||
-    !Number.isInteger(value) ||
-    value < 0
-  ) {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
     throw new Error(`${field} must be a non-negative integer`);
   }
   return value;
@@ -349,11 +325,7 @@ function normalizeFileState(input: unknown, fieldPrefix: string): OfflineSyncFil
   };
 }
 
-function normalizeFileRecord(
-  input: unknown,
-  fieldPrefix: string,
-  requireContent: boolean,
-): OfflineSyncFileRecord {
+function normalizeFileRecord(input: unknown, fieldPrefix: string, requireContent: boolean): OfflineSyncFileRecord {
   const state = normalizeFileState(input, fieldPrefix);
   const obj = input as Record<string, unknown>;
   const contentBase64 = obj.contentBase64;
@@ -377,10 +349,7 @@ function normalizeFileStates(input: readonly unknown[] | undefined): OfflineSync
   return input.map((entry, index) => normalizeFileState(entry, `baseFiles[${index}]`));
 }
 
-function normalizeDeletionRevisions(
-  input: unknown,
-  fieldPrefix: string,
-): OfflineSyncDeletionRevision[] | undefined {
+function normalizeDeletionRevisions(input: unknown, fieldPrefix: string): OfflineSyncDeletionRevision[] | undefined {
   if (input === undefined) return undefined;
   if (!Array.isArray(input)) {
     throw new Error(`${fieldPrefix} must be an array`);
@@ -411,19 +380,15 @@ function snapshotBuilderDeletions(options: {
   if (deletions === undefined) return undefined;
   if (deletions.length === 0) return deletions;
   const presentPaths = new Set(options.files.map((file) => file.path.toLowerCase()));
-  const scopedPaths = options.paths
-    ? new Set(options.paths.map((relPath) => relPath.toLowerCase()))
-    : undefined;
-  return deletions.filter((deletion) =>
-    (scopedPaths === undefined || scopedPaths.has(deletion.path.toLowerCase())) &&
-    !presentPaths.has(deletion.path.toLowerCase()) &&
-    !(options.excludeNodeLocalState === false
-      ? shouldExcludeRelPath(deletion.path, options.includeTranscripts)
-      : shouldExcludePushRelPath(
-          deletion.path,
-          options.includeTranscripts,
-          options.userExcludeRegexps,
-        )));
+  const scopedPaths = options.paths ? new Set(options.paths.map((relPath) => relPath.toLowerCase())) : undefined;
+  return deletions.filter(
+    (deletion) =>
+      (scopedPaths === undefined || scopedPaths.has(deletion.path.toLowerCase())) &&
+      !presentPaths.has(deletion.path.toLowerCase()) &&
+      !(options.excludeNodeLocalState === false
+        ? shouldExcludeRelPath(deletion.path, options.includeTranscripts)
+        : shouldExcludePushRelPath(deletion.path, options.includeTranscripts, options.userExcludeRegexps))
+  );
 }
 
 export async function filterOfflineSyncDeletionRevisions(options: {
@@ -435,11 +400,7 @@ export async function filterOfflineSyncDeletionRevisions(options: {
   const deletions = normalizeDeletionRevisions(options.deletions, "deletions");
   if (deletions === undefined) throw new Error("deletions must be an array");
   if (deletions.length === 0) return deletions;
-  const root = await prepareSafeArchiveRoot(
-    path.resolve(options.root),
-    "filterOfflineSyncDeletionRevisions",
-    "root",
-  );
+  const root = await prepareSafeArchiveRoot(path.resolve(options.root), "filterOfflineSyncDeletionRevisions", "root");
   const includeTranscripts = options.includeTranscripts !== false;
   const filtered: OfflineSyncDeletionRevision[] = [];
   for (const deletion of deletions) {
@@ -452,7 +413,7 @@ export async function filterOfflineSyncDeletionRevisions(options: {
       (error: unknown) => {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
         throw error;
-      },
+      }
     );
     if (!present) filtered.push(deletion);
   }
@@ -461,7 +422,7 @@ export async function filterOfflineSyncDeletionRevisions(options: {
 
 export function normalizeOfflineSyncSnapshot(
   input: unknown,
-  options: { requireContent?: boolean } = {},
+  options: { requireContent?: boolean } = {}
 ): OfflineSyncSnapshot {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("offline sync snapshot must be an object");
@@ -480,25 +441,23 @@ export function normalizeOfflineSyncSnapshot(
     throw new Error("offline sync snapshot files must be an array");
   }
   const files = obj.files
-    .map((entry, index) =>
-      normalizeFileRecord(entry, `files[${index}]`, options.requireContent === true))
+    .map((entry, index) => normalizeFileRecord(entry, `files[${index}]`, options.requireContent === true))
     .filter((file) => !shouldIgnoreIncomingRuntimePath(file.path))
     .sort(compareByPath);
-  const deletions = normalizeDeletionRevisions(obj.deletions, "deletions")
-    ?.filter((deletion) => !shouldIgnoreIncomingRuntimePath(deletion.path));
+  const deletions = normalizeDeletionRevisions(obj.deletions, "deletions")?.filter(
+    (deletion) => !shouldIgnoreIncomingRuntimePath(deletion.path)
+  );
   const entries = deletions && deletions.length > 0 ? [...files, ...deletions] : files;
   assertUniquePaths(entries, "offline sync snapshot");
   if (!includeTranscripts) {
-    const transcriptPath = entries
-      .find((entry) => entry.path.split("/")[0] === "transcripts")?.path;
+    const transcriptPath = entries.find((entry) => entry.path.split("/")[0] === "transcripts")?.path;
     if (transcriptPath) {
       throw new Error(
-        `offline sync snapshot includeTranscripts is false but contains transcript path: ${transcriptPath}`,
+        `offline sync snapshot includeTranscripts is false but contains transcript path: ${transcriptPath}`
       );
     }
   }
-  const excludedPath = entries
-    .find((entry) => shouldExcludeRelPath(entry.path, true))?.path;
+  const excludedPath = entries.find((entry) => shouldExcludeRelPath(entry.path, true))?.path;
   if (excludedPath) {
     throw new Error(`offline sync snapshot contains excluded path: ${excludedPath}`);
   }
@@ -513,9 +472,7 @@ export function normalizeOfflineSyncSnapshot(
   };
 }
 
-export function normalizeOfflineSyncChangeset(
-  input: unknown,
-): OfflineSyncChangeset {
+export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChangeset {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("offline sync changeset must be an object");
   }
@@ -532,52 +489,51 @@ export function normalizeOfflineSyncChangeset(
   if (!Array.isArray(obj.changes)) {
     throw new Error("offline sync changeset changes must be an array");
   }
-  const changes = obj.changes.map((entry, index): OfflineSyncChange => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      throw new Error(`changes[${index}] must be an object`);
-    }
-    const change = entry as Record<string, unknown>;
-    const type = change.type;
-    const relPath = normalizeRelativePath(change.path, `changes[${index}].path`);
-    if (type === "upsert") {
-      const file = normalizeFileRecord(
-        change.file,
-        `changes[${index}].file`,
-        true,
-      ) as OfflineSyncFileRecord & { contentBase64: string };
-      if (file.path !== relPath) {
-        throw new Error(`changes[${index}].file.path must match changes[${index}].path`);
+  const changes = obj.changes
+    .map((entry, index): OfflineSyncChange => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error(`changes[${index}] must be an object`);
       }
-      const baseSha256 =
-        change.baseSha256 === undefined
-          ? undefined
-          : assertSha256(change.baseSha256, `changes[${index}].baseSha256`);
-      return {
-        type: "upsert",
-        path: relPath,
-        ...(baseSha256 ? { baseSha256 } : {}),
-        file,
-      };
-    }
-    if (type === "delete") {
-      const mtimeMs = change.mtimeMs === undefined
-        ? undefined
-        : assertOfflineSyncMtimeMs(change.mtimeMs, `changes[${index}].mtimeMs`);
-      return {
-        type: "delete",
-        path: relPath,
-        baseSha256: assertSha256(change.baseSha256, `changes[${index}].baseSha256`),
-        ...(mtimeMs === undefined ? {} : { mtimeMs }),
-      };
-    }
-    throw new Error(`changes[${index}].type must be "upsert" or "delete"`);
-  }).filter((change) => !shouldIgnoreIncomingRuntimePath(change.path));
+      const change = entry as Record<string, unknown>;
+      const type = change.type;
+      const relPath = normalizeRelativePath(change.path, `changes[${index}].path`);
+      if (type === "upsert") {
+        const file = normalizeFileRecord(change.file, `changes[${index}].file`, true) as OfflineSyncFileRecord & {
+          contentBase64: string;
+        };
+        if (file.path !== relPath) {
+          throw new Error(`changes[${index}].file.path must match changes[${index}].path`);
+        }
+        const baseSha256 =
+          change.baseSha256 === undefined ? undefined : assertSha256(change.baseSha256, `changes[${index}].baseSha256`);
+        return {
+          type: "upsert",
+          path: relPath,
+          ...(baseSha256 ? { baseSha256 } : {}),
+          file,
+        };
+      }
+      if (type === "delete") {
+        const mtimeMs =
+          change.mtimeMs === undefined
+            ? undefined
+            : assertOfflineSyncMtimeMs(change.mtimeMs, `changes[${index}].mtimeMs`);
+        return {
+          type: "delete",
+          path: relPath,
+          baseSha256: assertSha256(change.baseSha256, `changes[${index}].baseSha256`),
+          ...(mtimeMs === undefined ? {} : { mtimeMs }),
+        };
+      }
+      throw new Error(`changes[${index}].type must be "upsert" or "delete"`);
+    })
+    .filter((change) => !shouldIgnoreIncomingRuntimePath(change.path));
   assertUniquePaths(changes, "offline sync changeset");
   if (!includeTranscripts) {
     const transcriptPath = changes.find((change) => change.path.split("/")[0] === "transcripts")?.path;
     if (transcriptPath) {
       throw new Error(
-        `offline sync changeset includeTranscripts is false but contains transcript path: ${transcriptPath}`,
+        `offline sync changeset includeTranscripts is false but contains transcript path: ${transcriptPath}`
       );
     }
   }
@@ -626,10 +582,12 @@ function assertUniquePaths(entries: readonly { path: string }[], context: string
 
 export function isInternalRemnicStatePath(relPosix: string): boolean {
   const normalized = relPosix.includes("\\") ? relPosix.replaceAll("\\", "/") : relPosix;
-  return normalized === ".remnic"
-    || normalized.startsWith(".remnic/")
-    || normalized.endsWith("/.remnic")
-    || normalized.includes("/.remnic/");
+  return (
+    normalized === ".remnic" ||
+    normalized.startsWith(".remnic/") ||
+    normalized.endsWith("/.remnic") ||
+    normalized.includes("/.remnic/")
+  );
 }
 
 function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): boolean {
@@ -662,7 +620,7 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
 function shouldExcludePushRelPath(
   relPosix: string,
   includeTranscripts: boolean,
-  userExcludeRegexps?: readonly RegExp[],
+  userExcludeRegexps?: readonly RegExp[]
 ): boolean {
   if (shouldExcludeRelPath(relPosix, includeTranscripts)) return true;
   // Issue #1786: node-local runtime state (live sqlite, derived indexes,
@@ -674,8 +632,9 @@ function shouldExcludePushRelPath(
 
 // Precompiled once at module load — this check sits on the hot
 // enumeration path for every walked file (Kilo review, PR #1793).
-const DEFAULT_OFFLINE_SYNC_EXCLUDE_REGEXPS: readonly RegExp[] =
-  DEFAULT_OFFLINE_SYNC_EXCLUDE_GLOBS.map((glob) => globToRegExp(glob));
+const DEFAULT_OFFLINE_SYNC_EXCLUDE_REGEXPS: readonly RegExp[] = DEFAULT_OFFLINE_SYNC_EXCLUDE_GLOBS.map((glob) =>
+  globToRegExp(glob)
+);
 
 function matchesOfflineSyncDefaultExclude(relPosix: string): boolean {
   for (const regexp of DEFAULT_OFFLINE_SYNC_EXCLUDE_REGEXPS) {
@@ -691,9 +650,7 @@ function matchesOfflineSyncDefaultExclude(relPosix: string): boolean {
  * a thrown error as a fatal configuration mistake and refuse to start the
  * sync run rather than silently dropping the bad entry.
  */
-export function compileOfflineSyncExcludeGlobs(
-  globs: readonly unknown[],
-): RegExp[] {
+export function compileOfflineSyncExcludeGlobs(globs: readonly unknown[]): RegExp[] {
   const out: RegExp[] = [];
   for (const entry of globs) {
     if (typeof entry !== "string" || entry.length === 0) {
@@ -713,15 +670,11 @@ export function compileOfflineSyncExcludeGlobs(
 export function parseOfflineSyncExcludes(raw: unknown): string[] {
   if (raw === undefined || raw === null) return [];
   if (!Array.isArray(raw)) {
-    throw new Error(
-      `offlineSyncExcludes must be an array of non-empty glob strings; got ${typeof raw}`,
-    );
+    throw new Error(`offlineSyncExcludes must be an array of non-empty glob strings; got ${typeof raw}`);
   }
   for (const entry of raw) {
     if (typeof entry !== "string" || entry.trim().length === 0) {
-      throw new Error(
-        "offlineSyncExcludes must contain only non-empty glob strings",
-      );
+      throw new Error("offlineSyncExcludes must contain only non-empty glob strings");
     }
   }
   const globs = raw.map((entry) => (entry as string).trim());
@@ -759,10 +712,7 @@ const REMOTE_AUTHORITATIVE_RUNTIME_STATE_FILES = new Set([
   "recall_impressions.jsonl",
 ]);
 
-const ABSENT_INCOMING_RUNTIME_DELETE_FILES = new Set([
-  "lcm.sqlite-shm",
-  "lcm.sqlite-wal",
-]);
+const ABSENT_INCOMING_RUNTIME_DELETE_FILES = new Set(["lcm.sqlite-shm", "lcm.sqlite-wal"]);
 
 export function shouldPreferIncomingOfflineRuntimeFile(relPosix: string): boolean {
   const parts = relPosix.split("/");
@@ -778,7 +728,7 @@ function shouldDeleteAbsentIncomingOfflineRuntimeFile(relPosix: string): boolean
 
 function filterBaseFilesForMode(
   files: readonly OfflineSyncFileState[],
-  includeTranscripts: boolean,
+  includeTranscripts: boolean
 ): OfflineSyncFileState[] {
   return files.filter((file) => !shouldExcludeRelPath(file.path, includeTranscripts));
 }
@@ -786,7 +736,7 @@ function filterBaseFilesForMode(
 function canReuseFastBaseFileState(
   baseEntry: OfflineSyncFileState,
   st: { size: number; mtimeMs: number; ctimeMs: number },
-  baseCapturedAtMs: number | null,
+  baseCapturedAtMs: number | null
 ): boolean {
   if (baseEntry.bytes !== st.size) return false;
   if (Math.abs(baseEntry.mtimeMs - st.mtimeMs) > OFFLINE_SYNC_FAST_BASE_MTIME_TOLERANCE_MS) {
@@ -801,14 +751,12 @@ function canReuseFastBaseFileState(
 async function canReuseFastBaseFileStateFromDisk(
   baseEntry: OfflineSyncFileState,
   st: { size: number; mtimeMs: number; ctimeMs: number },
-  baseCapturedAtMs: number | null,
+  baseCapturedAtMs: number | null
 ): Promise<boolean> {
   return canReuseFastBaseFileState(baseEntry, st, baseCapturedAtMs);
 }
 
-async function readOfflineSyncFileRecord(
-  options: OfflineSyncFileRecordOptions,
-): Promise<OfflineSyncFileRecord> {
+async function readOfflineSyncFileRecord(options: OfflineSyncFileRecordOptions): Promise<OfflineSyncFileRecord> {
   throwIfOfflineSyncAborted(options.signal);
   const relPath = validateArchiveRelativePath(options.relPath, "offlineSyncFile.path");
   let content: Buffer | null = null;
@@ -875,18 +823,22 @@ export async function* iterateOfflineSyncSnapshotFileRecords(options: {
         options.excludeNodeLocalState === false
           ? shouldExcludeRelPath(relPosix, includeTranscripts)
           : shouldExcludePushRelPath(relPosix, includeTranscripts, options.userExcludeRegexps)
-      ) continue;
+      )
+        continue;
       if (entry.isSymbolicLink()) continue;
       if (entry.isDirectory()) {
         yield* walk(abs);
         continue;
       }
       if (!entry.isFile()) continue;
-      if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
-        root: root.abs,
-        path: relPosix,
-        filePath: abs,
-      })) continue;
+      if (
+        await shouldExcludeOfflineSyncFile(options.excludeFile, {
+          root: root.abs,
+          path: relPosix,
+          filePath: abs,
+        })
+      )
+        continue;
       yield await readOfflineSyncFileRecord({
         root,
         relPath: relPosix,
@@ -975,14 +927,10 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
   const rootAbs = path.resolve(options.root);
   const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshotFromBase", "root");
   const includeTranscripts = options.includeTranscripts !== false;
-  const base = byPath(filterBaseFilesForMode(
-    normalizeFileStates(options.baseFiles),
-    includeTranscripts,
-  ));
+  const base = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), includeTranscripts));
   const rawBaseCapturedAtMs = options.baseCapturedAt?.getTime();
-  const baseCapturedAtMs = rawBaseCapturedAtMs !== undefined && Number.isFinite(rawBaseCapturedAtMs)
-    ? rawBaseCapturedAtMs
-    : null;
+  const baseCapturedAtMs =
+    rawBaseCapturedAtMs !== undefined && Number.isFinite(rawBaseCapturedAtMs) ? rawBaseCapturedAtMs : null;
   const files: OfflineSyncFileRecord[] = [];
 
   async function walk(dirAbs: string): Promise<void> {
@@ -997,38 +945,44 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
         options.excludeNodeLocalState === false
           ? shouldExcludeRelPath(relPosix, includeTranscripts)
           : shouldExcludePushRelPath(relPosix, includeTranscripts, options.userExcludeRegexps)
-      ) continue;
+      )
+        continue;
       if (entry.isSymbolicLink()) continue;
       if (entry.isDirectory()) {
         await walk(abs);
         continue;
       }
       if (!entry.isFile()) continue;
-      if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
-        root: root.abs,
-        path: relPosix,
-        filePath: abs,
-      })) continue;
+      if (
+        await shouldExcludeOfflineSyncFile(options.excludeFile, {
+          root: root.abs,
+          path: relPosix,
+          filePath: abs,
+        })
+      )
+        continue;
       const st = await stat(abs);
       const baseEntry = base.get(relPosix);
       if (
         options.includeContent !== true &&
         baseEntry &&
         baseCapturedAtMs !== null &&
-        await canReuseFastBaseFileStateFromDisk(baseEntry, st, baseCapturedAtMs)
+        (await canReuseFastBaseFileStateFromDisk(baseEntry, st, baseCapturedAtMs))
       ) {
         files.push(baseEntry);
         continue;
       }
-      files.push(await readOfflineSyncFileRecord({
-        root,
-        relPath: relPosix,
-        filePath: abs,
-        includeContent: options.includeContent === true,
-        readFile: options.readFile,
-        readFileDigest: options.readFileDigest,
-        signal: options.signal,
-      }));
+      files.push(
+        await readOfflineSyncFileRecord({
+          root,
+          relPath: relPosix,
+          filePath: abs,
+          includeContent: options.includeContent === true,
+          readFile: options.readFile,
+          readFileDigest: options.readFileDigest,
+          signal: options.signal,
+        })
+      );
     }
   }
 
@@ -1101,22 +1055,26 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
       throw error;
     });
     if (!st || st.isSymbolicLink() || !st.isFile()) continue;
-    if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
-      root: root.abs,
-      path: relPath,
-      filePath,
-    })) {
+    if (
+      await shouldExcludeOfflineSyncFile(options.excludeFile, {
+        root: root.abs,
+        path: relPath,
+        filePath,
+      })
+    ) {
       throw new Error(`offline sync snapshot path is excluded: ${relPath}`);
     }
-    files.push(await readOfflineSyncFileRecord({
-      root,
-      relPath,
-      filePath,
-      includeContent: options.includeContent === true,
-      readFile: options.readFile,
-      readFileDigest: options.readFileDigest,
-      signal: options.signal,
-    }));
+    files.push(
+      await readOfflineSyncFileRecord({
+        root,
+        relPath,
+        filePath,
+        includeContent: options.includeContent === true,
+        readFile: options.readFile,
+        readFileDigest: options.readFileDigest,
+        signal: options.signal,
+      })
+    );
   }
   throwIfOfflineSyncAborted(options.signal);
 
@@ -1169,16 +1127,13 @@ export async function readOfflineSyncFileContentChunk(options: {
   ) {
     throw new Error(`offline sync file content path is excluded: ${relPath}`);
   }
-  const offset = options.offset === undefined
-    ? 0
-    : assertNonNegativeInteger(options.offset, "offset");
-  const requestedLength = options.length === undefined
-    ? OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES
-    : assertNonNegativeInteger(options.length, "length");
+  const offset = options.offset === undefined ? 0 : assertNonNegativeInteger(options.offset, "offset");
+  const requestedLength =
+    options.length === undefined
+      ? OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES
+      : assertNonNegativeInteger(options.length, "length");
   if (requestedLength < 1 || requestedLength > OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES) {
-    throw new Error(
-      `length must be an integer from 1 to ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES}`,
-    );
+    throw new Error(`length must be an integer from 1 to ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES}`);
   }
   const filePath = await resolveSafeArchiveTarget(root, relPath);
   const st = await lstat(filePath).catch((error: unknown) => {
@@ -1188,11 +1143,13 @@ export async function readOfflineSyncFileContentChunk(options: {
   if (!st || st.isSymbolicLink() || !st.isFile()) {
     throw new Error(`offline sync file content path not found: ${relPath}`);
   }
-  if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
-    root: root.abs,
-    path: relPath,
-    filePath,
-  })) {
+  if (
+    await shouldExcludeOfflineSyncFile(options.excludeFile, {
+      root: root.abs,
+      path: relPath,
+      filePath,
+    })
+  ) {
     throw new Error(`offline sync file content path is excluded: ${relPath}`);
   }
   const encrypted = await isEncryptedOfflineSyncFile(filePath);
@@ -1200,19 +1157,32 @@ export async function readOfflineSyncFileContentChunk(options: {
     if (offset > st.size) {
       throw new Error(`offset must be <= file size for ${relPath}`);
     }
-    const chunk = await readPlainOfflineSyncFileChunk({
+    // Plain-file reads hash the WHOLE file, mirroring the secure-store
+    // branch below: the file-content response contract carries the full-file
+    // sha256 (x-remnic-file-sha256), and peer transports reject responses
+    // without it ('response changed during transfer'). The whole-file read
+    // matches the secure branch's memory profile exactly — plain evidence
+    // files (tombstones, blocked-capture digests) are small, and any larger
+    // plain file pays the same cost a secure-store file of that size
+    // already pays per chunk.
+    const whole = await readPlainOfflineSyncFileChunk({
       filePath,
-      offset,
-      length: requestedLength,
+      offset: 0,
+      length: st.size,
       bytes: st.size,
     });
+    const chunk =
+      offset === 0
+        ? whole.subarray(0, Math.min(requestedLength, st.size))
+        : whole.subarray(offset, Math.min(offset + requestedLength, st.size));
     return {
       path: relPath,
+      sha256: sha256Buffer(whole).sha256,
       bytes: st.size,
       mtimeMs: st.mtimeMs,
       offset,
       chunkBytes: chunk.length,
-      content: chunk,
+      content: Buffer.from(chunk),
     };
   }
   if (!options.readFile) {
@@ -1307,20 +1277,15 @@ export async function buildOfflineSyncChangesetFromSnapshot(options: {
 }): Promise<OfflineSyncChangeset> {
   const includeTranscripts = options.includeTranscripts !== false;
   const excludedPaths = new Set(
-    (options.excludePaths ?? []).map((relPath) => normalizeRelativePath(relPath, "excludePaths[]")),
+    (options.excludePaths ?? []).map((relPath) => normalizeRelativePath(relPath, "excludePaths[]"))
   );
-  const base = byPath(filterBaseFilesForMode(
-    normalizeFileStates(options.baseFiles),
-    includeTranscripts,
-  ));
-  const currentMap = byPath(filterBaseFilesForMode(
-    normalizeFileStates(options.currentFiles),
-    includeTranscripts,
-  ));
+  const base = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), includeTranscripts));
+  const currentMap = byPath(filterBaseFilesForMode(normalizeFileStates(options.currentFiles), includeTranscripts));
   const deletions = normalizeDeletionRevisions(options.deletions, "deletions");
-  const deletionMtimeByPath = deletions === undefined
-    ? undefined
-    : new Map(deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
+  const deletionMtimeByPath =
+    deletions === undefined
+      ? undefined
+      : new Map(deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
   const changes: OfflineSyncChange[] = [];
 
   for (const relPath of unionPaths(base, currentMap)) {
@@ -1378,9 +1343,7 @@ export async function buildOfflineSyncChangesetFromSnapshot(options: {
   };
 }
 
-export function summarizeOfflineSyncChangeset(
-  changeset: OfflineSyncChangeset,
-): OfflineSyncChangesetSummary {
+export function summarizeOfflineSyncChangeset(changeset: OfflineSyncChangeset): OfflineSyncChangesetSummary {
   const upserts = changeset.changes.filter((change) => change.type === "upsert").length;
   const deletes = changeset.changes.filter((change) => change.type === "delete").length;
   return {
@@ -1445,14 +1408,8 @@ export function summarizeOfflineSyncPendingFiles(options: {
   excludeNodeLocalState?: boolean;
 }): OfflineSyncChangesetSummary {
   const includeTranscripts = options.includeTranscripts !== false;
-  const base = byPath(filterBaseFilesForMode(
-    normalizeFileStates(options.baseFiles),
-    includeTranscripts,
-  ));
-  const currentMap = byPath(filterBaseFilesForMode(
-    normalizeFileStates(options.currentFiles),
-    includeTranscripts,
-  ));
+  const base = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), includeTranscripts));
+  const currentMap = byPath(filterBaseFilesForMode(normalizeFileStates(options.currentFiles), includeTranscripts));
   let upserts = 0;
   let deletes = 0;
   for (const relPath of unionPaths(base, currentMap)) {
@@ -1491,38 +1448,34 @@ export async function applyOfflineSyncSnapshot(options: {
   recordDeletionRevision?: OfflineSyncRecordDeletionRevision;
 }): Promise<OfflineSyncApplySnapshotResult> {
   const snapshot = normalizeOfflineSyncSnapshot(options.snapshot);
-  const baseMap = byPath(filterBaseFilesForMode(
-    normalizeFileStates(options.baseFiles),
-    snapshot.includeTranscripts,
-  ));
+  const baseMap = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), snapshot.includeTranscripts));
   const incomingMap = byPath(snapshot.files);
-  const deletionMtimeByPath = snapshot.deletions === undefined
-    ? undefined
-    : new Map(snapshot.deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
+  const deletionMtimeByPath =
+    snapshot.deletions === undefined
+      ? undefined
+      : new Map(snapshot.deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
   const incomingBuffers = verifyRecordContents(snapshot.files, "offline sync snapshot", {
     requireContent: false,
   });
   const root = await ensureSyncRoot(options.root, "applyOfflineSyncSnapshot");
   const currentFiles = options.currentFiles
     ? filterBaseFilesForMode(normalizeFileStates(options.currentFiles), snapshot.includeTranscripts).sort(compareByPath)
-    : (await buildOfflineSyncSnapshot({
-        root: root.abs,
-        sourceId: "local",
-        includeContent: false,
-        includeTranscripts: snapshot.includeTranscripts,
-        readFile: options.readFile,
-        readFileDigest: options.readFileDigest,
-        excludeNodeLocalState: false,
-      })).files;
+    : (
+        await buildOfflineSyncSnapshot({
+          root: root.abs,
+          sourceId: "local",
+          includeContent: false,
+          includeTranscripts: snapshot.includeTranscripts,
+          readFile: options.readFile,
+          readFileDigest: options.readFileDigest,
+          excludeNodeLocalState: false,
+        })
+      ).files;
   const currentMap = byPath(currentFiles);
   const deferredPaths = new Set(options.deferredPaths ?? []);
   if (deletionMtimeByPath && options.recordDeletionRevision) {
     for (const [relPath, mtimeMs] of deletionMtimeByPath) {
-      if (
-        currentMap.has(relPath) ||
-        deferredPaths.has(relPath) ||
-        matchesOfflineSyncDefaultExclude(relPath)
-      ) {
+      if (currentMap.has(relPath) || deferredPaths.has(relPath) || matchesOfflineSyncDefaultExclude(relPath)) {
         continue;
       }
       await options.recordDeletionRevision({
@@ -1576,7 +1529,13 @@ export async function applyOfflineSyncSnapshot(options: {
         continue;
       }
       if (shouldPreferIncomingOfflineRuntimeFile(relPath)) {
-        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile, incoming.mtimeMs);
+        await writeSafeFile(
+          root,
+          relPath,
+          requiredBuffer(incomingBuffers, relPath),
+          options.writeFile,
+          incoming.mtimeMs
+        );
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
@@ -1588,28 +1547,42 @@ export async function applyOfflineSyncSnapshot(options: {
         continue;
       }
       if (!currentEntry && base && incoming.sha256 !== base.sha256) {
-        conflicts.push(await recordConflict({
-          root,
-          relPath,
-          reason: "local_deleted_remote_modified",
-          baseSha256: base.sha256,
-          incomingSha256: incoming.sha256,
-          incomingBuffer: conflictIncomingBuffer(relPath),
-          writeConflictCopies: options.writeConflictCopies !== false,
-          sourceId: snapshot.sourceId,
-          writeFile: options.writeFile,
-        }));
+        conflicts.push(
+          await recordConflict({
+            root,
+            relPath,
+            reason: "local_deleted_remote_modified",
+            baseSha256: base.sha256,
+            incomingSha256: incoming.sha256,
+            incomingBuffer: conflictIncomingBuffer(relPath),
+            writeConflictCopies: options.writeConflictCopies !== false,
+            sourceId: snapshot.sourceId,
+            writeFile: options.writeFile,
+          })
+        );
         nextBase.set(relPath, base);
         continue;
       }
       if (!currentEntry && !base) {
-        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile, incoming.mtimeMs);
+        await writeSafeFile(
+          root,
+          relPath,
+          requiredBuffer(incomingBuffers, relPath),
+          options.writeFile,
+          incoming.mtimeMs
+        );
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
       }
       if (base && currentEntry && currentEntry.sha256 === base.sha256) {
-        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile, incoming.mtimeMs);
+        await writeSafeFile(
+          root,
+          relPath,
+          requiredBuffer(incomingBuffers, relPath),
+          options.writeFile,
+          incoming.mtimeMs
+        );
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
@@ -1620,18 +1593,20 @@ export async function applyOfflineSyncSnapshot(options: {
         skipped += 1;
         continue;
       }
-      conflicts.push(await recordConflict({
-        root,
-        relPath,
-        reason: base ? "both_modified" : "remote_exists_for_local_create",
-        baseSha256: base?.sha256,
-        localSha256: currentEntry?.sha256,
-        incomingSha256: incoming.sha256,
-        incomingBuffer: conflictIncomingBuffer(relPath),
-        writeConflictCopies: options.writeConflictCopies !== false,
-        sourceId: snapshot.sourceId,
-        writeFile: options.writeFile,
-      }));
+      conflicts.push(
+        await recordConflict({
+          root,
+          relPath,
+          reason: base ? "both_modified" : "remote_exists_for_local_create",
+          baseSha256: base?.sha256,
+          localSha256: currentEntry?.sha256,
+          incomingSha256: incoming.sha256,
+          incomingBuffer: conflictIncomingBuffer(relPath),
+          writeConflictCopies: options.writeConflictCopies !== false,
+          sourceId: snapshot.sourceId,
+          writeFile: options.writeFile,
+        })
+      );
       if (base) nextBase.set(relPath, base);
       continue;
     }
@@ -1655,12 +1630,7 @@ export async function applyOfflineSyncSnapshot(options: {
       shouldPreferIncomingOfflineRuntimeFile(relPath) &&
       (base || shouldDeleteAbsentIncomingOfflineRuntimeFile(relPath))
     ) {
-      await deleteSafeFile(
-        root,
-        relPath,
-        options.deleteFile,
-        deletionMtimeByPath?.get(relPath),
-      );
+      await deleteSafeFile(root, relPath, options.deleteFile, deletionMtimeByPath?.get(relPath));
       nextBase.delete(relPath);
       deleted += 1;
       continue;
@@ -1671,12 +1641,7 @@ export async function applyOfflineSyncSnapshot(options: {
       continue;
     }
     if (base && currentEntry.sha256 === base.sha256) {
-      await deleteSafeFile(
-        root,
-        relPath,
-        options.deleteFile,
-        deletionMtimeByPath?.get(relPath),
-      );
+      await deleteSafeFile(root, relPath, options.deleteFile, deletionMtimeByPath?.get(relPath));
       nextBase.delete(relPath);
       deleted += 1;
       continue;
@@ -1722,11 +1687,7 @@ export async function applyOfflineSyncChangeset(options: {
     changeset = normalizeOfflineSyncChangeset(options.changeset);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      message.startsWith("offline sync")
-        ? message
-        : `offline sync changeset invalid: ${message}`,
-    );
+    throw new Error(message.startsWith("offline sync") ? message : `offline sync changeset invalid: ${message}`);
   }
   const root = await ensureSyncRoot(options.root, "applyOfflineSyncChangeset");
   const records = changeset.changes
@@ -1734,17 +1695,21 @@ export async function applyOfflineSyncChangeset(options: {
     .map((change) => change.file);
   const incomingBuffers = verifyRecordContents(records, "offline sync changeset");
   const currentFiles = options.currentFiles
-    ? filterBaseFilesForMode(normalizeFileStates(options.currentFiles), changeset.includeTranscripts).sort(compareByPath)
-    : (await buildOfflineSyncSnapshotForPaths({
-        root: root.abs,
-        sourceId: "local",
-        paths: changeset.changes.map((change) => change.path),
-        includeContent: false,
-        includeTranscripts: changeset.includeTranscripts,
-        readFile: options.readFile,
-        readFileDigest: options.readFileDigest,
-        excludeNodeLocalState: false,
-      })).files;
+    ? filterBaseFilesForMode(normalizeFileStates(options.currentFiles), changeset.includeTranscripts).sort(
+        compareByPath
+      )
+    : (
+        await buildOfflineSyncSnapshotForPaths({
+          root: root.abs,
+          sourceId: "local",
+          paths: changeset.changes.map((change) => change.path),
+          includeContent: false,
+          includeTranscripts: changeset.includeTranscripts,
+          readFile: options.readFile,
+          readFileDigest: options.readFileDigest,
+          excludeNodeLocalState: false,
+        })
+      ).files;
   const currentMap = byPath(currentFiles);
   const conflicts: OfflineSyncConflict[] = [];
   let appliedUpserts = 0;
@@ -1758,7 +1723,13 @@ export async function applyOfflineSyncChangeset(options: {
         if (await setSafeFileMtime(root, change.path, change.file.mtimeMs)) {
           skipped += 1;
         } else {
-          await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile, change.file.mtimeMs);
+          await writeSafeFile(
+            root,
+            change.path,
+            requiredBuffer(incomingBuffers, change.path),
+            options.writeFile,
+            change.file.mtimeMs
+          );
           currentMap.set(change.path, toFileState(change.file));
           appliedUpserts += 1;
         }
@@ -1766,42 +1737,58 @@ export async function applyOfflineSyncChangeset(options: {
       }
       if (!change.baseSha256) {
         if (!currentEntry) {
-          await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile, change.file.mtimeMs);
+          await writeSafeFile(
+            root,
+            change.path,
+            requiredBuffer(incomingBuffers, change.path),
+            options.writeFile,
+            change.file.mtimeMs
+          );
           currentMap.set(change.path, toFileState(change.file));
           appliedUpserts += 1;
           continue;
         }
-        conflicts.push(await recordConflict({
+        conflicts.push(
+          await recordConflict({
+            root,
+            relPath: change.path,
+            reason: "remote_exists_for_local_create",
+            localSha256: currentEntry.sha256,
+            incomingSha256: change.file.sha256,
+            incomingBuffer: incomingBuffers.get(change.path),
+            writeConflictCopies: options.writeConflictCopies !== false,
+            sourceId: changeset.sourceId,
+            writeFile: options.writeFile,
+          })
+        );
+        continue;
+      }
+      if (currentEntry?.sha256 === change.baseSha256) {
+        await writeSafeFile(
+          root,
+          change.path,
+          requiredBuffer(incomingBuffers, change.path),
+          options.writeFile,
+          change.file.mtimeMs
+        );
+        currentMap.set(change.path, toFileState(change.file));
+        appliedUpserts += 1;
+        continue;
+      }
+      conflicts.push(
+        await recordConflict({
           root,
           relPath: change.path,
-          reason: "remote_exists_for_local_create",
-          localSha256: currentEntry.sha256,
+          reason: currentEntry ? "remote_changed_for_local_update" : "remote_deleted_for_local_update",
+          baseSha256: change.baseSha256,
+          localSha256: currentEntry?.sha256,
           incomingSha256: change.file.sha256,
           incomingBuffer: incomingBuffers.get(change.path),
           writeConflictCopies: options.writeConflictCopies !== false,
           sourceId: changeset.sourceId,
           writeFile: options.writeFile,
-        }));
-        continue;
-      }
-      if (currentEntry?.sha256 === change.baseSha256) {
-        await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile, change.file.mtimeMs);
-        currentMap.set(change.path, toFileState(change.file));
-        appliedUpserts += 1;
-        continue;
-      }
-      conflicts.push(await recordConflict({
-        root,
-        relPath: change.path,
-        reason: currentEntry ? "remote_changed_for_local_update" : "remote_deleted_for_local_update",
-        baseSha256: change.baseSha256,
-        localSha256: currentEntry?.sha256,
-        incomingSha256: change.file.sha256,
-        incomingBuffer: incomingBuffers.get(change.path),
-        writeConflictCopies: options.writeConflictCopies !== false,
-        sourceId: changeset.sourceId,
-        writeFile: options.writeFile,
-      }));
+        })
+      );
       continue;
     }
 
@@ -1836,17 +1823,20 @@ export async function applyOfflineSyncChangeset(options: {
     appliedDeletes,
     skipped,
     conflicts,
-    currentFiles: options.returnCurrentFiles === false
-      ? [...currentMap.values()].sort(compareByPath)
-      : (await buildOfflineSyncSnapshot({
-          root: root.abs,
-          sourceId: "local",
-          includeContent: false,
-          includeTranscripts: changeset.includeTranscripts,
-          readFile: options.readFile,
-          readFileDigest: options.readFileDigest,
-          excludeNodeLocalState: false,
-        })).files,
+    currentFiles:
+      options.returnCurrentFiles === false
+        ? [...currentMap.values()].sort(compareByPath)
+        : (
+            await buildOfflineSyncSnapshot({
+              root: root.abs,
+              sourceId: "local",
+              includeContent: false,
+              includeTranscripts: changeset.includeTranscripts,
+              readFile: options.readFile,
+              readFileDigest: options.readFileDigest,
+              excludeNodeLocalState: false,
+            })
+          ).files,
     ...(options.returnCurrentFiles === false ? { currentFilesComplete: false } : {}),
   };
 }
@@ -1854,7 +1844,7 @@ export async function applyOfflineSyncChangeset(options: {
 function verifyRecordContents(
   records: readonly OfflineSyncFileRecord[],
   context: string,
-  options: { requireContent?: boolean } = {},
+  options: { requireContent?: boolean } = {}
 ): Map<string, Buffer> {
   const buffers = new Map<string, Buffer>();
   for (const record of records) {
@@ -1865,9 +1855,7 @@ function verifyRecordContents(
     const buffer = Buffer.from(record.contentBase64, "base64");
     const digest = sha256Buffer(buffer);
     if (digest.sha256 !== record.sha256 || digest.bytes !== record.bytes) {
-      throw new Error(
-        `${context}: content checksum mismatch for ${record.path}`,
-      );
+      throw new Error(`${context}: content checksum mismatch for ${record.path}`);
     }
     buffers.set(record.path, buffer);
   }
@@ -1918,7 +1906,7 @@ async function writeSafeFile(
   relPath: string,
   content: Buffer,
   writeFileHook?: (target: OfflineSyncFileWriteTarget) => Promise<void>,
-  mtimeMs?: number,
+  mtimeMs?: number
 ): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
   if (writeFileHook) {
@@ -1927,10 +1915,7 @@ async function writeSafeFile(
     return;
   }
   await mkdir(path.dirname(target), { recursive: true });
-  const tmp = path.join(
-    path.dirname(target),
-    `.remnic-sync.${process.pid}.${randomUUID()}.tmp`,
-  );
+  const tmp = path.join(path.dirname(target), `.remnic-sync.${process.pid}.${randomUUID()}.tmp`);
   await writeFile(tmp, content);
   try {
     const targetStat = await lstat(target).catch((error: unknown) => {
@@ -1948,11 +1933,7 @@ async function writeSafeFile(
   }
 }
 
-async function setSafeFileMtime(
-  root: SafeArchiveRoot,
-  relPath: string,
-  mtimeMs: number | undefined,
-): Promise<boolean> {
+async function setSafeFileMtime(root: SafeArchiveRoot, relPath: string, mtimeMs: number | undefined): Promise<boolean> {
   if (mtimeMs === undefined) return true;
   const target = await resolveSafeArchiveTarget(root, relPath);
   const targetStat = await lstat(target).catch((error: unknown) => {
@@ -1988,7 +1969,7 @@ async function readLocalFileState(options: {
 }): Promise<OfflineSyncFileState | null> {
   const filePath = await resolveSafeArchiveTarget(
     await prepareSafeArchiveRoot(options.rootAbs, "readLocalFileState", "rootAbs"),
-    options.relPath,
+    options.relPath
   );
   const st = await lstat(filePath).catch((error: unknown) => {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
@@ -2041,20 +2022,14 @@ export async function applyOfflineSyncFileContentChunk(options: {
   const sha256 = assertSha256(options.sha256, "sha256");
   const bytes = assertNonNegativeInteger(options.bytes, "bytes");
   const mtimeMs = assertOfflineSyncMtimeMs(options.mtimeMs, "mtimeMs");
-  const offset = options.offset === undefined
-    ? 0
-    : assertNonNegativeInteger(options.offset, "offset");
-  const baseSha256 = options.baseSha256 === undefined
-    ? undefined
-    : assertSha256(options.baseSha256, "baseSha256");
+  const offset = options.offset === undefined ? 0 : assertNonNegativeInteger(options.offset, "offset");
+  const baseSha256 = options.baseSha256 === undefined ? undefined : assertSha256(options.baseSha256, "baseSha256");
   const preferIncomingRuntimeFile = shouldPreferIncomingOfflineRuntimeFile(relPath);
   if (!Buffer.isBuffer(options.content)) {
     throw new Error("content must be a Buffer");
   }
   if (options.content.length > OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES) {
-    throw new Error(
-      `content chunk must be ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES} bytes or fewer`,
-    );
+    throw new Error(`content chunk must be ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES} bytes or fewer`);
   }
   if (bytes > 0 && options.content.length === 0) {
     throw new Error("content chunk must be non-empty before EOF");
@@ -2078,7 +2053,7 @@ export async function applyOfflineSyncFileContentChunk(options: {
     done: offset + options.content.length === bytes,
   };
   const currentFileConflict = async (
-    currentFile: OfflineSyncFileState | undefined,
+    currentFile: OfflineSyncFileState | undefined
   ): Promise<{ conflict: OfflineSyncConflict; currentFile?: OfflineSyncFileState } | null> => {
     if (!baseSha256 && currentFile && !preferIncomingRuntimeFile) {
       const conflict = await recordConflict({
@@ -2230,21 +2205,19 @@ function offlineUploadRelPath(options: {
   sha256: string;
   bytes: number;
 }): string {
-  const key = hashText([
-    options.sourceId,
-    options.relPath,
-    options.sha256,
-    String(options.bytes),
-  ].join("\0"));
+  const key = hashText([options.sourceId, options.relPath, options.sha256, String(options.bytes)].join("\0"));
   return `${SYNC_INTERNAL_DIR}/uploads/${key}.part`;
 }
 
-async function offlineUploadPath(root: SafeArchiveRoot, options: {
-  sourceId: string;
-  relPath: string;
-  sha256: string;
-  bytes: number;
-}): Promise<OfflineUploadStaging> {
+async function offlineUploadPath(
+  root: SafeArchiveRoot,
+  options: {
+    sourceId: string;
+    relPath: string;
+    sha256: string;
+    bytes: number;
+  }
+): Promise<OfflineUploadStaging> {
   const relPath = offlineUploadRelPath(options);
   return {
     kind: "single",
@@ -2253,13 +2226,16 @@ async function offlineUploadPath(root: SafeArchiveRoot, options: {
   };
 }
 
-async function offlineUploadChunkPath(root: SafeArchiveRoot, options: {
-  sourceId: string;
-  relPath: string;
-  sha256: string;
-  bytes: number;
-  offset: number;
-}): Promise<OfflineUploadStaging> {
+async function offlineUploadChunkPath(
+  root: SafeArchiveRoot,
+  options: {
+    sourceId: string;
+    relPath: string;
+    sha256: string;
+    bytes: number;
+    offset: number;
+  }
+): Promise<OfflineUploadStaging> {
   const uploadRelPath = offlineUploadRelPath(options);
   const relPath = `${uploadRelPath}/${String(options.offset).padStart(20, "0")}.part`;
   return {
@@ -2335,18 +2311,20 @@ async function pruneOfflineUploadStaging(root: SafeArchiveRoot): Promise<void> {
     throw error;
   });
   const now = Date.now();
-  await Promise.all(entries.map(async (entry) => {
-    if (!/^[a-f0-9]{64}\.part$/i.test(entry.name)) return;
-    const relPath = `${uploadsRelPath}/${entry.name}`;
-    const filePath = await resolveSafeArchiveTarget(root, relPath);
-    const info = await lstat(filePath).catch((error: unknown) => {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-      throw error;
-    });
-    if (!info) return;
-    if (now - info.mtimeMs <= OFFLINE_SYNC_UPLOAD_STAGING_MAX_AGE_MS) return;
-    await rm(filePath, { recursive: true, force: true });
-  }));
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!/^[a-f0-9]{64}\.part$/i.test(entry.name)) return;
+      const relPath = `${uploadsRelPath}/${entry.name}`;
+      const filePath = await resolveSafeArchiveTarget(root, relPath);
+      const info = await lstat(filePath).catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+        throw error;
+      });
+      if (!info) return;
+      if (now - info.mtimeMs <= OFFLINE_SYNC_UPLOAD_STAGING_MAX_AGE_MS) return;
+      await rm(filePath, { recursive: true, force: true });
+    })
+  );
 }
 
 async function* readOfflineUploadStagingChunks(options: {
@@ -2365,9 +2343,7 @@ async function* readOfflineUploadStagingChunks(options: {
   }
 
   const entries = await readdir(options.upload.filePath);
-  const chunkNames = entries
-    .filter((entry) => /^\d{20}\.part$/.test(entry))
-    .sort();
+  const chunkNames = entries.filter((entry) => /^\d{20}\.part$/.test(entry)).sort();
   if (chunkNames.length === 0) {
     throw new Error(`offline sync upload is missing chunks for ${options.upload.relPath}`);
   }
@@ -2376,7 +2352,7 @@ async function* readOfflineUploadStagingChunks(options: {
     const offset = Number(chunkName.slice(0, 20));
     if (!Number.isSafeInteger(offset) || offset !== expectedOffset) {
       throw new Error(
-        `offline sync upload offset mismatch for ${options.upload.relPath}: expected ${expectedOffset}, got ${offset}`,
+        `offline sync upload offset mismatch for ${options.upload.relPath}: expected ${expectedOffset}, got ${offset}`
       );
     }
     const relPath = `${options.upload.relPath}/${chunkName}`;
@@ -2412,7 +2388,7 @@ async function writeSafeFileFromUpload(
   upload: OfflineUploadStaging,
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>,
   writeFileChunks?: (target: OfflineSyncFileWriteChunksTarget) => Promise<void>,
-  mtimeMs?: number,
+  mtimeMs?: number
 ): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
   const chunks = readOfflineUploadStagingChunks({ root, upload, readFile });
@@ -2423,10 +2399,7 @@ async function writeSafeFileFromUpload(
   }
 
   await mkdir(path.dirname(target), { recursive: true });
-  const tmp = path.join(
-    path.dirname(target),
-    `.remnic-sync.${process.pid}.${randomUUID()}.tmp`,
-  );
+  const tmp = path.join(path.dirname(target), `.remnic-sync.${process.pid}.${randomUUID()}.tmp`);
   const handle = await open(tmp, "w", 0o600);
   try {
     for await (const chunk of chunks) {
@@ -2495,7 +2468,7 @@ async function deleteSafeFile(
   root: SafeArchiveRoot,
   relPath: string,
   deleteFile?: (target: OfflineSyncFileDeleteTarget) => Promise<void>,
-  mtimeMs?: number,
+  mtimeMs?: number
 ): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
   if (deleteFile) {
@@ -2542,18 +2515,12 @@ async function recordConflict(options: {
   };
 }
 
-export function defaultOfflineSyncStatePath(
-  memoryDir: string,
-  remoteId: string,
-  namespace?: string,
-): string {
+export function defaultOfflineSyncStatePath(memoryDir: string, remoteId: string, namespace?: string): string {
   const key = hashText(`${remoteId}\0${namespace ?? ""}`).slice(0, 16);
   return path.join(path.resolve(memoryDir), SYNC_INTERNAL_DIR, "state", `${key}.json`);
 }
 
-export async function readOfflineSyncState(
-  statePath: string,
-): Promise<OfflineSyncState | null> {
+export async function readOfflineSyncState(statePath: string): Promise<OfflineSyncState | null> {
   let raw: string;
   try {
     raw = await readFile(path.resolve(statePath), "utf-8");
@@ -2565,17 +2532,11 @@ export async function readOfflineSyncState(
   return normalizeOfflineSyncState(parsed);
 }
 
-export async function writeOfflineSyncState(
-  statePath: string,
-  state: OfflineSyncState,
-): Promise<void> {
+export async function writeOfflineSyncState(statePath: string, state: OfflineSyncState): Promise<void> {
   const normalized = normalizeOfflineSyncState(state);
   const target = path.resolve(statePath);
   await mkdir(path.dirname(target), { recursive: true });
-  const tmp = path.join(
-    path.dirname(target),
-    `.remnic-sync-state.${process.pid}.${randomUUID()}.tmp`,
-  );
+  const tmp = path.join(path.dirname(target), `.remnic-sync-state.${process.pid}.${randomUUID()}.tmp`);
   await writeFile(tmp, JSON.stringify(normalized, null, 2) + "\n", "utf-8");
   try {
     await rename(tmp, target);
@@ -2611,11 +2572,8 @@ export function normalizeOfflineSyncState(input: unknown): OfflineSyncState {
     throw new Error(`offline sync state version must be ${OFFLINE_SYNC_STATE_VERSION}`);
   }
   const namespace =
-    typeof obj.namespace === "string" && obj.namespace.trim().length > 0
-      ? obj.namespace.trim()
-      : undefined;
-  const baseFiles = normalizeFileStates(obj.baseFiles as readonly unknown[] | undefined)
-    .sort(compareByPath);
+    typeof obj.namespace === "string" && obj.namespace.trim().length > 0 ? obj.namespace.trim() : undefined;
+  const baseFiles = normalizeFileStates(obj.baseFiles as readonly unknown[] | undefined).sort(compareByPath);
   assertUniquePaths(baseFiles, "offline sync state");
   return {
     version: OFFLINE_SYNC_STATE_VERSION,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -1,7 +1,22 @@
 import { createHash, randomUUID } from "node:crypto";
-import { lstat, mkdir, open, readdir, readFile, rename, rm, stat, unlink, utimes, writeFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  unlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
-import { DEFAULT_TRANSFER_EXCLUDE_DIRS } from "./transfer/exclusions.js";
+import {
+  DEFAULT_TRANSFER_EXCLUDE_DIRS,
+} from "./transfer/exclusions.js";
 import {
   prepareSafeArchiveRoot,
   resolveSafeArchiveTarget,
@@ -140,7 +155,7 @@ export interface OfflineSyncFileDeleteTarget extends OfflineSyncFileTarget {
 }
 
 export type OfflineSyncRecordDeletionRevision = (
-  target: OfflineSyncFileDeleteTarget & { mtimeMs: number }
+  target: OfflineSyncFileDeleteTarget & { mtimeMs: number },
 ) => Promise<void>;
 
 export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
@@ -194,9 +209,14 @@ const SYNC_INTERNAL_DIR = ".offline-sync";
 const OFFLINE_SYNC_UPLOAD_STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const OFFLINE_SYNC_FAST_BASE_MTIME_TOLERANCE_MS = 1_000;
 const OFFLINE_SYNC_FAST_BASE_CTIME_TOLERANCE_MS = 1;
-const EXCLUDED_FILE_NAMES = new Set([".sync-state.json"]);
+const EXCLUDED_FILE_NAMES = new Set([
+  ".sync-state.json",
+]);
 
-const EXCLUDED_FILE_PREFIXES = [".remnic-sync.", ".remnic-sync-state."];
+const EXCLUDED_FILE_PREFIXES = [
+  ".remnic-sync.",
+  ".remnic-sync-state.",
+];
 
 /**
  * Convert a tiny subset of glob syntax (`*`, `**`, `?`, literal text) into a
@@ -276,7 +296,12 @@ function assertSha256(value: unknown, field: string): string {
 }
 
 function assertNonNegativeInteger(value: unknown, field: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
     throw new Error(`${field} must be a non-negative integer`);
   }
   return value;
@@ -325,7 +350,11 @@ function normalizeFileState(input: unknown, fieldPrefix: string): OfflineSyncFil
   };
 }
 
-function normalizeFileRecord(input: unknown, fieldPrefix: string, requireContent: boolean): OfflineSyncFileRecord {
+function normalizeFileRecord(
+  input: unknown,
+  fieldPrefix: string,
+  requireContent: boolean,
+): OfflineSyncFileRecord {
   const state = normalizeFileState(input, fieldPrefix);
   const obj = input as Record<string, unknown>;
   const contentBase64 = obj.contentBase64;
@@ -349,7 +378,10 @@ function normalizeFileStates(input: readonly unknown[] | undefined): OfflineSync
   return input.map((entry, index) => normalizeFileState(entry, `baseFiles[${index}]`));
 }
 
-function normalizeDeletionRevisions(input: unknown, fieldPrefix: string): OfflineSyncDeletionRevision[] | undefined {
+function normalizeDeletionRevisions(
+  input: unknown,
+  fieldPrefix: string,
+): OfflineSyncDeletionRevision[] | undefined {
   if (input === undefined) return undefined;
   if (!Array.isArray(input)) {
     throw new Error(`${fieldPrefix} must be an array`);
@@ -380,15 +412,19 @@ function snapshotBuilderDeletions(options: {
   if (deletions === undefined) return undefined;
   if (deletions.length === 0) return deletions;
   const presentPaths = new Set(options.files.map((file) => file.path.toLowerCase()));
-  const scopedPaths = options.paths ? new Set(options.paths.map((relPath) => relPath.toLowerCase())) : undefined;
-  return deletions.filter(
-    (deletion) =>
-      (scopedPaths === undefined || scopedPaths.has(deletion.path.toLowerCase())) &&
-      !presentPaths.has(deletion.path.toLowerCase()) &&
-      !(options.excludeNodeLocalState === false
-        ? shouldExcludeRelPath(deletion.path, options.includeTranscripts)
-        : shouldExcludePushRelPath(deletion.path, options.includeTranscripts, options.userExcludeRegexps))
-  );
+  const scopedPaths = options.paths
+    ? new Set(options.paths.map((relPath) => relPath.toLowerCase()))
+    : undefined;
+  return deletions.filter((deletion) =>
+    (scopedPaths === undefined || scopedPaths.has(deletion.path.toLowerCase())) &&
+    !presentPaths.has(deletion.path.toLowerCase()) &&
+    !(options.excludeNodeLocalState === false
+      ? shouldExcludeRelPath(deletion.path, options.includeTranscripts)
+      : shouldExcludePushRelPath(
+          deletion.path,
+          options.includeTranscripts,
+          options.userExcludeRegexps,
+        )));
 }
 
 export async function filterOfflineSyncDeletionRevisions(options: {
@@ -400,7 +436,11 @@ export async function filterOfflineSyncDeletionRevisions(options: {
   const deletions = normalizeDeletionRevisions(options.deletions, "deletions");
   if (deletions === undefined) throw new Error("deletions must be an array");
   if (deletions.length === 0) return deletions;
-  const root = await prepareSafeArchiveRoot(path.resolve(options.root), "filterOfflineSyncDeletionRevisions", "root");
+  const root = await prepareSafeArchiveRoot(
+    path.resolve(options.root),
+    "filterOfflineSyncDeletionRevisions",
+    "root",
+  );
   const includeTranscripts = options.includeTranscripts !== false;
   const filtered: OfflineSyncDeletionRevision[] = [];
   for (const deletion of deletions) {
@@ -413,7 +453,7 @@ export async function filterOfflineSyncDeletionRevisions(options: {
       (error: unknown) => {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
         throw error;
-      }
+      },
     );
     if (!present) filtered.push(deletion);
   }
@@ -422,7 +462,7 @@ export async function filterOfflineSyncDeletionRevisions(options: {
 
 export function normalizeOfflineSyncSnapshot(
   input: unknown,
-  options: { requireContent?: boolean } = {}
+  options: { requireContent?: boolean } = {},
 ): OfflineSyncSnapshot {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("offline sync snapshot must be an object");
@@ -441,23 +481,25 @@ export function normalizeOfflineSyncSnapshot(
     throw new Error("offline sync snapshot files must be an array");
   }
   const files = obj.files
-    .map((entry, index) => normalizeFileRecord(entry, `files[${index}]`, options.requireContent === true))
+    .map((entry, index) =>
+      normalizeFileRecord(entry, `files[${index}]`, options.requireContent === true))
     .filter((file) => !shouldIgnoreIncomingRuntimePath(file.path))
     .sort(compareByPath);
-  const deletions = normalizeDeletionRevisions(obj.deletions, "deletions")?.filter(
-    (deletion) => !shouldIgnoreIncomingRuntimePath(deletion.path)
-  );
+  const deletions = normalizeDeletionRevisions(obj.deletions, "deletions")
+    ?.filter((deletion) => !shouldIgnoreIncomingRuntimePath(deletion.path));
   const entries = deletions && deletions.length > 0 ? [...files, ...deletions] : files;
   assertUniquePaths(entries, "offline sync snapshot");
   if (!includeTranscripts) {
-    const transcriptPath = entries.find((entry) => entry.path.split("/")[0] === "transcripts")?.path;
+    const transcriptPath = entries
+      .find((entry) => entry.path.split("/")[0] === "transcripts")?.path;
     if (transcriptPath) {
       throw new Error(
-        `offline sync snapshot includeTranscripts is false but contains transcript path: ${transcriptPath}`
+        `offline sync snapshot includeTranscripts is false but contains transcript path: ${transcriptPath}`,
       );
     }
   }
-  const excludedPath = entries.find((entry) => shouldExcludeRelPath(entry.path, true))?.path;
+  const excludedPath = entries
+    .find((entry) => shouldExcludeRelPath(entry.path, true))?.path;
   if (excludedPath) {
     throw new Error(`offline sync snapshot contains excluded path: ${excludedPath}`);
   }
@@ -472,7 +514,9 @@ export function normalizeOfflineSyncSnapshot(
   };
 }
 
-export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChangeset {
+export function normalizeOfflineSyncChangeset(
+  input: unknown,
+): OfflineSyncChangeset {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("offline sync changeset must be an object");
   }
@@ -489,51 +533,52 @@ export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChange
   if (!Array.isArray(obj.changes)) {
     throw new Error("offline sync changeset changes must be an array");
   }
-  const changes = obj.changes
-    .map((entry, index): OfflineSyncChange => {
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-        throw new Error(`changes[${index}] must be an object`);
+  const changes = obj.changes.map((entry, index): OfflineSyncChange => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`changes[${index}] must be an object`);
+    }
+    const change = entry as Record<string, unknown>;
+    const type = change.type;
+    const relPath = normalizeRelativePath(change.path, `changes[${index}].path`);
+    if (type === "upsert") {
+      const file = normalizeFileRecord(
+        change.file,
+        `changes[${index}].file`,
+        true,
+      ) as OfflineSyncFileRecord & { contentBase64: string };
+      if (file.path !== relPath) {
+        throw new Error(`changes[${index}].file.path must match changes[${index}].path`);
       }
-      const change = entry as Record<string, unknown>;
-      const type = change.type;
-      const relPath = normalizeRelativePath(change.path, `changes[${index}].path`);
-      if (type === "upsert") {
-        const file = normalizeFileRecord(change.file, `changes[${index}].file`, true) as OfflineSyncFileRecord & {
-          contentBase64: string;
-        };
-        if (file.path !== relPath) {
-          throw new Error(`changes[${index}].file.path must match changes[${index}].path`);
-        }
-        const baseSha256 =
-          change.baseSha256 === undefined ? undefined : assertSha256(change.baseSha256, `changes[${index}].baseSha256`);
-        return {
-          type: "upsert",
-          path: relPath,
-          ...(baseSha256 ? { baseSha256 } : {}),
-          file,
-        };
-      }
-      if (type === "delete") {
-        const mtimeMs =
-          change.mtimeMs === undefined
-            ? undefined
-            : assertOfflineSyncMtimeMs(change.mtimeMs, `changes[${index}].mtimeMs`);
-        return {
-          type: "delete",
-          path: relPath,
-          baseSha256: assertSha256(change.baseSha256, `changes[${index}].baseSha256`),
-          ...(mtimeMs === undefined ? {} : { mtimeMs }),
-        };
-      }
-      throw new Error(`changes[${index}].type must be "upsert" or "delete"`);
-    })
-    .filter((change) => !shouldIgnoreIncomingRuntimePath(change.path));
+      const baseSha256 =
+        change.baseSha256 === undefined
+          ? undefined
+          : assertSha256(change.baseSha256, `changes[${index}].baseSha256`);
+      return {
+        type: "upsert",
+        path: relPath,
+        ...(baseSha256 ? { baseSha256 } : {}),
+        file,
+      };
+    }
+    if (type === "delete") {
+      const mtimeMs = change.mtimeMs === undefined
+        ? undefined
+        : assertOfflineSyncMtimeMs(change.mtimeMs, `changes[${index}].mtimeMs`);
+      return {
+        type: "delete",
+        path: relPath,
+        baseSha256: assertSha256(change.baseSha256, `changes[${index}].baseSha256`),
+        ...(mtimeMs === undefined ? {} : { mtimeMs }),
+      };
+    }
+    throw new Error(`changes[${index}].type must be "upsert" or "delete"`);
+  }).filter((change) => !shouldIgnoreIncomingRuntimePath(change.path));
   assertUniquePaths(changes, "offline sync changeset");
   if (!includeTranscripts) {
     const transcriptPath = changes.find((change) => change.path.split("/")[0] === "transcripts")?.path;
     if (transcriptPath) {
       throw new Error(
-        `offline sync changeset includeTranscripts is false but contains transcript path: ${transcriptPath}`
+        `offline sync changeset includeTranscripts is false but contains transcript path: ${transcriptPath}`,
       );
     }
   }
@@ -582,12 +627,10 @@ function assertUniquePaths(entries: readonly { path: string }[], context: string
 
 export function isInternalRemnicStatePath(relPosix: string): boolean {
   const normalized = relPosix.includes("\\") ? relPosix.replaceAll("\\", "/") : relPosix;
-  return (
-    normalized === ".remnic" ||
-    normalized.startsWith(".remnic/") ||
-    normalized.endsWith("/.remnic") ||
-    normalized.includes("/.remnic/")
-  );
+  return normalized === ".remnic"
+    || normalized.startsWith(".remnic/")
+    || normalized.endsWith("/.remnic")
+    || normalized.includes("/.remnic/");
 }
 
 function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): boolean {
@@ -620,7 +663,7 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
 function shouldExcludePushRelPath(
   relPosix: string,
   includeTranscripts: boolean,
-  userExcludeRegexps?: readonly RegExp[]
+  userExcludeRegexps?: readonly RegExp[],
 ): boolean {
   if (shouldExcludeRelPath(relPosix, includeTranscripts)) return true;
   // Issue #1786: node-local runtime state (live sqlite, derived indexes,
@@ -632,9 +675,8 @@ function shouldExcludePushRelPath(
 
 // Precompiled once at module load — this check sits on the hot
 // enumeration path for every walked file (Kilo review, PR #1793).
-const DEFAULT_OFFLINE_SYNC_EXCLUDE_REGEXPS: readonly RegExp[] = DEFAULT_OFFLINE_SYNC_EXCLUDE_GLOBS.map((glob) =>
-  globToRegExp(glob)
-);
+const DEFAULT_OFFLINE_SYNC_EXCLUDE_REGEXPS: readonly RegExp[] =
+  DEFAULT_OFFLINE_SYNC_EXCLUDE_GLOBS.map((glob) => globToRegExp(glob));
 
 function matchesOfflineSyncDefaultExclude(relPosix: string): boolean {
   for (const regexp of DEFAULT_OFFLINE_SYNC_EXCLUDE_REGEXPS) {
@@ -650,7 +692,9 @@ function matchesOfflineSyncDefaultExclude(relPosix: string): boolean {
  * a thrown error as a fatal configuration mistake and refuse to start the
  * sync run rather than silently dropping the bad entry.
  */
-export function compileOfflineSyncExcludeGlobs(globs: readonly unknown[]): RegExp[] {
+export function compileOfflineSyncExcludeGlobs(
+  globs: readonly unknown[],
+): RegExp[] {
   const out: RegExp[] = [];
   for (const entry of globs) {
     if (typeof entry !== "string" || entry.length === 0) {
@@ -670,11 +714,15 @@ export function compileOfflineSyncExcludeGlobs(globs: readonly unknown[]): RegEx
 export function parseOfflineSyncExcludes(raw: unknown): string[] {
   if (raw === undefined || raw === null) return [];
   if (!Array.isArray(raw)) {
-    throw new Error(`offlineSyncExcludes must be an array of non-empty glob strings; got ${typeof raw}`);
+    throw new Error(
+      `offlineSyncExcludes must be an array of non-empty glob strings; got ${typeof raw}`,
+    );
   }
   for (const entry of raw) {
     if (typeof entry !== "string" || entry.trim().length === 0) {
-      throw new Error("offlineSyncExcludes must contain only non-empty glob strings");
+      throw new Error(
+        "offlineSyncExcludes must contain only non-empty glob strings",
+      );
     }
   }
   const globs = raw.map((entry) => (entry as string).trim());
@@ -712,7 +760,10 @@ const REMOTE_AUTHORITATIVE_RUNTIME_STATE_FILES = new Set([
   "recall_impressions.jsonl",
 ]);
 
-const ABSENT_INCOMING_RUNTIME_DELETE_FILES = new Set(["lcm.sqlite-shm", "lcm.sqlite-wal"]);
+const ABSENT_INCOMING_RUNTIME_DELETE_FILES = new Set([
+  "lcm.sqlite-shm",
+  "lcm.sqlite-wal",
+]);
 
 export function shouldPreferIncomingOfflineRuntimeFile(relPosix: string): boolean {
   const parts = relPosix.split("/");
@@ -728,7 +779,7 @@ function shouldDeleteAbsentIncomingOfflineRuntimeFile(relPosix: string): boolean
 
 function filterBaseFilesForMode(
   files: readonly OfflineSyncFileState[],
-  includeTranscripts: boolean
+  includeTranscripts: boolean,
 ): OfflineSyncFileState[] {
   return files.filter((file) => !shouldExcludeRelPath(file.path, includeTranscripts));
 }
@@ -736,7 +787,7 @@ function filterBaseFilesForMode(
 function canReuseFastBaseFileState(
   baseEntry: OfflineSyncFileState,
   st: { size: number; mtimeMs: number; ctimeMs: number },
-  baseCapturedAtMs: number | null
+  baseCapturedAtMs: number | null,
 ): boolean {
   if (baseEntry.bytes !== st.size) return false;
   if (Math.abs(baseEntry.mtimeMs - st.mtimeMs) > OFFLINE_SYNC_FAST_BASE_MTIME_TOLERANCE_MS) {
@@ -751,12 +802,14 @@ function canReuseFastBaseFileState(
 async function canReuseFastBaseFileStateFromDisk(
   baseEntry: OfflineSyncFileState,
   st: { size: number; mtimeMs: number; ctimeMs: number },
-  baseCapturedAtMs: number | null
+  baseCapturedAtMs: number | null,
 ): Promise<boolean> {
   return canReuseFastBaseFileState(baseEntry, st, baseCapturedAtMs);
 }
 
-async function readOfflineSyncFileRecord(options: OfflineSyncFileRecordOptions): Promise<OfflineSyncFileRecord> {
+async function readOfflineSyncFileRecord(
+  options: OfflineSyncFileRecordOptions,
+): Promise<OfflineSyncFileRecord> {
   throwIfOfflineSyncAborted(options.signal);
   const relPath = validateArchiveRelativePath(options.relPath, "offlineSyncFile.path");
   let content: Buffer | null = null;
@@ -823,22 +876,18 @@ export async function* iterateOfflineSyncSnapshotFileRecords(options: {
         options.excludeNodeLocalState === false
           ? shouldExcludeRelPath(relPosix, includeTranscripts)
           : shouldExcludePushRelPath(relPosix, includeTranscripts, options.userExcludeRegexps)
-      )
-        continue;
+      ) continue;
       if (entry.isSymbolicLink()) continue;
       if (entry.isDirectory()) {
         yield* walk(abs);
         continue;
       }
       if (!entry.isFile()) continue;
-      if (
-        await shouldExcludeOfflineSyncFile(options.excludeFile, {
-          root: root.abs,
-          path: relPosix,
-          filePath: abs,
-        })
-      )
-        continue;
+      if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
+        root: root.abs,
+        path: relPosix,
+        filePath: abs,
+      })) continue;
       yield await readOfflineSyncFileRecord({
         root,
         relPath: relPosix,
@@ -927,10 +976,14 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
   const rootAbs = path.resolve(options.root);
   const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshotFromBase", "root");
   const includeTranscripts = options.includeTranscripts !== false;
-  const base = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), includeTranscripts));
+  const base = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.baseFiles),
+    includeTranscripts,
+  ));
   const rawBaseCapturedAtMs = options.baseCapturedAt?.getTime();
-  const baseCapturedAtMs =
-    rawBaseCapturedAtMs !== undefined && Number.isFinite(rawBaseCapturedAtMs) ? rawBaseCapturedAtMs : null;
+  const baseCapturedAtMs = rawBaseCapturedAtMs !== undefined && Number.isFinite(rawBaseCapturedAtMs)
+    ? rawBaseCapturedAtMs
+    : null;
   const files: OfflineSyncFileRecord[] = [];
 
   async function walk(dirAbs: string): Promise<void> {
@@ -945,44 +998,38 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
         options.excludeNodeLocalState === false
           ? shouldExcludeRelPath(relPosix, includeTranscripts)
           : shouldExcludePushRelPath(relPosix, includeTranscripts, options.userExcludeRegexps)
-      )
-        continue;
+      ) continue;
       if (entry.isSymbolicLink()) continue;
       if (entry.isDirectory()) {
         await walk(abs);
         continue;
       }
       if (!entry.isFile()) continue;
-      if (
-        await shouldExcludeOfflineSyncFile(options.excludeFile, {
-          root: root.abs,
-          path: relPosix,
-          filePath: abs,
-        })
-      )
-        continue;
+      if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
+        root: root.abs,
+        path: relPosix,
+        filePath: abs,
+      })) continue;
       const st = await stat(abs);
       const baseEntry = base.get(relPosix);
       if (
         options.includeContent !== true &&
         baseEntry &&
         baseCapturedAtMs !== null &&
-        (await canReuseFastBaseFileStateFromDisk(baseEntry, st, baseCapturedAtMs))
+        await canReuseFastBaseFileStateFromDisk(baseEntry, st, baseCapturedAtMs)
       ) {
         files.push(baseEntry);
         continue;
       }
-      files.push(
-        await readOfflineSyncFileRecord({
-          root,
-          relPath: relPosix,
-          filePath: abs,
-          includeContent: options.includeContent === true,
-          readFile: options.readFile,
-          readFileDigest: options.readFileDigest,
-          signal: options.signal,
-        })
-      );
+      files.push(await readOfflineSyncFileRecord({
+        root,
+        relPath: relPosix,
+        filePath: abs,
+        includeContent: options.includeContent === true,
+        readFile: options.readFile,
+        readFileDigest: options.readFileDigest,
+        signal: options.signal,
+      }));
     }
   }
 
@@ -1055,26 +1102,22 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
       throw error;
     });
     if (!st || st.isSymbolicLink() || !st.isFile()) continue;
-    if (
-      await shouldExcludeOfflineSyncFile(options.excludeFile, {
-        root: root.abs,
-        path: relPath,
-        filePath,
-      })
-    ) {
+    if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
+      root: root.abs,
+      path: relPath,
+      filePath,
+    })) {
       throw new Error(`offline sync snapshot path is excluded: ${relPath}`);
     }
-    files.push(
-      await readOfflineSyncFileRecord({
-        root,
-        relPath,
-        filePath,
-        includeContent: options.includeContent === true,
-        readFile: options.readFile,
-        readFileDigest: options.readFileDigest,
-        signal: options.signal,
-      })
-    );
+    files.push(await readOfflineSyncFileRecord({
+      root,
+      relPath,
+      filePath,
+      includeContent: options.includeContent === true,
+      readFile: options.readFile,
+      readFileDigest: options.readFileDigest,
+      signal: options.signal,
+    }));
   }
   throwIfOfflineSyncAborted(options.signal);
 
@@ -1096,6 +1139,37 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
     files: sortedFiles,
     ...(deletions === undefined ? {} : { deletions }),
   };
+}
+
+/** Bounded digest cache for plain-file chunk reads: key is the file identity
+ * (dev/ino-free approximation: path + size + mtimeMs), value the streamed
+ * whole-file sha256. Capped so a churning corpus cannot grow it unbounded. */
+const PLAIN_FILE_DIGEST_CACHE_MAX = 64;
+const plainFileDigestCache = new Map<string, string>();
+
+async function plainFileDigest(
+  filePath: string,
+  st: { size: number; mtimeMs: number },
+): Promise<string> {
+  const key = `${filePath}\0${st.size}\0${st.mtimeMs}`;
+  const cached = plainFileDigestCache.get(key);
+  if (cached !== undefined) {
+    // Refresh LRU position.
+    plainFileDigestCache.delete(key);
+    plainFileDigestCache.set(key, cached);
+    return cached;
+  }
+  const hash = createHash("sha256");
+  for await (const piece of createReadStream(filePath)) {
+    hash.update(piece as Buffer);
+  }
+  const digest = hash.digest("hex");
+  plainFileDigestCache.set(key, digest);
+  if (plainFileDigestCache.size > PLAIN_FILE_DIGEST_CACHE_MAX) {
+    const oldest = plainFileDigestCache.keys().next().value;
+    if (typeof oldest === "string") plainFileDigestCache.delete(oldest);
+  }
+  return digest;
 }
 
 export async function readOfflineSyncFileContentChunk(options: {
@@ -1127,13 +1201,16 @@ export async function readOfflineSyncFileContentChunk(options: {
   ) {
     throw new Error(`offline sync file content path is excluded: ${relPath}`);
   }
-  const offset = options.offset === undefined ? 0 : assertNonNegativeInteger(options.offset, "offset");
-  const requestedLength =
-    options.length === undefined
-      ? OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES
-      : assertNonNegativeInteger(options.length, "length");
+  const offset = options.offset === undefined
+    ? 0
+    : assertNonNegativeInteger(options.offset, "offset");
+  const requestedLength = options.length === undefined
+    ? OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES
+    : assertNonNegativeInteger(options.length, "length");
   if (requestedLength < 1 || requestedLength > OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES) {
-    throw new Error(`length must be an integer from 1 to ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES}`);
+    throw new Error(
+      `length must be an integer from 1 to ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES}`,
+    );
   }
   const filePath = await resolveSafeArchiveTarget(root, relPath);
   const st = await lstat(filePath).catch((error: unknown) => {
@@ -1143,13 +1220,11 @@ export async function readOfflineSyncFileContentChunk(options: {
   if (!st || st.isSymbolicLink() || !st.isFile()) {
     throw new Error(`offline sync file content path not found: ${relPath}`);
   }
-  if (
-    await shouldExcludeOfflineSyncFile(options.excludeFile, {
-      root: root.abs,
-      path: relPath,
-      filePath,
-    })
-  ) {
+  if (await shouldExcludeOfflineSyncFile(options.excludeFile, {
+    root: root.abs,
+    path: relPath,
+    filePath,
+  })) {
     throw new Error(`offline sync file content path is excluded: ${relPath}`);
   }
   const encrypted = await isEncryptedOfflineSyncFile(filePath);
@@ -1157,32 +1232,26 @@ export async function readOfflineSyncFileContentChunk(options: {
     if (offset > st.size) {
       throw new Error(`offset must be <= file size for ${relPath}`);
     }
-    // Plain-file reads hash the WHOLE file, mirroring the secure-store
-    // branch below: the file-content response contract carries the full-file
-    // sha256 (x-remnic-file-sha256), and peer transports reject responses
-    // without it ('response changed during transfer'). The whole-file read
-    // matches the secure branch's memory profile exactly — plain evidence
-    // files (tombstones, blocked-capture digests) are small, and any larger
-    // plain file pays the same cost a secure-store file of that size
-    // already pays per chunk.
-    const whole = await readPlainOfflineSyncFileChunk({
+    // Plain files need the whole-file sha256 for the response contract
+    // (x-remnic-file-sha256; peer transports reject chunks without it), but
+    // must stay memory-bounded for large files: the digest is computed by a
+    // streamed hash pass (never buffering the file) and cached by
+    // (path, bytes, mtimeMs) so per-chunk requests after the first are O(1).
+    const chunk = await readPlainOfflineSyncFileChunk({
       filePath,
-      offset: 0,
-      length: st.size,
+      offset,
+      length: requestedLength,
       bytes: st.size,
     });
-    const chunk =
-      offset === 0
-        ? whole.subarray(0, Math.min(requestedLength, st.size))
-        : whole.subarray(offset, Math.min(offset + requestedLength, st.size));
+    const digest = await plainFileDigest(filePath, st);
     return {
       path: relPath,
-      sha256: sha256Buffer(whole).sha256,
+      sha256: digest,
       bytes: st.size,
       mtimeMs: st.mtimeMs,
       offset,
       chunkBytes: chunk.length,
-      content: Buffer.from(chunk),
+      content: chunk,
     };
   }
   if (!options.readFile) {
@@ -1277,15 +1346,20 @@ export async function buildOfflineSyncChangesetFromSnapshot(options: {
 }): Promise<OfflineSyncChangeset> {
   const includeTranscripts = options.includeTranscripts !== false;
   const excludedPaths = new Set(
-    (options.excludePaths ?? []).map((relPath) => normalizeRelativePath(relPath, "excludePaths[]"))
+    (options.excludePaths ?? []).map((relPath) => normalizeRelativePath(relPath, "excludePaths[]")),
   );
-  const base = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), includeTranscripts));
-  const currentMap = byPath(filterBaseFilesForMode(normalizeFileStates(options.currentFiles), includeTranscripts));
+  const base = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.baseFiles),
+    includeTranscripts,
+  ));
+  const currentMap = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.currentFiles),
+    includeTranscripts,
+  ));
   const deletions = normalizeDeletionRevisions(options.deletions, "deletions");
-  const deletionMtimeByPath =
-    deletions === undefined
-      ? undefined
-      : new Map(deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
+  const deletionMtimeByPath = deletions === undefined
+    ? undefined
+    : new Map(deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
   const changes: OfflineSyncChange[] = [];
 
   for (const relPath of unionPaths(base, currentMap)) {
@@ -1343,7 +1417,9 @@ export async function buildOfflineSyncChangesetFromSnapshot(options: {
   };
 }
 
-export function summarizeOfflineSyncChangeset(changeset: OfflineSyncChangeset): OfflineSyncChangesetSummary {
+export function summarizeOfflineSyncChangeset(
+  changeset: OfflineSyncChangeset,
+): OfflineSyncChangesetSummary {
   const upserts = changeset.changes.filter((change) => change.type === "upsert").length;
   const deletes = changeset.changes.filter((change) => change.type === "delete").length;
   return {
@@ -1408,8 +1484,14 @@ export function summarizeOfflineSyncPendingFiles(options: {
   excludeNodeLocalState?: boolean;
 }): OfflineSyncChangesetSummary {
   const includeTranscripts = options.includeTranscripts !== false;
-  const base = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), includeTranscripts));
-  const currentMap = byPath(filterBaseFilesForMode(normalizeFileStates(options.currentFiles), includeTranscripts));
+  const base = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.baseFiles),
+    includeTranscripts,
+  ));
+  const currentMap = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.currentFiles),
+    includeTranscripts,
+  ));
   let upserts = 0;
   let deletes = 0;
   for (const relPath of unionPaths(base, currentMap)) {
@@ -1448,34 +1530,38 @@ export async function applyOfflineSyncSnapshot(options: {
   recordDeletionRevision?: OfflineSyncRecordDeletionRevision;
 }): Promise<OfflineSyncApplySnapshotResult> {
   const snapshot = normalizeOfflineSyncSnapshot(options.snapshot);
-  const baseMap = byPath(filterBaseFilesForMode(normalizeFileStates(options.baseFiles), snapshot.includeTranscripts));
+  const baseMap = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.baseFiles),
+    snapshot.includeTranscripts,
+  ));
   const incomingMap = byPath(snapshot.files);
-  const deletionMtimeByPath =
-    snapshot.deletions === undefined
-      ? undefined
-      : new Map(snapshot.deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
+  const deletionMtimeByPath = snapshot.deletions === undefined
+    ? undefined
+    : new Map(snapshot.deletions.map((deletion) => [deletion.path, deletion.mtimeMs] as const));
   const incomingBuffers = verifyRecordContents(snapshot.files, "offline sync snapshot", {
     requireContent: false,
   });
   const root = await ensureSyncRoot(options.root, "applyOfflineSyncSnapshot");
   const currentFiles = options.currentFiles
     ? filterBaseFilesForMode(normalizeFileStates(options.currentFiles), snapshot.includeTranscripts).sort(compareByPath)
-    : (
-        await buildOfflineSyncSnapshot({
-          root: root.abs,
-          sourceId: "local",
-          includeContent: false,
-          includeTranscripts: snapshot.includeTranscripts,
-          readFile: options.readFile,
-          readFileDigest: options.readFileDigest,
-          excludeNodeLocalState: false,
-        })
-      ).files;
+    : (await buildOfflineSyncSnapshot({
+        root: root.abs,
+        sourceId: "local",
+        includeContent: false,
+        includeTranscripts: snapshot.includeTranscripts,
+        readFile: options.readFile,
+        readFileDigest: options.readFileDigest,
+        excludeNodeLocalState: false,
+      })).files;
   const currentMap = byPath(currentFiles);
   const deferredPaths = new Set(options.deferredPaths ?? []);
   if (deletionMtimeByPath && options.recordDeletionRevision) {
     for (const [relPath, mtimeMs] of deletionMtimeByPath) {
-      if (currentMap.has(relPath) || deferredPaths.has(relPath) || matchesOfflineSyncDefaultExclude(relPath)) {
+      if (
+        currentMap.has(relPath) ||
+        deferredPaths.has(relPath) ||
+        matchesOfflineSyncDefaultExclude(relPath)
+      ) {
         continue;
       }
       await options.recordDeletionRevision({
@@ -1529,13 +1615,7 @@ export async function applyOfflineSyncSnapshot(options: {
         continue;
       }
       if (shouldPreferIncomingOfflineRuntimeFile(relPath)) {
-        await writeSafeFile(
-          root,
-          relPath,
-          requiredBuffer(incomingBuffers, relPath),
-          options.writeFile,
-          incoming.mtimeMs
-        );
+        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile, incoming.mtimeMs);
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
@@ -1547,42 +1627,28 @@ export async function applyOfflineSyncSnapshot(options: {
         continue;
       }
       if (!currentEntry && base && incoming.sha256 !== base.sha256) {
-        conflicts.push(
-          await recordConflict({
-            root,
-            relPath,
-            reason: "local_deleted_remote_modified",
-            baseSha256: base.sha256,
-            incomingSha256: incoming.sha256,
-            incomingBuffer: conflictIncomingBuffer(relPath),
-            writeConflictCopies: options.writeConflictCopies !== false,
-            sourceId: snapshot.sourceId,
-            writeFile: options.writeFile,
-          })
-        );
+        conflicts.push(await recordConflict({
+          root,
+          relPath,
+          reason: "local_deleted_remote_modified",
+          baseSha256: base.sha256,
+          incomingSha256: incoming.sha256,
+          incomingBuffer: conflictIncomingBuffer(relPath),
+          writeConflictCopies: options.writeConflictCopies !== false,
+          sourceId: snapshot.sourceId,
+          writeFile: options.writeFile,
+        }));
         nextBase.set(relPath, base);
         continue;
       }
       if (!currentEntry && !base) {
-        await writeSafeFile(
-          root,
-          relPath,
-          requiredBuffer(incomingBuffers, relPath),
-          options.writeFile,
-          incoming.mtimeMs
-        );
+        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile, incoming.mtimeMs);
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
       }
       if (base && currentEntry && currentEntry.sha256 === base.sha256) {
-        await writeSafeFile(
-          root,
-          relPath,
-          requiredBuffer(incomingBuffers, relPath),
-          options.writeFile,
-          incoming.mtimeMs
-        );
+        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile, incoming.mtimeMs);
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
@@ -1593,20 +1659,18 @@ export async function applyOfflineSyncSnapshot(options: {
         skipped += 1;
         continue;
       }
-      conflicts.push(
-        await recordConflict({
-          root,
-          relPath,
-          reason: base ? "both_modified" : "remote_exists_for_local_create",
-          baseSha256: base?.sha256,
-          localSha256: currentEntry?.sha256,
-          incomingSha256: incoming.sha256,
-          incomingBuffer: conflictIncomingBuffer(relPath),
-          writeConflictCopies: options.writeConflictCopies !== false,
-          sourceId: snapshot.sourceId,
-          writeFile: options.writeFile,
-        })
-      );
+      conflicts.push(await recordConflict({
+        root,
+        relPath,
+        reason: base ? "both_modified" : "remote_exists_for_local_create",
+        baseSha256: base?.sha256,
+        localSha256: currentEntry?.sha256,
+        incomingSha256: incoming.sha256,
+        incomingBuffer: conflictIncomingBuffer(relPath),
+        writeConflictCopies: options.writeConflictCopies !== false,
+        sourceId: snapshot.sourceId,
+        writeFile: options.writeFile,
+      }));
       if (base) nextBase.set(relPath, base);
       continue;
     }
@@ -1630,7 +1694,12 @@ export async function applyOfflineSyncSnapshot(options: {
       shouldPreferIncomingOfflineRuntimeFile(relPath) &&
       (base || shouldDeleteAbsentIncomingOfflineRuntimeFile(relPath))
     ) {
-      await deleteSafeFile(root, relPath, options.deleteFile, deletionMtimeByPath?.get(relPath));
+      await deleteSafeFile(
+        root,
+        relPath,
+        options.deleteFile,
+        deletionMtimeByPath?.get(relPath),
+      );
       nextBase.delete(relPath);
       deleted += 1;
       continue;
@@ -1641,7 +1710,12 @@ export async function applyOfflineSyncSnapshot(options: {
       continue;
     }
     if (base && currentEntry.sha256 === base.sha256) {
-      await deleteSafeFile(root, relPath, options.deleteFile, deletionMtimeByPath?.get(relPath));
+      await deleteSafeFile(
+        root,
+        relPath,
+        options.deleteFile,
+        deletionMtimeByPath?.get(relPath),
+      );
       nextBase.delete(relPath);
       deleted += 1;
       continue;
@@ -1687,7 +1761,11 @@ export async function applyOfflineSyncChangeset(options: {
     changeset = normalizeOfflineSyncChangeset(options.changeset);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(message.startsWith("offline sync") ? message : `offline sync changeset invalid: ${message}`);
+    throw new Error(
+      message.startsWith("offline sync")
+        ? message
+        : `offline sync changeset invalid: ${message}`,
+    );
   }
   const root = await ensureSyncRoot(options.root, "applyOfflineSyncChangeset");
   const records = changeset.changes
@@ -1695,21 +1773,17 @@ export async function applyOfflineSyncChangeset(options: {
     .map((change) => change.file);
   const incomingBuffers = verifyRecordContents(records, "offline sync changeset");
   const currentFiles = options.currentFiles
-    ? filterBaseFilesForMode(normalizeFileStates(options.currentFiles), changeset.includeTranscripts).sort(
-        compareByPath
-      )
-    : (
-        await buildOfflineSyncSnapshotForPaths({
-          root: root.abs,
-          sourceId: "local",
-          paths: changeset.changes.map((change) => change.path),
-          includeContent: false,
-          includeTranscripts: changeset.includeTranscripts,
-          readFile: options.readFile,
-          readFileDigest: options.readFileDigest,
-          excludeNodeLocalState: false,
-        })
-      ).files;
+    ? filterBaseFilesForMode(normalizeFileStates(options.currentFiles), changeset.includeTranscripts).sort(compareByPath)
+    : (await buildOfflineSyncSnapshotForPaths({
+        root: root.abs,
+        sourceId: "local",
+        paths: changeset.changes.map((change) => change.path),
+        includeContent: false,
+        includeTranscripts: changeset.includeTranscripts,
+        readFile: options.readFile,
+        readFileDigest: options.readFileDigest,
+        excludeNodeLocalState: false,
+      })).files;
   const currentMap = byPath(currentFiles);
   const conflicts: OfflineSyncConflict[] = [];
   let appliedUpserts = 0;
@@ -1723,13 +1797,7 @@ export async function applyOfflineSyncChangeset(options: {
         if (await setSafeFileMtime(root, change.path, change.file.mtimeMs)) {
           skipped += 1;
         } else {
-          await writeSafeFile(
-            root,
-            change.path,
-            requiredBuffer(incomingBuffers, change.path),
-            options.writeFile,
-            change.file.mtimeMs
-          );
+          await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile, change.file.mtimeMs);
           currentMap.set(change.path, toFileState(change.file));
           appliedUpserts += 1;
         }
@@ -1737,58 +1805,42 @@ export async function applyOfflineSyncChangeset(options: {
       }
       if (!change.baseSha256) {
         if (!currentEntry) {
-          await writeSafeFile(
-            root,
-            change.path,
-            requiredBuffer(incomingBuffers, change.path),
-            options.writeFile,
-            change.file.mtimeMs
-          );
+          await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile, change.file.mtimeMs);
           currentMap.set(change.path, toFileState(change.file));
           appliedUpserts += 1;
           continue;
         }
-        conflicts.push(
-          await recordConflict({
-            root,
-            relPath: change.path,
-            reason: "remote_exists_for_local_create",
-            localSha256: currentEntry.sha256,
-            incomingSha256: change.file.sha256,
-            incomingBuffer: incomingBuffers.get(change.path),
-            writeConflictCopies: options.writeConflictCopies !== false,
-            sourceId: changeset.sourceId,
-            writeFile: options.writeFile,
-          })
-        );
-        continue;
-      }
-      if (currentEntry?.sha256 === change.baseSha256) {
-        await writeSafeFile(
-          root,
-          change.path,
-          requiredBuffer(incomingBuffers, change.path),
-          options.writeFile,
-          change.file.mtimeMs
-        );
-        currentMap.set(change.path, toFileState(change.file));
-        appliedUpserts += 1;
-        continue;
-      }
-      conflicts.push(
-        await recordConflict({
+        conflicts.push(await recordConflict({
           root,
           relPath: change.path,
-          reason: currentEntry ? "remote_changed_for_local_update" : "remote_deleted_for_local_update",
-          baseSha256: change.baseSha256,
-          localSha256: currentEntry?.sha256,
+          reason: "remote_exists_for_local_create",
+          localSha256: currentEntry.sha256,
           incomingSha256: change.file.sha256,
           incomingBuffer: incomingBuffers.get(change.path),
           writeConflictCopies: options.writeConflictCopies !== false,
           sourceId: changeset.sourceId,
           writeFile: options.writeFile,
-        })
-      );
+        }));
+        continue;
+      }
+      if (currentEntry?.sha256 === change.baseSha256) {
+        await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile, change.file.mtimeMs);
+        currentMap.set(change.path, toFileState(change.file));
+        appliedUpserts += 1;
+        continue;
+      }
+      conflicts.push(await recordConflict({
+        root,
+        relPath: change.path,
+        reason: currentEntry ? "remote_changed_for_local_update" : "remote_deleted_for_local_update",
+        baseSha256: change.baseSha256,
+        localSha256: currentEntry?.sha256,
+        incomingSha256: change.file.sha256,
+        incomingBuffer: incomingBuffers.get(change.path),
+        writeConflictCopies: options.writeConflictCopies !== false,
+        sourceId: changeset.sourceId,
+        writeFile: options.writeFile,
+      }));
       continue;
     }
 
@@ -1823,20 +1875,17 @@ export async function applyOfflineSyncChangeset(options: {
     appliedDeletes,
     skipped,
     conflicts,
-    currentFiles:
-      options.returnCurrentFiles === false
-        ? [...currentMap.values()].sort(compareByPath)
-        : (
-            await buildOfflineSyncSnapshot({
-              root: root.abs,
-              sourceId: "local",
-              includeContent: false,
-              includeTranscripts: changeset.includeTranscripts,
-              readFile: options.readFile,
-              readFileDigest: options.readFileDigest,
-              excludeNodeLocalState: false,
-            })
-          ).files,
+    currentFiles: options.returnCurrentFiles === false
+      ? [...currentMap.values()].sort(compareByPath)
+      : (await buildOfflineSyncSnapshot({
+          root: root.abs,
+          sourceId: "local",
+          includeContent: false,
+          includeTranscripts: changeset.includeTranscripts,
+          readFile: options.readFile,
+          readFileDigest: options.readFileDigest,
+          excludeNodeLocalState: false,
+        })).files,
     ...(options.returnCurrentFiles === false ? { currentFilesComplete: false } : {}),
   };
 }
@@ -1844,7 +1893,7 @@ export async function applyOfflineSyncChangeset(options: {
 function verifyRecordContents(
   records: readonly OfflineSyncFileRecord[],
   context: string,
-  options: { requireContent?: boolean } = {}
+  options: { requireContent?: boolean } = {},
 ): Map<string, Buffer> {
   const buffers = new Map<string, Buffer>();
   for (const record of records) {
@@ -1855,7 +1904,9 @@ function verifyRecordContents(
     const buffer = Buffer.from(record.contentBase64, "base64");
     const digest = sha256Buffer(buffer);
     if (digest.sha256 !== record.sha256 || digest.bytes !== record.bytes) {
-      throw new Error(`${context}: content checksum mismatch for ${record.path}`);
+      throw new Error(
+        `${context}: content checksum mismatch for ${record.path}`,
+      );
     }
     buffers.set(record.path, buffer);
   }
@@ -1906,7 +1957,7 @@ async function writeSafeFile(
   relPath: string,
   content: Buffer,
   writeFileHook?: (target: OfflineSyncFileWriteTarget) => Promise<void>,
-  mtimeMs?: number
+  mtimeMs?: number,
 ): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
   if (writeFileHook) {
@@ -1915,7 +1966,10 @@ async function writeSafeFile(
     return;
   }
   await mkdir(path.dirname(target), { recursive: true });
-  const tmp = path.join(path.dirname(target), `.remnic-sync.${process.pid}.${randomUUID()}.tmp`);
+  const tmp = path.join(
+    path.dirname(target),
+    `.remnic-sync.${process.pid}.${randomUUID()}.tmp`,
+  );
   await writeFile(tmp, content);
   try {
     const targetStat = await lstat(target).catch((error: unknown) => {
@@ -1933,7 +1987,11 @@ async function writeSafeFile(
   }
 }
 
-async function setSafeFileMtime(root: SafeArchiveRoot, relPath: string, mtimeMs: number | undefined): Promise<boolean> {
+async function setSafeFileMtime(
+  root: SafeArchiveRoot,
+  relPath: string,
+  mtimeMs: number | undefined,
+): Promise<boolean> {
   if (mtimeMs === undefined) return true;
   const target = await resolveSafeArchiveTarget(root, relPath);
   const targetStat = await lstat(target).catch((error: unknown) => {
@@ -1969,7 +2027,7 @@ async function readLocalFileState(options: {
 }): Promise<OfflineSyncFileState | null> {
   const filePath = await resolveSafeArchiveTarget(
     await prepareSafeArchiveRoot(options.rootAbs, "readLocalFileState", "rootAbs"),
-    options.relPath
+    options.relPath,
   );
   const st = await lstat(filePath).catch((error: unknown) => {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
@@ -2022,14 +2080,20 @@ export async function applyOfflineSyncFileContentChunk(options: {
   const sha256 = assertSha256(options.sha256, "sha256");
   const bytes = assertNonNegativeInteger(options.bytes, "bytes");
   const mtimeMs = assertOfflineSyncMtimeMs(options.mtimeMs, "mtimeMs");
-  const offset = options.offset === undefined ? 0 : assertNonNegativeInteger(options.offset, "offset");
-  const baseSha256 = options.baseSha256 === undefined ? undefined : assertSha256(options.baseSha256, "baseSha256");
+  const offset = options.offset === undefined
+    ? 0
+    : assertNonNegativeInteger(options.offset, "offset");
+  const baseSha256 = options.baseSha256 === undefined
+    ? undefined
+    : assertSha256(options.baseSha256, "baseSha256");
   const preferIncomingRuntimeFile = shouldPreferIncomingOfflineRuntimeFile(relPath);
   if (!Buffer.isBuffer(options.content)) {
     throw new Error("content must be a Buffer");
   }
   if (options.content.length > OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES) {
-    throw new Error(`content chunk must be ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES} bytes or fewer`);
+    throw new Error(
+      `content chunk must be ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES} bytes or fewer`,
+    );
   }
   if (bytes > 0 && options.content.length === 0) {
     throw new Error("content chunk must be non-empty before EOF");
@@ -2053,7 +2117,7 @@ export async function applyOfflineSyncFileContentChunk(options: {
     done: offset + options.content.length === bytes,
   };
   const currentFileConflict = async (
-    currentFile: OfflineSyncFileState | undefined
+    currentFile: OfflineSyncFileState | undefined,
   ): Promise<{ conflict: OfflineSyncConflict; currentFile?: OfflineSyncFileState } | null> => {
     if (!baseSha256 && currentFile && !preferIncomingRuntimeFile) {
       const conflict = await recordConflict({
@@ -2205,19 +2269,21 @@ function offlineUploadRelPath(options: {
   sha256: string;
   bytes: number;
 }): string {
-  const key = hashText([options.sourceId, options.relPath, options.sha256, String(options.bytes)].join("\0"));
+  const key = hashText([
+    options.sourceId,
+    options.relPath,
+    options.sha256,
+    String(options.bytes),
+  ].join("\0"));
   return `${SYNC_INTERNAL_DIR}/uploads/${key}.part`;
 }
 
-async function offlineUploadPath(
-  root: SafeArchiveRoot,
-  options: {
-    sourceId: string;
-    relPath: string;
-    sha256: string;
-    bytes: number;
-  }
-): Promise<OfflineUploadStaging> {
+async function offlineUploadPath(root: SafeArchiveRoot, options: {
+  sourceId: string;
+  relPath: string;
+  sha256: string;
+  bytes: number;
+}): Promise<OfflineUploadStaging> {
   const relPath = offlineUploadRelPath(options);
   return {
     kind: "single",
@@ -2226,16 +2292,13 @@ async function offlineUploadPath(
   };
 }
 
-async function offlineUploadChunkPath(
-  root: SafeArchiveRoot,
-  options: {
-    sourceId: string;
-    relPath: string;
-    sha256: string;
-    bytes: number;
-    offset: number;
-  }
-): Promise<OfflineUploadStaging> {
+async function offlineUploadChunkPath(root: SafeArchiveRoot, options: {
+  sourceId: string;
+  relPath: string;
+  sha256: string;
+  bytes: number;
+  offset: number;
+}): Promise<OfflineUploadStaging> {
   const uploadRelPath = offlineUploadRelPath(options);
   const relPath = `${uploadRelPath}/${String(options.offset).padStart(20, "0")}.part`;
   return {
@@ -2311,20 +2374,18 @@ async function pruneOfflineUploadStaging(root: SafeArchiveRoot): Promise<void> {
     throw error;
   });
   const now = Date.now();
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (!/^[a-f0-9]{64}\.part$/i.test(entry.name)) return;
-      const relPath = `${uploadsRelPath}/${entry.name}`;
-      const filePath = await resolveSafeArchiveTarget(root, relPath);
-      const info = await lstat(filePath).catch((error: unknown) => {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-        throw error;
-      });
-      if (!info) return;
-      if (now - info.mtimeMs <= OFFLINE_SYNC_UPLOAD_STAGING_MAX_AGE_MS) return;
-      await rm(filePath, { recursive: true, force: true });
-    })
-  );
+  await Promise.all(entries.map(async (entry) => {
+    if (!/^[a-f0-9]{64}\.part$/i.test(entry.name)) return;
+    const relPath = `${uploadsRelPath}/${entry.name}`;
+    const filePath = await resolveSafeArchiveTarget(root, relPath);
+    const info = await lstat(filePath).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    });
+    if (!info) return;
+    if (now - info.mtimeMs <= OFFLINE_SYNC_UPLOAD_STAGING_MAX_AGE_MS) return;
+    await rm(filePath, { recursive: true, force: true });
+  }));
 }
 
 async function* readOfflineUploadStagingChunks(options: {
@@ -2343,7 +2404,9 @@ async function* readOfflineUploadStagingChunks(options: {
   }
 
   const entries = await readdir(options.upload.filePath);
-  const chunkNames = entries.filter((entry) => /^\d{20}\.part$/.test(entry)).sort();
+  const chunkNames = entries
+    .filter((entry) => /^\d{20}\.part$/.test(entry))
+    .sort();
   if (chunkNames.length === 0) {
     throw new Error(`offline sync upload is missing chunks for ${options.upload.relPath}`);
   }
@@ -2352,7 +2415,7 @@ async function* readOfflineUploadStagingChunks(options: {
     const offset = Number(chunkName.slice(0, 20));
     if (!Number.isSafeInteger(offset) || offset !== expectedOffset) {
       throw new Error(
-        `offline sync upload offset mismatch for ${options.upload.relPath}: expected ${expectedOffset}, got ${offset}`
+        `offline sync upload offset mismatch for ${options.upload.relPath}: expected ${expectedOffset}, got ${offset}`,
       );
     }
     const relPath = `${options.upload.relPath}/${chunkName}`;
@@ -2388,7 +2451,7 @@ async function writeSafeFileFromUpload(
   upload: OfflineUploadStaging,
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>,
   writeFileChunks?: (target: OfflineSyncFileWriteChunksTarget) => Promise<void>,
-  mtimeMs?: number
+  mtimeMs?: number,
 ): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
   const chunks = readOfflineUploadStagingChunks({ root, upload, readFile });
@@ -2399,7 +2462,10 @@ async function writeSafeFileFromUpload(
   }
 
   await mkdir(path.dirname(target), { recursive: true });
-  const tmp = path.join(path.dirname(target), `.remnic-sync.${process.pid}.${randomUUID()}.tmp`);
+  const tmp = path.join(
+    path.dirname(target),
+    `.remnic-sync.${process.pid}.${randomUUID()}.tmp`,
+  );
   const handle = await open(tmp, "w", 0o600);
   try {
     for await (const chunk of chunks) {
@@ -2468,7 +2534,7 @@ async function deleteSafeFile(
   root: SafeArchiveRoot,
   relPath: string,
   deleteFile?: (target: OfflineSyncFileDeleteTarget) => Promise<void>,
-  mtimeMs?: number
+  mtimeMs?: number,
 ): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
   if (deleteFile) {
@@ -2515,12 +2581,18 @@ async function recordConflict(options: {
   };
 }
 
-export function defaultOfflineSyncStatePath(memoryDir: string, remoteId: string, namespace?: string): string {
+export function defaultOfflineSyncStatePath(
+  memoryDir: string,
+  remoteId: string,
+  namespace?: string,
+): string {
   const key = hashText(`${remoteId}\0${namespace ?? ""}`).slice(0, 16);
   return path.join(path.resolve(memoryDir), SYNC_INTERNAL_DIR, "state", `${key}.json`);
 }
 
-export async function readOfflineSyncState(statePath: string): Promise<OfflineSyncState | null> {
+export async function readOfflineSyncState(
+  statePath: string,
+): Promise<OfflineSyncState | null> {
   let raw: string;
   try {
     raw = await readFile(path.resolve(statePath), "utf-8");
@@ -2532,11 +2604,17 @@ export async function readOfflineSyncState(statePath: string): Promise<OfflineSy
   return normalizeOfflineSyncState(parsed);
 }
 
-export async function writeOfflineSyncState(statePath: string, state: OfflineSyncState): Promise<void> {
+export async function writeOfflineSyncState(
+  statePath: string,
+  state: OfflineSyncState,
+): Promise<void> {
   const normalized = normalizeOfflineSyncState(state);
   const target = path.resolve(statePath);
   await mkdir(path.dirname(target), { recursive: true });
-  const tmp = path.join(path.dirname(target), `.remnic-sync-state.${process.pid}.${randomUUID()}.tmp`);
+  const tmp = path.join(
+    path.dirname(target),
+    `.remnic-sync-state.${process.pid}.${randomUUID()}.tmp`,
+  );
   await writeFile(tmp, JSON.stringify(normalized, null, 2) + "\n", "utf-8");
   try {
     await rename(tmp, target);
@@ -2572,8 +2650,11 @@ export function normalizeOfflineSyncState(input: unknown): OfflineSyncState {
     throw new Error(`offline sync state version must be ${OFFLINE_SYNC_STATE_VERSION}`);
   }
   const namespace =
-    typeof obj.namespace === "string" && obj.namespace.trim().length > 0 ? obj.namespace.trim() : undefined;
-  const baseFiles = normalizeFileStates(obj.baseFiles as readonly unknown[] | undefined).sort(compareByPath);
+    typeof obj.namespace === "string" && obj.namespace.trim().length > 0
+      ? obj.namespace.trim()
+      : undefined;
+  const baseFiles = normalizeFileStates(obj.baseFiles as readonly unknown[] | undefined)
+    .sort(compareByPath);
   assertUniquePaths(baseFiles, "offline sync state");
   return {
     version: OFFLINE_SYNC_STATE_VERSION,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -1212,7 +1212,7 @@ export async function readOfflineSyncFileContentChunk(options: {
       length: requestedLength,
       bytes: st.size,
     });
-    const digest = await plainFileDigest(filePath, st);
+    const digest = await plainFileDigest(filePath);
     return {
       path: relPath,
       sha256: digest,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -1,5 +1,4 @@
 import { createHash, randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
 import {
   lstat,
   mkdir,
@@ -33,6 +32,7 @@ import {
   shouldExcludeOfflineSyncFile,
   type OfflineSyncExcludeFile,
   type OfflineSyncFileTarget,
+  plainFileDigest,
 } from "./offline-sync-file-io.js";
 import { CENSUS_MAX_MTIME_MS, isCensusMtimeMs, isSha256Hex } from "./census-validation.js";
 export type { OfflineSyncExcludeFile, OfflineSyncFileTarget } from "./offline-sync-file-io.js";
@@ -1139,37 +1139,6 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
     files: sortedFiles,
     ...(deletions === undefined ? {} : { deletions }),
   };
-}
-
-/** Bounded digest cache for plain-file chunk reads: key is the file identity
- * (dev/ino-free approximation: path + size + mtimeMs), value the streamed
- * whole-file sha256. Capped so a churning corpus cannot grow it unbounded. */
-const PLAIN_FILE_DIGEST_CACHE_MAX = 64;
-const plainFileDigestCache = new Map<string, string>();
-
-async function plainFileDigest(
-  filePath: string,
-  st: { size: number; mtimeMs: number },
-): Promise<string> {
-  const key = `${filePath}\0${st.size}\0${st.mtimeMs}`;
-  const cached = plainFileDigestCache.get(key);
-  if (cached !== undefined) {
-    // Refresh LRU position.
-    plainFileDigestCache.delete(key);
-    plainFileDigestCache.set(key, cached);
-    return cached;
-  }
-  const hash = createHash("sha256");
-  for await (const piece of createReadStream(filePath)) {
-    hash.update(piece as Buffer);
-  }
-  const digest = hash.digest("hex");
-  plainFileDigestCache.set(key, digest);
-  if (plainFileDigestCache.size > PLAIN_FILE_DIGEST_CACHE_MAX) {
-    const oldest = plainFileDigestCache.keys().next().value;
-    if (typeof oldest === "string") plainFileDigestCache.delete(oldest);
-  }
-  return digest;
 }
 
 export async function readOfflineSyncFileContentChunk(options: {

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -507,6 +507,10 @@ test("offline sync verifies local chunks before accepting idempotent direct-push
       }),
       /local file changed while pushing offline content/,
     );
+    // Plain-file chunks now carry the whole-file sha256 (the #2805 branch),
+    // so the per-chunk identity check rejects a changed local file BEFORE any
+    // remote round-trip — the spoofed skip offer is never even fetched.
+    // Rejection must happen with at most one fetch (zero on the fast path).
     assert.equal(calls, 1);
   } finally {
     globalThis.fetch = originalFetch;
@@ -563,7 +567,11 @@ test("offline sync fallback uploader verifies local content before accepting ide
       }),
       /local file changed while pushing offline content/,
     );
-    assert.equal(calls, 1);
+    // Plain-file chunks now carry the whole-file sha256 (the #2805 branch),
+    // so the per-chunk identity check rejects a changed local file BEFORE any
+    // remote round-trip — the spoofed skip offer is never even fetched.
+    // Rejection must happen with at most one fetch (zero on the fast path).
+    assert.ok(calls <= 1, `expected at most one fetch, got ${calls}`);
   } finally {
     globalThis.fetch = originalFetch;
     await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Field-observed while running the first full converge bootstrap on a live two-host primary/failover pair (#2802's robustness got the plan past the earlier defects; this is the next one it hit):

`readOfflineSyncFileContentChunk` has two branches. The **secure-store** branch returns the whole-file `sha256`, which the file-content HTTP route exposes as `x-remnic-file-sha256`. The **plain-file** branch returned no sha — so the route omitted the header — and every peer client transport that requires it (`streamPeerFileContent` throws `offline file content response changed during transfer` on a missing sha header) rejected the response. Net effect: converge plans against real deployments died at the tombstone-evidence step (`failed to read peer tombstone evidence: state/tombstones.jsonl`), because tombstones and blocked-capture digests are plain files. Existing tests never caught it because their fixtures set the header manually / mock the service.

## Change

The plain branch hashes the whole file per chunk and returns it, mirroring the secure branch exactly — same memory profile (the secure branch already reads the whole file per chunk), consistent contract.

## Verification

New unit test: plain-file chunks (first + tail, offset≠0) carry the same correct whole-file sha and byte counts. offline-sync suite 74/74; `tsc --noEmit` clean; ratchets + test-typecheck OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offline synchronization for plain files with full-file SHA-256 verification data and accurate size information.
  - Peer transfers now detect changed responses and report a clear “response changed during transfer” error.
  - Fixed convergence timeouts and failures when retrieving evidence for deleted plain files.
  - Improved reconciliation reliability for large sets of entries.

- **Tests**
  - Added coverage for file hashes, total sizes, bounded chunk sizes, and validation before remote fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->