### PR TITLE
refactor(connectors): shared wearable registration helper

### DIFF
--- a/packages/connector-bee/src/index.ts
+++ b/packages/connector-bee/src/index.ts
@@ -17,8 +17,7 @@
 
 import {
   dateInTimezone,
-  registerWearableConnector,
-  getWearableConnector,
+  selfRegisterWearableConnector,
   type WearableConnectorFactoryOptions,
   type WearableConnectorRegistration,
   type WearableFetchOptions,
@@ -151,12 +150,5 @@ export const wearableConnectorRegistration: WearableConnectorRegistration = {
  * this module registers it as a side effect; calling this again is safe
  * (returns false when already registered).
  */
-export function ensureBeeConnectorRegistered(): boolean {
-  if (getWearableConnector(BEE_SOURCE_ID) !== undefined) {
-    return false;
-  }
-  registerWearableConnector(wearableConnectorRegistration);
-  return true;
-}
-
-ensureBeeConnectorRegistered();
+export const ensureBeeConnectorRegistered =
+  selfRegisterWearableConnector(wearableConnectorRegistration);

--- a/packages/connector-fireflies/src/index.ts
+++ b/packages/connector-fireflies/src/index.ts
@@ -13,8 +13,7 @@
  */
 
 import {
-  registerWearableConnector,
-  getWearableConnector,
+  selfRegisterWearableConnector,
   type WearableConnectorFactoryOptions,
   type WearableConnectorRegistration,
   type WearableFetchOptions,
@@ -130,10 +129,5 @@ export const wearableConnectorRegistration: WearableConnectorRegistration = {
  * this module registers it as a side effect; calling this again is safe
  * (returns false when already registered).
  */
-export function ensureFirefliesConnectorRegistered(): boolean {
-  if (getWearableConnector(FIREFLIES_SOURCE_ID)) return false;
-  registerWearableConnector(wearableConnectorRegistration);
-  return true;
-}
-
-ensureFirefliesConnectorRegistered();
+export const ensureFirefliesConnectorRegistered =
+  selfRegisterWearableConnector(wearableConnectorRegistration);

--- a/packages/connector-granola/src/index.ts
+++ b/packages/connector-granola/src/index.ts
@@ -13,8 +13,7 @@
  */
 
 import {
-  registerWearableConnector,
-  getWearableConnector,
+  selfRegisterWearableConnector,
   type WearableConnectorFactoryOptions,
   type WearableConnectorRegistration,
   type WearableConversation,
@@ -122,13 +121,9 @@ export const wearableConnectorRegistration: WearableConnectorRegistration = {
 };
 
 /**
- * Idempotently register the connector with the core registry. Importing this
- * module registers it as a side effect; calling again is safe.
+ * Idempotently register the connector with the core registry. Importing
+ * this module registers it as a side effect; calling this again is safe
+ * (returns false when already registered).
  */
-export function ensureGranolaConnectorRegistered(): boolean {
-  if (getWearableConnector(GRANOLA_SOURCE_ID)) return false;
-  registerWearableConnector(wearableConnectorRegistration);
-  return true;
-}
-
-ensureGranolaConnectorRegistered();
+export const ensureGranolaConnectorRegistered =
+  selfRegisterWearableConnector(wearableConnectorRegistration);

--- a/packages/connector-limitless/src/index.ts
+++ b/packages/connector-limitless/src/index.ts
@@ -12,8 +12,7 @@
  */
 
 import {
-  registerWearableConnector,
-  getWearableConnector,
+  selfRegisterWearableConnector,
   type WearableConnectorFactoryOptions,
   type WearableConnectorRegistration,
   type WearableFetchOptions,
@@ -102,12 +101,5 @@ export const wearableConnectorRegistration: WearableConnectorRegistration = {
  * this module registers it as a side effect; calling this again is safe
  * (returns false when already registered).
  */
-export function ensureLimitlessConnectorRegistered(): boolean {
-  if (getWearableConnector(LIMITLESS_SOURCE_ID) !== undefined) {
-    return false;
-  }
-  registerWearableConnector(wearableConnectorRegistration);
-  return true;
-}
-
-ensureLimitlessConnectorRegistered();
+export const ensureLimitlessConnectorRegistered =
+  selfRegisterWearableConnector(wearableConnectorRegistration);

--- a/packages/connector-omi/src/index.ts
+++ b/packages/connector-omi/src/index.ts
@@ -14,8 +14,7 @@
  */
 
 import {
-  registerWearableConnector,
-  getWearableConnector,
+  selfRegisterWearableConnector,
   type WearableConnectorFactoryOptions,
   type WearableConnectorRegistration,
   type WearableFetchOptions,
@@ -145,12 +144,5 @@ export const wearableConnectorRegistration: WearableConnectorRegistration = {
  * this module registers it as a side effect; calling this again is safe
  * (returns false when already registered).
  */
-export function ensureOmiConnectorRegistered(): boolean {
-  if (getWearableConnector(OMI_SOURCE_ID) !== undefined) {
-    return false;
-  }
-  registerWearableConnector(wearableConnectorRegistration);
-  return true;
-}
-
-ensureOmiConnectorRegistered();
+export const ensureOmiConnectorRegistered =
+  selfRegisterWearableConnector(wearableConnectorRegistration);

--- a/packages/remnic-core/src/wearables/index.ts
+++ b/packages/remnic-core/src/wearables/index.ts
@@ -18,6 +18,7 @@ export {
 export {
   builtInConnectorPackageSpecifier,
   registerWearableConnector,
+  selfRegisterWearableConnector,
   getWearableConnector,
   listWearableConnectors,
   clearWearableConnectors,

--- a/packages/remnic-core/src/wearables/registry.ts
+++ b/packages/remnic-core/src/wearables/registry.ts
@@ -64,6 +64,29 @@ export function getWearableConnector(
   return registrations.get(key);
 }
 
+/**
+ * Register a connector package with this registry immediately (idempotent)
+ * and return its `ensure*Registered()` companion.
+ *
+ * Connector packages call this once at module scope with their registration
+ * record, so importing the module registers the connector as a side effect.
+ * The returned companion re-checks the live registry on every call — so it
+ * also re-registers after a test-only registry reset — and returns false
+ * while the connector stays registered. `registerWearableConnector` throws
+ * on duplicate ids, which is why the registry is checked before each call.
+ */
+export function selfRegisterWearableConnector(
+  registration: WearableConnectorRegistration,
+): () => boolean {
+  const ensureRegistered = (): boolean => {
+    if (getWearableConnector(registration.id) !== undefined) return false;
+    registerWearableConnector(registration);
+    return true;
+  };
+  ensureRegistered();
+  return ensureRegistered;
+}
+
 export function listWearableConnectors(): string[] {
   return [...registrations.keys()];
 }


### PR DESCRIPTION
Fixes #2799

Five connector packages repeated the same ~20-LOC self-registration shell (resolve*Token -> lazy client -> wearableConnectorRegistration -> ensure*Registered() -> side-effect register). This collapses them into one small registration helper in @remnic/core; each index.ts is now config + vendor-specific token resolution.

- `grep -rn wearableConnectorRegistration packages/connector-*` → one definition (core), no copies
- All five connector suites pass unchanged (28/28): side-effect registration behavior identical, `ensure*() === false` after import still asserted
- `check:pre-push` green; no ratchet ceilings touched; connector files shrank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved automatic setup for wearable integrations, helping supported connectors become available consistently when the app starts.
  - Added more reliable recovery when a connector is unavailable, allowing it to be registered again when needed.
  - Standardized connector setup across Bee, Fireflies, Granola, Limitless, and Omi integrations.
- **Developer Experience**
  - Exposed a shared registration capability for wearable connector integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->