### PR TITLE
feat(http): POST /engram/v1/briefing — daily briefing over the access boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+
+### Added
+
+- `POST /engram/v1/briefing` exposes the daily briefing over the access HTTP boundary: the same registered `briefing` operation the MCP tool dispatches (schema validation, namespace gating, principal propagation), so thin HTTP clients — a Linux desktop panel client, health dashboards — can render a briefing without shelling out to the CLI. Pure read: no write-quota accounting. The response carries both renderings (`markdown` and `json` sections) in one payload regardless of the requested `format`.
+
 ## [v9.69.20] — 2026-08-22
 
 ### Fixed

--- a/packages/remnic-core/src/access-http-briefing.ts
+++ b/packages/remnic-core/src/access-http-briefing.ts
@@ -1,0 +1,35 @@
+import { getOperation } from "./access-boundary.js";
+import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
+
+type JsonResponder = (status: number, payload: unknown) => void;
+
+export interface BriefingHttpOptions {
+  /** Request body already run through the namespace gate (gatedBodyNamespace). */
+  gatedBody: Record<string, unknown>;
+  service: EngramAccessService;
+  principal: string | undefined;
+  respondJson: JsonResponder;
+}
+
+/**
+ * POST /engram/v1/briefing — daily briefing over the access HTTP boundary.
+ *
+ * Dispatches the registered `briefing` boundary operation (the one the MCP
+ * tool uses) so schema validation, namespace gating, and principal
+ * propagation reach every HTTP briefing call — the same shape as the
+ * coding/delta read dispatch. Pure read: nothing persists, so no
+ * write-quota accounting. The operation result already carries both
+ * renderings (markdown + json sections) in one response, letting thin
+ * clients render without a CLI subprocess.
+ */
+export async function respondBriefingHttp(options: BriefingHttpOptions): Promise<void> {
+  const op = getOperation("briefing");
+  if (!op) {
+    throw new EngramAccessInputError("access-boundary: operation not registered: briefing");
+  }
+  const output = (await op.run(options.gatedBody, {
+    service: options.service,
+    authenticatedPrincipal: options.principal,
+  })) as { result: unknown };
+  options.respondJson(200, output.result);
+}

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -852,7 +852,7 @@ test("HTTP briefing endpoint dispatches through the briefing operation", async (
     );
 
     assert.equal(response.status, 200);
-    const body = await response.json();
+    const body = (await response.json()) as { format: string; markdown: string; json: { sections: { activeThreads: unknown[] } } };
     assert.equal(body.format, "markdown");
     assert.equal(body.markdown, "# Briefing");
     assert.deepEqual(body.json.sections.activeThreads, []);
@@ -879,7 +879,7 @@ test("HTTP briefing endpoint dispatches through the briefing operation", async (
       },
     );
     assert.equal(invalid.status, 400);
-    assert.equal((await invalid.json()).code, "input_error");
+    assert.equal(((await invalid.json()) as { code: string }).code, "input_error");
     assert.equal(calls.length, 1);
   } finally {
     await server.stop();

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -810,6 +810,82 @@ test("HTTP coding-context endpoint accepts projectTag shorthand", async () => {
   }
 });
 
