### PR TITLE
fix(reconcile): per-entry push — spread-push overflows at boot scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `planReconciliation` spread-pushed each namespace's entries (`entries.push(...nsEntries)`); a boot-scale namespace (~100k entries) exceeds the call-stack argument limit and the plan dies with `RangeError: Maximum call stack size exceeded`. Entries are pushed per element now.
+
 ## [v9.69.18] — 2026-08-22
 
 ### Fixed

--- a/packages/remnic-core/src/reconcile/plan.test.ts
+++ b/packages/remnic-core/src/reconcile/plan.test.ts
@@ -1033,3 +1033,20 @@ test("POSIX-origin colon paths are rejected when the PEER platform is win32", ()
     "a push to a Windows peer must not plan a colon path"
   );
 });
+
+test("entry accumulation survives a boot-scale namespace (spread-push regression)", () => {
+  // V8's spread-argument limit sits near 125k; a namespace planning more
+  // entries than that previously died with RangeError: Maximum call stack
+  // size exceeded inside entries.push(...nsEntries).
+  const files: ReconcileFileState[] = [];
+  for (let i = 0; i < 130_000; i++) {
+    files.push({ path: `facts/boot-scale/f-${i}.md`, sha256: digest(`peer-${i}`), mtimeMs: 1000 });
+  }
+  const entries = planNamespaceReconciliation({
+    namespace: "default",
+    local: [],
+    peer: files,
+  });
+  assert.equal(entries.length, 130_000);
+  assert.ok(entries.every((entry) => entry.action === "pull"));
+});

--- a/packages/remnic-core/src/reconcile/plan.ts
+++ b/packages/remnic-core/src/reconcile/plan.ts
@@ -867,7 +867,12 @@ export function planReconciliation(
       );
     }
     seenNamespaces.add(name);
-    entries.push(...planNamespaceReconciliation(namespace, options));
+    // Spread-push over a boot-scale namespace (~100k entries) exceeds the
+    // call-stack argument limit (RangeError: Maximum call stack size exceeded)
+    // — push per entry instead.
+    for (const entry of planNamespaceReconciliation(namespace, options)) {
+      entries.push(entry);
+    }
   }
   entries.sort(compareReconcilePlanEntries);
   return {


### PR DESCRIPTION
## Summary

Third boot-scale defect from the same live two-host bootstrap run (after #2802 and #2805): `planReconciliation` gathered each namespace's entries with `entries.push(...nsEntries)`. A namespace planning ~100k entries exceeds the call-stack argument limit and the whole plan dies with `RangeError: Maximum call stack size exceeded` (stack trace points exactly at the spread push).

## Change

Push per element. No behavior change — same order, same result.

## Verification

reconcile/plan suite 61/61; `tsc --noEmit` clean; ratchets OK. The runtime proof is the live bootstrap run proceeding past the spread push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reconciliation failures for namespaces with approximately 100,000 entries.
  * Large namespace plans can now be processed without causing call-stack overflow errors.

* **Documentation**
  * Added an unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->