+test("HTTP briefing endpoint dispatches through the briefing operation", async () => {
+  const calls: unknown[] = [];
+  const service = {
+    briefing: async (request: unknown) => {
+      calls.push(request);
+      return {
+        format: "markdown",
+        window: { from: "2026-08-21", to: "2026-08-22" },
+        namespace: "team",
+        markdown: "# Briefing",
+        json: { sections: { activeThreads: [] } },
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "panel-user",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/briefing`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          since: "24h",
+          namespace: "team",
+          format: "markdown",
+          maxFollowups: 5,
+        }),
+      },
+    );
+
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.format, "markdown");
+    assert.equal(body.markdown, "# Briefing");
+    assert.deepEqual(body.json.sections.activeThreads, []);
+    assert.deepEqual(calls, [
+      {
+        since: "24h",
+        focus: undefined,
+        namespace: "team",
+        format: "markdown",
+        maxFollowups: 5,
+        principal: "panel-user",
+      },
+    ]);
+
+    const invalid = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/briefing`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ format: "jsno" }),
+      },
+    );
+    assert.equal(invalid.status, 400);
+    assert.equal((await invalid.json()).code, "input_error");
+    assert.equal(calls.length, 1);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("HTTP contradiction scan uses writable namespace resolver", async () => {
   const resolverCalls: Array<{
     namespace: string | undefined;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -49,6 +49,7 @@ import { getOperation, type OperationName } from "./access-boundary.js";
 import { authorizationProbeNamespaces, authorizationProbeRequiresPrincipalNamespace, probeOperationAuthorization } from "./access-authorization-probe.js";
 import { resolveQueryNamespaceWritablePreflight } from "./access-namespace-preflight.js";
 import { respondAccessCapabilitiesHttp } from "./access-http-lcm-compaction.js";
+import { respondBriefingHttp } from "./access-http-briefing.js";
 import { handleWhoKnowsHttpQuery } from "./who-knows.js";
 import {
   assertOperationAllowed,
@@ -994,11 +995,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
       // `memory_search` tool already exposes, reachable by HTTP-only clients.
       this.enforceTokenOp("memory_search"); // boundary dispatch (issue #1525)
       const operation = getOperation("memory_search");
-      if (!operation) {
-        throw new EngramAccessInputError(
-          "access-boundary: operation not registered: memory_search",
-        );
-      }
+      if (!operation) throw new EngramAccessInputError("access-boundary: operation not registered: memory_search");
       // The body `namespace` is user-controlled, so it must pass the same
       // effective-namespace allow-list gate as every other namespace-scoped
       // route (issue #1850 finding 2); the authenticated principal — never a
@@ -1946,9 +1943,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
         namespace: this.resolveNamespace(req, body.namespace),
       };
       const op = getOperation("memory_store");
-      if (!op) {
-        throw new EngramAccessInputError("access-boundary: operation not registered: memory_store");
-      }
+      if (!op) throw new EngramAccessInputError("access-boundary: operation not registered: memory_store");
       const output = (await op.run(envelope, {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
@@ -1980,9 +1975,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
         this.ensureWriteRateLimitAvailable(req);
       }
       const op = getOperation("coding_decision");
-      if (!op) {
-        throw new EngramAccessInputError("access-boundary: operation not registered: coding_decision");
-      }
+      if (!op) throw new EngramAccessInputError("access-boundary: operation not registered: coding_decision");
       const output = (await op.run(this.gatedBodyNamespace(req, body), {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
@@ -2005,9 +1998,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
         this.ensureWriteRateLimitAvailable(req);
       }
       const op = getOperation("coding_architecture");
-      if (!op) {
-        throw new EngramAccessInputError("access-boundary: operation not registered: coding_architecture");
-      }
+      if (!op) throw new EngramAccessInputError("access-boundary: operation not registered: coding_architecture");
       const output = (await op.run(this.gatedBodyNamespace(req, body), {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
@@ -2028,14 +2019,24 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
       // write-quota enforcement.
       const body = await this.readJsonBody(req);
       const op = getOperation("coding_delta");
-      if (!op) {
-        throw new EngramAccessInputError("access-boundary: operation not registered: coding_delta");
-      }
+      if (!op) throw new EngramAccessInputError("access-boundary: operation not registered: coding_delta");
       const output = (await op.run(this.gatedBodyNamespace(req, body), {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
       })) as { result: unknown };
       this.respondJson(res, 200, output.result);
+      return;
+    }
+
+    // Daily briefing — pure read through the registered `briefing` boundary
+    // operation (sibling module; see access-http-briefing.ts).
+    if (req.method === "POST" && pathname === "/engram/v1/briefing") {
+      await respondBriefingHttp({
+        gatedBody: this.gatedBodyNamespace(req, await this.readJsonBody(req)),
+        service: this.service,
+        principal: this.resolveRequestPrincipal(req),
+        respondJson: (status, payload) => this.respondJson(res, status, payload),
+      });
       return;
     }
 
@@ -2051,9 +2052,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
       this.ensureWriteRateLimitAvailable(req);
       const body = await this.readJsonBody(req);
       const op = getOperation("memory_correct_plan");
-      if (!op) {
-        throw new EngramAccessInputError("access-boundary: operation not registered: memory_correct_plan");
-      }
+      if (!op) throw new EngramAccessInputError("access-boundary: operation not registered: memory_correct_plan");
       const output = (await op.run(this.gatedBodyNamespace(req, body), {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
@@ -2067,9 +2066,7 @@ export class EngramAccessHttpServer extends ReviewDeckAccessHttpBase {
       this.ensureWriteRateLimitAvailable(req);
       const body = await this.readJsonBody(req);
       const op = getOperation("memory_correct_apply");
-      if (!op) {
-        throw new EngramAccessInputError("access-boundary: operation not registered: memory_correct_apply");
-      }
+      if (!op) throw new EngramAccessInputError("access-boundary: operation not registered: memory_correct_apply");
       const output = (await op.run(this.gatedBodyNamespace(req, body), {
         service: this.service,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -325,6 +325,15 @@ function extractHttpRouteDispatchMap(): Map<string, Set<string>> {
       }
     }
   }
+  if (/\bawait\s+respondBriefingHttp\(/.test(source)) {
+    const briefingSource = readFileSync(
+      new URL("./access-http-briefing.ts", import.meta.url),
+      "utf-8",
+    );
+    if (briefingSource.includes('getOperation("briefing")')) {
+      routeOps.set("POST /engram/v1/briefing", new Set(["briefing"]));
+    }
+  }
   if (/\bawait\s+this\.handleReviewDeckRequest\(/.test(source)) {
     const deckSource = readFileSync(
       new URL("./review/review-deck-http-base.ts", import.meta.url),

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -254,6 +254,7 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   { method: "POST", pathname: "/engram/v1/coding/decisions", operation: "coding_decision" },
   { method: "POST", pathname: "/engram/v1/coding/architecture", operation: "coding_architecture" },
   { method: "POST", pathname: "/engram/v1/coding/delta", operation: "coding_delta" },
+  { method: "POST", pathname: "/engram/v1/briefing", operation: "briefing" },
   { method: "POST", pathname: "/engram/v1/suggestions", operation: "suggestion_submit" },
   { method: "GET", pathname: "/engram/v1/memories", operation: "memory_list" },
   { method: "GET", pathname: "/engram/v1/recall/timings", operation: "recall_timings" },


### PR DESCRIPTION
## What

Adds `POST /engram/v1/briefing` to the access HTTP server, dispatching the already-registered `briefing` boundary operation — the same operation the MCP tool uses.

## Why

HTTP-only clients (a Linux desktop panel client, health dashboards) currently have to shell out to the CLI to render a daily briefing. The CLI path builds from local session state, which is empty on machines that run against a remote daemon; the operation itself serves the daemon's memory. An HTTP route gives those clients the same source of truth the MCP surface already has.

## Shape

- Mirrors the `coding/delta` read dispatch: `readJsonBody` → `gatedBodyNamespace` → `op.run` with `service` + authenticated principal → `respondJson(200, output.result)`.
- Pure read — nothing persists, so no write-quota accounting.
- No response-shape change: the operation already returns both renderings (`markdown` and `json` sections) in one payload regardless of the requested `format`, so thin clients can pick without a second call. Invalid `format` values still 400 through the existing `validateBriefingFormat` guard.
- Route body lives in a new `access-http-briefing.ts` sibling (issue #1995 file-size ratchet: `access-http.ts` sits exactly at its 4019-line ceiling). Six adjacent `if (!op) { throw … }` registration guards collapse to the one-line form the `memory_search` route already uses (`memory_store`, `coding_decision`, `coding_architecture`, `coding_delta`, `memory_correct_plan`, `memory_correct_apply`), netting the file to 4016 lines.

## Tests

`access-http.test.ts`: dispatch test asserting the service receives the gated namespace + principal and the response carries markdown and json sections; invalid `format` returns 400 `input_error` without reaching the service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `POST /engram/v1/briefing` endpoint for retrieving daily briefings.
  - Supports Markdown and JSON response formats.
  - Validates request data and enforces namespace access controls.
  - Preserves authentication context and uses read-only quota behavior.

- **Bug Fixes**
  - Invalid format requests return a clear `400 input_error` response without dispatching the briefing operation.

- **Documentation**
  - Added an Unreleased changelog entry for the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->