### PR TITLE
refactor(connectors): use core day-window and timezone helpers

### DIFF
--- a/packages/connector-fireflies/src/normalize.ts
+++ b/packages/connector-fireflies/src/normalize.ts
@@ -1,6 +1,6 @@
 /**
  * Normalize Fireflies.ai transcripts into Remnic's provider-agnostic
- * `WearableConversation` shape, plus the timezone-aware day-window helpers
+ * `WearableConversation` shape, plus the timezone-aware day-window helper
  * the Fireflies `transcripts(fromDate, toDate)` filter needs.
  *
  * Fireflies sentences carry `start_time`/`end_time` as second-offsets from the
@@ -12,78 +12,27 @@
  * day-anchored recall material.
  */
 
-import type {
-  WearableConversation,
-  WearableTranscriptSegment,
+import {
+  activityDayWindow,
+  type WearableConversation,
+  type WearableTranscriptSegment,
 } from "@remnic/core";
 
 import type { FirefliesTranscript } from "./client.js";
 
 export const FIREFLIES_SOURCE_ID = "fireflies";
 
-/** "GMT+05:30" → "+05:30"; plain "GMT" → "+00:00". */
-export function timezoneOffsetIso(instant: Date, timezone: string): string {
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      timeZoneName: "longOffset",
-    }).formatToParts(instant);
-    const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
-    const match = name.match(/GMT([+-]\d{2}:\d{2})?/);
-    return match?.[1] ?? "+00:00";
-  } catch {
-    return "+00:00";
-  }
-}
-
-/** ISO instant for local midnight of `date` in `timezone`. */
-export function zonedDayStartIso(date: string, timezone: string): string {
-  // Two-pass offset resolution: guess from midday (stable away from DST
-  // transitions), then re-derive at the candidate midnight itself.
-  let offset = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
-  const candidate = new Date(`${date}T00:00:00${offset}`);
-  const refined = timezoneOffsetIso(candidate, timezone);
-  if (refined !== offset) {
-    offset = refined;
-  }
-  return `${date}T00:00:00${offset}`;
-}
-
-export function nextIsoDate(date: string): string {
-  const parsed = new Date(`${date}T00:00:00Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + 1);
-  return parsed.toISOString().slice(0, 10);
-}
-
-/**
- * Reject an invalid/unsupported IANA timezone loudly. `Intl.DateTimeFormat`
- * throws a RangeError for an unknown zone; without this guard a typo'd
- * timezone would silently coerce to UTC and shift every meeting's day window
- * and timestamps (AGENTS.md §39 — reject, don't silently default).
- */
-function assertValidTimezone(timezone: string): void {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
-  } catch {
-    throw new RangeError(
-      `Invalid IANA timezone "${timezone}" for the Fireflies connector — check wearables.timezone.`,
-    );
-  }
-}
-
 /**
  * Half-open [fromDate, toDate) UTC ISO bounds of a local day — the window the
- * Fireflies `transcripts` query filters on.
+ * Fireflies `transcripts` query filters on. Field names map to the Fireflies
+ * API; the DST-aware window math is core's `activityDayWindow`.
  */
 export function firefliesDayWindow(
   date: string,
   timezone: string,
 ): { fromDate: string; toDate: string } {
-  assertValidTimezone(timezone);
-  return {
-    fromDate: new Date(zonedDayStartIso(date, timezone)).toISOString(),
-    toDate: new Date(zonedDayStartIso(nextIsoDate(date), timezone)).toISOString(),
-  };
+  const { startUtc, endUtc } = activityDayWindow(date, timezone);
+  return { fromDate: startUtc, toDate: endUtc };
 }
 
 /** Meeting start as epoch ms, from Fireflies' epoch-ms Float or ISO string. */

--- a/packages/connector-granola/src/normalize.ts
+++ b/packages/connector-granola/src/normalize.ts
@@ -1,6 +1,6 @@
 /**
  * Normalize Granola notes into Remnic's provider-agnostic
- * `WearableConversation` shape, plus the timezone-aware day-window helpers the
+ * `WearableConversation` shape, plus the timezone-aware day-window helper the
  * Granola `created_after`/`created_before` filters need.
  *
  * Granola transcript items carry absolute `start_time`/`end_time` (ISO) and a
@@ -11,74 +11,27 @@
  * transcript degrade to a single `note` segment.
  */
 
-import type {
-  WearableConversation,
-  WearableTranscriptSegment,
+import {
+  activityDayWindow,
+  type WearableConversation,
+  type WearableTranscriptSegment,
 } from "@remnic/core";
 
 import type { GranolaNote } from "./client.js";
 
 export const GRANOLA_SOURCE_ID = "granola";
 
-/** "GMT+05:30" → "+05:30"; plain "GMT" → "+00:00". */
-export function timezoneOffsetIso(instant: Date, timezone: string): string {
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      timeZoneName: "longOffset",
-    }).formatToParts(instant);
-    const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
-    const match = name.match(/GMT([+-]\d{2}:\d{2})?/);
-    return match?.[1] ?? "+00:00";
-  } catch {
-    return "+00:00";
-  }
-}
-
-/** ISO instant for local midnight of `date` in `timezone`. */
-export function zonedDayStartIso(date: string, timezone: string): string {
-  let offset = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
-  const candidate = new Date(`${date}T00:00:00${offset}`);
-  const refined = timezoneOffsetIso(candidate, timezone);
-  if (refined !== offset) {
-    offset = refined;
-  }
-  return `${date}T00:00:00${offset}`;
-}
-
-export function nextIsoDate(date: string): string {
-  const parsed = new Date(`${date}T00:00:00Z`);
-  parsed.setUTCDate(parsed.getUTCDate() + 1);
-  return parsed.toISOString().slice(0, 10);
-}
-
-/**
- * Reject an invalid/unsupported IANA timezone loudly instead of silently
- * coercing to UTC and shifting every meeting's day window (AGENTS.md §39).
- */
-function assertValidTimezone(timezone: string): void {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: timezone });
-  } catch {
-    throw new RangeError(
-      `Invalid IANA timezone "${timezone}" for the Granola connector — check wearables.timezone.`,
-    );
-  }
-}
-
 /**
  * Half-open [createdAfter, createdBefore) UTC ISO bounds of a local day — the
- * window the Granola notes list filters on.
+ * window the Granola notes list filters on. Field names map to the Granola
+ * API; the DST-aware window math is core's `activityDayWindow`.
  */
 export function granolaDayWindow(
   date: string,
   timezone: string,
 ): { createdAfter: string; createdBefore: string } {
-  assertValidTimezone(timezone);
-  return {
-    createdAfter: new Date(zonedDayStartIso(date, timezone)).toISOString(),
-    createdBefore: new Date(zonedDayStartIso(nextIsoDate(date), timezone)).toISOString(),
-  };
+  const { startUtc, endUtc } = activityDayWindow(date, timezone);
+  return { createdAfter: startUtc, createdBefore: endUtc };
 }
 
 function trimmed(value: string | null | undefined): string | undefined {

--- a/packages/connector-omi/src/index.test.ts
+++ b/packages/connector-omi/src/index.test.ts
@@ -7,8 +7,11 @@ import type { WearableSourceSettings } from "@remnic/core";
 import {
   createOmiConnector,
   ensureOmiConnectorRegistered,
+  omiDayWindow,
   resolveOmiApiKey,
   wearableConnectorRegistration,
+  zonedDayBounds,
+  zonedDayStartIso,
 } from "./index.js";
 
 function settings(overrides: Partial<WearableSourceSettings> = {}): WearableSourceSettings {
@@ -173,4 +176,13 @@ test("fetchNativeMemories maps Omi memories and skips empty content", async () =
   } finally {
     stub.restore();
   }
+});
+
+test("legacy day-window export names still resolve from the entry point", () => {
+  // Pre-refactor consumers import zonedDayBounds/zonedDayStartIso from the
+  // package entry; removing them breaks module loading. Both must keep
+  // resolving and behave identically to omiDayWindow.
+  const bounds = omiDayWindow("2026-06-10", "America/Chicago");
+  assert.deepEqual(zonedDayBounds("2026-06-10", "America/Chicago"), bounds);
+  assert.equal(zonedDayStartIso("2026-06-10", "America/Chicago"), bounds.startIso);
 });

--- a/packages/connector-omi/src/index.ts
+++ b/packages/connector-omi/src/index.ts
@@ -48,6 +48,8 @@ export {
   omiDayWindow,
   OMI_SOURCE_ID,
   timezoneOffsetIso,
+  zonedDayBounds,
+  zonedDayStartIso,
 } from "./normalize.js";
 
 export function resolveOmiApiKey(

--- a/packages/connector-omi/src/index.ts
+++ b/packages/connector-omi/src/index.ts
@@ -28,8 +28,8 @@ import { OmiClient } from "./client.js";
 import {
   conversationToWearable,
   memoryToNativeMemory,
+  omiDayWindow,
   OMI_SOURCE_ID,
-  zonedDayBounds,
 } from "./normalize.js";
 
 export { OmiApiError, OmiClient, OMI_DEFAULT_BASE_URL } from "./client.js";
@@ -45,10 +45,9 @@ export {
   conversationToWearable,
   memoryToNativeMemory,
   nextIsoDate,
+  omiDayWindow,
   OMI_SOURCE_ID,
   timezoneOffsetIso,
-  zonedDayBounds,
-  zonedDayStartIso,
 } from "./normalize.js";
 
 export function resolveOmiApiKey(
@@ -99,7 +98,7 @@ export function createOmiConnector(
       return getClient().verifyAuth(signal);
     },
     async fetchConversations(opts: WearableFetchOptions): Promise<WearableFetchPage> {
-      const bounds = zonedDayBounds(opts.date, opts.timezone);
+      const bounds = omiDayWindow(opts.date, opts.timezone);
       const page = await getClient().listConversations({
         startIso: bounds.startIso,
         endIso: bounds.endIso,

--- a/packages/connector-omi/src/normalize.test.ts
+++ b/packages/connector-omi/src/normalize.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { activityDayWindow } from "@remnic/core";
 import {
   conversationToWearable,
   memoryToNativeMemory,
@@ -42,6 +43,26 @@ test("omiDayWindow handles the spring-forward DST boundary", () => {
   const bounds = omiDayWindow("2026-03-08", "America/Chicago");
   assert.equal(bounds.startIso, "2026-03-08T00:00:00-06:00");
   assert.equal(bounds.endIso, "2026-03-09T00:00:00-05:00");
+});
+
+test("omiDayWindow preserves resolved instants when local midnight is skipped", () => {
+  // Africa/Cairo restarts DST on 2026-04-24 at 00:00 (00:00 → 01:00), so
+  // local midnight never occurs and core resolves the day start to 01:00
+  // local (2026-04-23T22:00:00Z). Pre-fix, rebuilding the bounds as
+  // `T00:00:00` produced 2026-04-24T00:00:00+03:00 (= 21:00Z), pulling an
+  // hour of the previous local day into the window.
+  const core = activityDayWindow("2026-04-24", "Africa/Cairo");
+  const bounds = omiDayWindow("2026-04-24", "Africa/Cairo");
+  assert.equal(bounds.startIso, "2026-04-24T01:00:00+03:00");
+  assert.equal(bounds.endIso, "2026-04-25T00:00:00+03:00");
+  assert.equal(Date.parse(bounds.startIso), Date.parse(core.startUtc));
+  assert.equal(Date.parse(bounds.endIso), Date.parse(core.endUtc));
+  // The prior local day ENDS on the skipped midnight; its end bound must
+  // equal core's end instant too, or the final hour gets truncated.
+  const priorCore = activityDayWindow("2026-04-23", "Africa/Cairo");
+  const prior = omiDayWindow("2026-04-23", "Africa/Cairo");
+  assert.equal(prior.endIso, "2026-04-24T01:00:00+03:00");
+  assert.equal(Date.parse(prior.endIso), Date.parse(priorCore.endUtc));
 });
 
 const CONVERSATION = {

--- a/packages/connector-omi/src/normalize.test.ts
+++ b/packages/connector-omi/src/normalize.test.ts
@@ -65,6 +65,14 @@ test("omiDayWindow preserves resolved instants when local midnight is skipped", 
   assert.equal(Date.parse(prior.endIso), Date.parse(priorCore.endUtc));
 });
 
+test("omiDayWindow keeps the never-throw zone contract: unknown zone is a UTC day", () => {
+  // Pre-refactor zonedDayBounds never threw on a bad zone (the offset helper
+  // falls back to +00:00); delegating to core's fail-fast assertValidTimezone
+  // made this path throw RangeError. An unknown zone must resolve to UTC.
+  const bounds = omiDayWindow("2026-06-10", "Not/AZone");
+  assert.deepEqual(bounds, omiDayWindow("2026-06-10", "UTC"));
+});
+
 const CONVERSATION = {
   id: "omi-1",
   created_at: "2026-06-10T14:00:05+00:00",

--- a/packages/connector-omi/src/normalize.test.ts
+++ b/packages/connector-omi/src/normalize.test.ts
@@ -5,8 +5,8 @@ import {
   conversationToWearable,
   memoryToNativeMemory,
   nextIsoDate,
+  omiDayWindow,
   timezoneOffsetIso,
-  zonedDayBounds,
 } from "./normalize.js";
 
 test("timezoneOffsetIso resolves fixed and DST offsets", () => {
@@ -27,13 +27,21 @@ test("nextIsoDate handles month and year boundaries", () => {
   assert.equal(nextIsoDate("2028-02-28"), "2028-02-29");
 });
 
-test("zonedDayBounds produces a half-open local-day window", () => {
-  const bounds = zonedDayBounds("2026-06-10", "America/Chicago");
+test("omiDayWindow produces a half-open local-day window", () => {
+  const bounds = omiDayWindow("2026-06-10", "America/Chicago");
   assert.equal(bounds.startIso, "2026-06-10T00:00:00-05:00");
   assert.equal(bounds.endIso, "2026-06-11T00:00:00-05:00");
-  const utc = zonedDayBounds("2026-06-10", "UTC");
+  const utc = omiDayWindow("2026-06-10", "UTC");
   assert.equal(utc.startIso, "2026-06-10T00:00:00+00:00");
   assert.equal(utc.endIso, "2026-06-11T00:00:00+00:00");
+});
+
+test("omiDayWindow handles the spring-forward DST boundary", () => {
+  // 2026-03-08 is the US spring-forward day: local midnight is CST (UTC-6)
+  // and the next day's midnight is CDT (UTC-5).
+  const bounds = omiDayWindow("2026-03-08", "America/Chicago");
+  assert.equal(bounds.startIso, "2026-03-08T00:00:00-06:00");
+  assert.equal(bounds.endIso, "2026-03-09T00:00:00-05:00");
 });
 
 const CONVERSATION = {

--- a/packages/connector-omi/src/normalize.test.ts
+++ b/packages/connector-omi/src/normalize.test.ts
@@ -8,6 +8,8 @@ import {
   nextIsoDate,
   omiDayWindow,
   timezoneOffsetIso,
+  zonedDayBounds,
+  zonedDayStartIso,
 } from "./normalize.js";
 
 test("timezoneOffsetIso resolves fixed and DST offsets", () => {
@@ -71,6 +73,26 @@ test("omiDayWindow keeps the never-throw zone contract: unknown zone is a UTC da
   // made this path throw RangeError. An unknown zone must resolve to UTC.
   const bounds = omiDayWindow("2026-06-10", "Not/AZone");
   assert.deepEqual(bounds, omiDayWindow("2026-06-10", "UTC"));
+});
+
+test("legacy day-window names warn once per process", async () => {
+  const warnings: Array<string | undefined> = [];
+  const onWarning = (warning: Error & { code?: string }) => warnings.push(warning.code);
+  process.on("warning", onWarning);
+  try {
+    zonedDayBounds("2026-06-10", "UTC");
+    zonedDayStartIso("2026-06-10", "UTC");
+    // Second calls must not re-warn.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  } finally {
+    process.off("warning", onWarning);
+  }
+  assert.deepEqual(warnings.sort(), [
+    "REMNIC_DEP_OMI_ZONEDDAYBOUNDS",
+    "REMNIC_DEP_OMI_ZONEDDAYSTARTISO",
+  ]);
 });
 
 const CONVERSATION = {

--- a/packages/connector-omi/src/normalize.ts
+++ b/packages/connector-omi/src/normalize.ts
@@ -10,42 +10,25 @@
  * `speaker_name`/`speaker_id` instead; normalize both shapes.
  */
 
-import type {
-  WearableConversation,
-  WearableNativeMemory,
-  WearableTranscriptSegment,
+import {
+  activityDayWindow,
+  timezoneOffsetIso as resolveTimezoneOffset,
+  type WearableConversation,
+  type WearableNativeMemory,
+  type WearableTranscriptSegment,
 } from "@remnic/core";
 
 import type { OmiConversation, OmiMemory } from "./client.js";
 
 export const OMI_SOURCE_ID = "omi";
 
-/** "GMT+05:30" → "+05:30"; plain "GMT" → "+00:00". */
+/** "GMT+05:30" → "+05:30"; an unknown zone falls back to "+00:00" so a bad config never crashes the sync. */
 export function timezoneOffsetIso(instant: Date, timezone: string): string {
   try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      timeZoneName: "longOffset",
-    }).formatToParts(instant);
-    const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
-    const match = name.match(/GMT([+-]\d{2}:\d{2})?/);
-    return match?.[1] ?? "+00:00";
+    return resolveTimezoneOffset(instant, timezone);
   } catch {
     return "+00:00";
   }
-}
-
-/** ISO instant for local midnight of `date` in `timezone`. */
-export function zonedDayStartIso(date: string, timezone: string): string {
-  // Two-pass offset resolution: guess from midday (stable away from DST
-  // transitions), then re-derive at the candidate midnight itself.
-  let offset = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
-  const candidate = new Date(`${date}T00:00:00${offset}`);
-  const refined = timezoneOffsetIso(candidate, timezone);
-  if (refined !== offset) {
-    offset = refined;
-  }
-  return `${date}T00:00:00${offset}`;
 }
 
 export function nextIsoDate(date: string): string {
@@ -54,14 +37,20 @@ export function nextIsoDate(date: string): string {
   return parsed.toISOString().slice(0, 10);
 }
 
-/** Half-open [start, end) ISO bounds of a local day. */
-export function zonedDayBounds(
+/**
+ * Half-open [start, end) local-midnight ISO bounds of a local day, in the
+ * offset-datetime form the Omi API's date filters expect. Field names and
+ * format map to the Omi API; the DST-aware window math is core's
+ * `activityDayWindow`.
+ */
+export function omiDayWindow(
   date: string,
   timezone: string,
 ): { startIso: string; endIso: string } {
+  const { startUtc, endUtc } = activityDayWindow(date, timezone);
   return {
-    startIso: zonedDayStartIso(date, timezone),
-    endIso: zonedDayStartIso(nextIsoDate(date), timezone),
+    startIso: `${date}T00:00:00${timezoneOffsetIso(new Date(startUtc), timezone)}`,
+    endIso: `${nextIsoDate(date)}T00:00:00${timezoneOffsetIso(new Date(endUtc), timezone)}`,
   };
 }
 

--- a/packages/connector-omi/src/normalize.ts
+++ b/packages/connector-omi/src/normalize.ts
@@ -12,6 +12,7 @@
 
 import {
   activityDayWindow,
+  assertValidTimezone,
   timezoneOffsetIso as resolveTimezoneOffset,
   type WearableConversation,
   type WearableNativeMemory,
@@ -47,10 +48,19 @@ export function omiDayWindow(
   date: string,
   timezone: string,
 ): { startIso: string; endIso: string } {
-  const { startUtc, endUtc } = activityDayWindow(date, timezone);
+  // Keep this package's documented never-throw zone contract (see
+  // `timezoneOffsetIso`): an unknown zone resolves to a UTC day instead of
+  // surfacing core's fail-fast RangeError.
+  let zone = timezone;
+  try {
+    assertValidTimezone(timezone);
+  } catch {
+    zone = "UTC";
+  }
+  const { startUtc, endUtc } = activityDayWindow(date, zone);
   return {
-    startIso: instantToOffsetIso(new Date(startUtc), timezone),
-    endIso: instantToOffsetIso(new Date(endUtc), timezone),
+    startIso: instantToOffsetIso(new Date(startUtc), zone),
+    endIso: instantToOffsetIso(new Date(endUtc), zone),
   };
 }
 

--- a/packages/connector-omi/src/normalize.ts
+++ b/packages/connector-omi/src/normalize.ts
@@ -93,6 +93,7 @@ function instantToOffsetIso(instant: Date, timezone: string): string {
  * `omiDayWindow`. Returns the resolved start bound, not a rebuilt midnight.
  */
 export function zonedDayStartIso(date: string, timezone: string): string {
+  warnLegacyDayWindow("zonedDayStartIso");
   return omiDayWindow(date, timezone).startIso;
 }
 
@@ -101,7 +102,19 @@ export function zonedDayBounds(
   date: string,
   timezone: string,
 ): { startIso: string; endIso: string } {
+  warnLegacyDayWindow("zonedDayBounds");
   return omiDayWindow(date, timezone);
+}
+
+const warnedLegacyDayWindow = new Set<string>();
+
+function warnLegacyDayWindow(name: "zonedDayBounds" | "zonedDayStartIso"): void {
+  if (warnedLegacyDayWindow.has(name)) return;
+  warnedLegacyDayWindow.add(name);
+  process.emitWarning(
+    `@remnic/connector-omi: ${name} is deprecated; use omiDayWindow instead.`,
+    { type: "DeprecationWarning", code: `REMNIC_DEP_OMI_${name.toUpperCase()}` },
+  );
 }
 
 export function conversationToWearable(

--- a/packages/connector-omi/src/normalize.ts
+++ b/packages/connector-omi/src/normalize.ts
@@ -49,9 +49,49 @@ export function omiDayWindow(
 ): { startIso: string; endIso: string } {
   const { startUtc, endUtc } = activityDayWindow(date, timezone);
   return {
-    startIso: `${date}T00:00:00${timezoneOffsetIso(new Date(startUtc), timezone)}`,
-    endIso: `${nextIsoDate(date)}T00:00:00${timezoneOffsetIso(new Date(endUtc), timezone)}`,
+    startIso: instantToOffsetIso(new Date(startUtc), timezone),
+    endIso: instantToOffsetIso(new Date(endUtc), timezone),
   };
+}
+
+/**
+ * Render a resolved instant as an offset datetime in `timezone`. Formatting
+ * the wall-clock at that instant (not `T00:00:00`) is what preserves skipped
+ * local midnights: a 00:00→01:00 spring-forward resolves to 01:00 local, and
+ * rebuilding `T00:00:00` would move the instant an hour into the prior day.
+ */
+function instantToOffsetIso(instant: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(instant);
+  const field = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((part) => part.type === type)?.value ?? "00";
+  const day = `${field("year")}-${field("month")}-${field("day")}`;
+  const time = `${field("hour")}:${field("minute")}:${field("second")}`;
+  return `${day}T${time}${timezoneOffsetIso(instant, timezone)}`;
+}
+
+/**
+ * @deprecated Compatibility wrapper (pre-core-refactor export); delegates to
+ * `omiDayWindow`. Returns the resolved start bound, not a rebuilt midnight.
+ */
+export function zonedDayStartIso(date: string, timezone: string): string {
+  return omiDayWindow(date, timezone).startIso;
+}
+
+/** @deprecated Compatibility wrapper (pre-core-refactor export); delegates to `omiDayWindow`. */
+export function zonedDayBounds(
+  date: string,
+  timezone: string,
+): { startIso: string; endIso: string } {
+  return omiDayWindow(date, timezone);
 }
 
 export function conversationToWearable(

--- a/packages/connector-reitti/src/client.test.ts
+++ b/packages/connector-reitti/src/client.test.ts
@@ -5,7 +5,7 @@ import {
   REITTI_AUTH_MODES,
   ReittiApiError,
   ReittiClient,
-  assertValidIanaTimezone,
+  assertReittiTimezone,
   normalizeReittiBaseUrl,
 } from "./client.js";
 
@@ -87,7 +87,7 @@ test("fetchTimeline validates the date and timezone before any request", async (
   await assert.rejects(client.fetchTimeline({ date: "2026-13-40", timezone: "UTC" }), RangeError);
   await assert.rejects(client.fetchTimeline({ date: "2026-08-17", timezone: "Not/AZone" }), RangeError);
   assert.equal(requests.length, 0);
-  assert.throws(() => assertValidIanaTimezone("Also/Bogus"), RangeError);
+  assert.throws(() => assertReittiTimezone("Also/Bogus"), RangeError);
 });
 
 const visitRow = (overrides: Record<string, unknown> = {}) => ({

--- a/packages/connector-reitti/src/client.ts
+++ b/packages/connector-reitti/src/client.ts
@@ -176,6 +176,14 @@ export function assertReittiTimezone(timezone: string): void {
 }
 
 /**
+ * @deprecated Alias of `assertReittiTimezone`, kept so pre-rename imports from
+ * this published package keep resolving. Same TypeError/RangeError behavior.
+ */
+export function assertValidIanaTimezone(timezone: string): void {
+  assertReittiTimezone(timezone);
+}
+
+/**
  * Validate and normalize the base URL: absolute HTTP(S), trailing slashes
  * stripped without touching path semantics (a sub-path install keeps its
  * prefix). Loop instead of a `/\/+$/` regex — CodeQL polynomial-redos.

--- a/packages/connector-reitti/src/client.ts
+++ b/packages/connector-reitti/src/client.ts
@@ -180,7 +180,19 @@ export function assertReittiTimezone(timezone: string): void {
  * this published package keep resolving. Same TypeError/RangeError behavior.
  */
 export function assertValidIanaTimezone(timezone: string): void {
+  warnLegacyTimezoneValidator();
   assertReittiTimezone(timezone);
+}
+
+let warnedLegacyTimezoneValidator = false;
+
+function warnLegacyTimezoneValidator(): void {
+  if (warnedLegacyTimezoneValidator) return;
+  warnedLegacyTimezoneValidator = true;
+  process.emitWarning(
+    "@remnic/connector-reitti: assertValidIanaTimezone is deprecated; use assertReittiTimezone instead.",
+    { type: "DeprecationWarning", code: "REMNIC_DEP_REITTI_ASSERT_VALID_IANA_TIMEZONE" },
+  );
 }
 
 /**

--- a/packages/connector-reitti/src/client.ts
+++ b/packages/connector-reitti/src/client.ts
@@ -17,6 +17,7 @@
  * and never advance any state (the client is stateless).
  */
 
+import { assertValidTimezone } from "@remnic/core";
 import { isValidLocationDate } from "@remnic/core/location";
 
 export type ReittiAuthMode = "x-api-token" | "bearer";
@@ -163,16 +164,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
 
-/** Validate an IANA timezone by constructing a formatter (throws RangeError). */
-export function assertValidIanaTimezone(timezone: string): void {
+/**
+ * Validate an IANA timezone for Reitti requests: non-string/empty input is a
+ * TypeError; an unknown zone is a RangeError from core's `assertValidTimezone`.
+ */
+export function assertReittiTimezone(timezone: string): void {
   if (typeof timezone !== "string" || timezone.length === 0) {
     throw new TypeError("Reitti timezone must be a non-empty IANA zone string");
   }
-  try {
-    new Intl.DateTimeFormat("en-CA", { timeZone: timezone });
-  } catch {
-    throw new RangeError(`Reitti timezone "${timezone}" is not a valid IANA zone`);
-  }
+  assertValidTimezone(timezone);
 }
 
 /**
@@ -326,7 +326,7 @@ export class ReittiClient {
 
   /** Every VISIT/TRIP entry overlapping the local day (primary source). */
   async fetchTimeline(request: ReittiDayRequest): Promise<ReittiTimelineEntry[]> {
-    assertValidIanaTimezone(request.timezone);
+    assertReittiTimezone(request.timezone);
     if (!isValidLocationDate(request.date)) {
       throw new RangeError(`Reitti date "${request.date}" must be a real YYYY-MM-DD day`);
     }
@@ -342,7 +342,7 @@ export class ReittiClient {
 
   /** Processed visits grouped by place (fallback/enrichment source). */
   async fetchVisits(request: ReittiDayRequest): Promise<ReittiPlaceVisitSummary[]> {
-    assertValidIanaTimezone(request.timezone);
+    assertReittiTimezone(request.timezone);
     if (!isValidLocationDate(request.date)) {
       throw new RangeError(`Reitti date "${request.date}" must be a real YYYY-MM-DD day`);
     }

--- a/packages/connector-reitti/src/index.test.ts
+++ b/packages/connector-reitti/src/index.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   REITTI_PROVIDER_ID,
   REITTI_VISITS_CURSOR,
+  assertValidIanaTimezone,
   createReittiProvider,
   ensureReittiProviderRegistered,
 } from "./index.js";
@@ -217,4 +218,12 @@ test("verify rethrows a caller abort instead of reporting the provider unavailab
     provider.verify(controller.signal),
     (err: unknown) => err instanceof Error && err.name === "AbortError",
   );
+});
+
+test("legacy assertValidIanaTimezone still resolves and validates identically", () => {
+  // Pre-rename consumers import assertValidIanaTimezone from the package
+  // entry; it must keep resolving with the same throw behavior.
+  assertValidIanaTimezone("Europe/Helsinki");
+  assert.throws(() => assertValidIanaTimezone(""), TypeError);
+  assert.throws(() => assertValidIanaTimezone("Also/Bogus"), RangeError);
 });

--- a/packages/connector-reitti/src/index.test.ts
+++ b/packages/connector-reitti/src/index.test.ts
@@ -220,10 +220,22 @@ test("verify rethrows a caller abort instead of reporting the provider unavailab
   );
 });
 
-test("legacy assertValidIanaTimezone still resolves and validates identically", () => {
+test("legacy assertValidIanaTimezone still resolves and validates identically", async () => {
   // Pre-rename consumers import assertValidIanaTimezone from the package
-  // entry; it must keep resolving with the same throw behavior.
-  assertValidIanaTimezone("Europe/Helsinki");
-  assert.throws(() => assertValidIanaTimezone(""), TypeError);
-  assert.throws(() => assertValidIanaTimezone("Also/Bogus"), RangeError);
+  // entry; it must keep resolving with the same throw behavior and warn
+  // about the rename exactly once per process.
+  const warnings: Array<string | undefined> = [];
+  const onWarning = (warning: Error & { code?: string }) => warnings.push(warning.code);
+  process.on("warning", onWarning);
+  try {
+    assertValidIanaTimezone("Europe/Helsinki");
+    assert.throws(() => assertValidIanaTimezone(""), TypeError);
+    assert.throws(() => assertValidIanaTimezone("Also/Bogus"), RangeError);
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setImmediate(resolve);
+    await promise;
+  } finally {
+    process.off("warning", onWarning);
+  }
+  assert.deepEqual(warnings, ["REMNIC_DEP_REITTI_ASSERT_VALID_IANA_TIMEZONE"]);
 });

--- a/packages/connector-reitti/src/index.ts
+++ b/packages/connector-reitti/src/index.ts
@@ -40,6 +40,7 @@ export {
   REITTI_PLACE_TYPES,
   REITTI_TRANSPORT_MODES,
   assertReittiTimezone,
+  assertValidIanaTimezone,
   normalizeReittiBaseUrl,
 } from "./client.js";
 export type {

--- a/packages/connector-reitti/src/index.ts
+++ b/packages/connector-reitti/src/index.ts
@@ -27,7 +27,7 @@ import {
 import {
   ReittiApiError,
   ReittiClient,
-  assertValidIanaTimezone,
+  assertReittiTimezone,
   normalizeReittiBaseUrl,
   type ReittiAuthMode,
 } from "./client.js";
@@ -39,7 +39,7 @@ export {
   REITTI_AUTH_MODES,
   REITTI_PLACE_TYPES,
   REITTI_TRANSPORT_MODES,
-  assertValidIanaTimezone,
+  assertReittiTimezone,
   normalizeReittiBaseUrl,
 } from "./client.js";
 export type {
@@ -89,7 +89,7 @@ export function createReittiProvider(options: ReittiProviderOptions): LocationPr
   if (typeof options.token !== "string" || options.token.trim().length === 0) {
     throw new TypeError("Reitti provider requires a non-empty token (resolve the secret reference first)");
   }
-  assertValidIanaTimezone(options.timezone);
+  assertReittiTimezone(options.timezone);
   if (options.visitsFallback !== undefined && typeof options.visitsFallback !== "boolean") {
     throw new TypeError("Reitti visitsFallback must be a boolean");
   }

--- a/packages/remnic-core/src/activity/digest.test.ts
+++ b/packages/remnic-core/src/activity/digest.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  activityDateInTimezone,
   activityDayWindow,
   activityDigestPath,
   composeActivityDigestBody,
@@ -160,6 +161,37 @@ test("activityDayWindow does not backdate a skipped local midnight", () => {
     hour12: false,
   }).format(new Date(w.startUtc));
   assert.ok(local.startsWith("2026-04-24"), local);
+});
+
+test("activityDayWindow keeps the last real day whole across an entirely skipped civil date", () => {
+  // Pacific/Apia jumped the date line at 2011-12-29 23:59:59-10:00 →
+  // 2011-12-31 00:00:00+14:00, so local 2011-12-30 never existed. Pre-fix,
+  // the skipped date's day start backdated into 2011-12-29, collapsing the
+  // 29th's window to identical bounds — a `wearables sync --date
+  // 2011-12-29` then dropped every Fireflies transcript of the day.
+  const w = activityDayWindow("2011-12-29", "Pacific/Apia");
+  assert.equal(w.startUtc, "2011-12-29T10:00:00.000Z"); // 2011-12-29 00:00 -10:00
+  assert.equal(w.endUtc, "2011-12-30T10:00:00.000Z"); // the jump instant
+  assert.ok(Date.parse(w.endUtc) > Date.parse(w.startUtc), "window must be non-degenerate");
+  // Attribution is exact: every instant in the window is locally the 29th.
+  assert.equal(activityDateInTimezone(new Date(w.startUtc), "Pacific/Apia"), "2011-12-29");
+  assert.equal(activityDateInTimezone(new Date(Date.parse(w.endUtc) - 1), "Pacific/Apia"), "2011-12-29");
+});
+
+test("activityDayWindow resolves an entirely skipped civil date to a well-defined window", () => {
+  // 2011-12-30 never occurred in Pacific/Apia. Pre-fix it returned the
+  // 29th's interval, misattributing that day's transcripts to the 30th.
+  // Per the skipped-date semantics it instead adopts the interval of the
+  // day the calendar jumped into (2011-12-31's), staying non-degenerate.
+  const w = activityDayWindow("2011-12-30", "Pacific/Apia");
+  assert.equal(w.startUtc, "2011-12-30T10:00:00.000Z");
+  assert.equal(w.endUtc, "2011-12-31T10:00:00.000Z");
+  assert.ok(Date.parse(w.endUtc) > Date.parse(w.startUtc), "window must be non-degenerate");
+  // The skipped date never overlaps the 29th's data: the last real day ends
+  // exactly where the skipped date's window starts. Past the skip it adopts
+  // 2011-12-31's interval wholesale, and the 31st keeps its own window.
+  assert.equal(activityDayWindow("2011-12-29", "Pacific/Apia").endUtc, w.startUtc);
+  assert.deepEqual(w, activityDayWindow("2011-12-31", "Pacific/Apia"));
 });
 
 test("timeline keeps a second machine's span even with the same app/window", () => {

--- a/packages/remnic-core/src/activity/digest.test.ts
+++ b/packages/remnic-core/src/activity/digest.test.ts
@@ -178,20 +178,22 @@ test("activityDayWindow keeps the last real day whole across an entirely skipped
   assert.equal(activityDateInTimezone(new Date(Date.parse(w.endUtc) - 1), "Pacific/Apia"), "2011-12-29");
 });
 
-test("activityDayWindow resolves an entirely skipped civil date to a well-defined window", () => {
-  // 2011-12-30 never occurred in Pacific/Apia. Pre-fix it returned the
-  // 29th's interval, misattributing that day's transcripts to the 30th.
-  // Per the skipped-date semantics it instead adopts the interval of the
-  // day the calendar jumped into (2011-12-31's), staying non-degenerate.
+test("activityDayWindow gives an entirely skipped civil date no interval", () => {
+  // 2011-12-30 never occurred in Pacific/Apia: the date-line jump went
+  // 2011-12-29 23:59:59-10:00 → 2011-12-31 00:00:00+14:00. The skipped
+  // date's nominal start and 2011-12-31's start both resolve to that jump
+  // instant, so its window is zero-width [jump, jump). A date that never
+  // occurred owns no interval: it must not adopt 2011-12-31's, which
+  // double-attributed the 31st's cards to two daily totals and made
+  // connector syncs for the skipped date fetch the 31st's records.
   const w = activityDayWindow("2011-12-30", "Pacific/Apia");
-  assert.equal(w.startUtc, "2011-12-30T10:00:00.000Z");
-  assert.equal(w.endUtc, "2011-12-31T10:00:00.000Z");
-  assert.ok(Date.parse(w.endUtc) > Date.parse(w.startUtc), "window must be non-degenerate");
-  // The skipped date never overlaps the 29th's data: the last real day ends
-  // exactly where the skipped date's window starts. Past the skip it adopts
-  // 2011-12-31's interval wholesale, and the 31st keeps its own window.
-  assert.equal(activityDayWindow("2011-12-29", "Pacific/Apia").endUtc, w.startUtc);
-  assert.deepEqual(w, activityDayWindow("2011-12-31", "Pacific/Apia"));
+  assert.equal(w.startUtc, "2011-12-30T10:00:00.000Z"); // the jump instant
+  assert.equal(w.endUtc, w.startUtc); // zero-width: syncs nothing
+  // The 31st keeps its OWN window; no interval is shared with the skip.
+  const dec31 = activityDayWindow("2011-12-31", "Pacific/Apia");
+  assert.equal(dec31.startUtc, "2011-12-30T10:00:00.000Z");
+  assert.equal(dec31.endUtc, "2011-12-31T10:00:00.000Z");
+  assert.notDeepEqual(w, dec31);
 });
 
 test("timeline keeps a second machine's span even with the same app/window", () => {

--- a/packages/remnic-core/src/activity/digest.ts
+++ b/packages/remnic-core/src/activity/digest.ts
@@ -109,9 +109,24 @@ function zonedDayStartIso(date: string, timezone: string): string {
     }
   }
   if (best === null) {
-    // Degenerate safety net: use the noon-derived offset for a deterministic start.
-    const noon = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
-    best = Date.parse(`${date}T00:00:00${noon}`);
+    // The ENTIRE civil date was skipped — no local wall-clock time on it
+    // exists (Pacific/Apia 2011-12-30 is the canonical case: the date-line
+    // jump went 2011-12-29 23:59:59-10:00 → 2011-12-31 00:00:00+14:00).
+    // Extending the never-backdate convention above, resolve the day start
+    // to the transition instant: the earliest instant whose local calendar
+    // date reaches `date`. Local date is monotone non-decreasing in the UTC
+    // instant (a fall-back never crosses local midnight backwards), so
+    // binary-search a 48h bracket at minute granularity. The bracket is
+    // safe: `<date>T00:00Z − 24h` is always locally before `date`, and
+    // `<date>T00:00Z + 24h` is always locally on/after it.
+    let lo = Date.parse(`${date}T00:00:00Z`) - 24 * 3_600_000;
+    let hi = lo + 48 * 3_600_000;
+    while (hi - lo > 60_000) {
+      const mid = lo + Math.floor((hi - lo) / 2 / 60_000) * 60_000;
+      if (activityDateInTimezone(new Date(mid), timezone) >= date) hi = mid;
+      else lo = mid;
+    }
+    best = hi;
   }
   if (best === null || !Number.isFinite(best)) {
     throw new RangeError(`activity: could not resolve a local day start for "${date}" in "${timezone}".`);
@@ -135,10 +150,24 @@ export function activityDayWindow(date: string, timezone: string): { startUtc: s
     throw new RangeError(`Invalid activity date "${date}"; expected a real YYYY-MM-DD day.`);
   }
   assertValidTimezone(timezone);
-  return {
-    startUtc: new Date(zonedDayStartIso(date, timezone)).toISOString(),
-    endUtc: new Date(zonedDayStartIso(nextIsoDate(date), timezone)).toISOString(),
-  };
+  const startUtc = zonedDayStartIso(date, timezone);
+  let endDate = nextIsoDate(date);
+  let endUtc = zonedDayStartIso(endDate, timezone);
+  // Semantics for a date the zone skipped entirely: its day start resolves
+  // to the transition instant, which is ALSO the following existing date's
+  // start — so the naive [start, end) collapses to identical bounds (an
+  // empty window that drops every record nominally of that day). A skipped
+  // date instead spans [transition instant, the next EXISTING date's start):
+  // it adopts the local day the calendar jumped into (Pacific/Apia
+  // 2011-12-30 adopts 2011-12-31's interval, sharing it). Windows stay
+  // non-degenerate, the last REAL day keeps its full window (its end is
+  // exactly the skipped date's start), and no date inherits the PREVIOUS
+  // date's interval.
+  while (endUtc <= startUtc) {
+    endDate = nextIsoDate(endDate);
+    endUtc = zonedDayStartIso(endDate, timezone);
+  }
+  return { startUtc, endUtc };
 }
 
 /**

--- a/packages/remnic-core/src/activity/digest.ts
+++ b/packages/remnic-core/src/activity/digest.ts
@@ -144,29 +144,26 @@ function nextIsoDate(date: string): string {
   return shiftIsoDate(date, 1);
 }
 
-/** Half-open [start, end) UTC ISO bounds of a local day. */
+/**
+ * Half-open [start, end) UTC ISO bounds of a local day. A civil date the
+ * zone skipped entirely owns no interval: the window is zero-width
+ * `[transition, transition)`.
+ */
 export function activityDayWindow(date: string, timezone: string): { startUtc: string; endUtc: string } {
   if (!isValidActivityDate(date)) {
     throw new RangeError(`Invalid activity date "${date}"; expected a real YYYY-MM-DD day.`);
   }
   assertValidTimezone(timezone);
   const startUtc = zonedDayStartIso(date, timezone);
-  let endDate = nextIsoDate(date);
-  let endUtc = zonedDayStartIso(endDate, timezone);
-  // Semantics for a date the zone skipped entirely: its day start resolves
-  // to the transition instant, which is ALSO the following existing date's
-  // start — so the naive [start, end) collapses to identical bounds (an
-  // empty window that drops every record nominally of that day). A skipped
-  // date instead spans [transition instant, the next EXISTING date's start):
-  // it adopts the local day the calendar jumped into (Pacific/Apia
-  // 2011-12-30 adopts 2011-12-31's interval, sharing it). Windows stay
-  // non-degenerate, the last REAL day keeps its full window (its end is
-  // exactly the skipped date's start), and no date inherits the PREVIOUS
-  // date's interval.
-  while (endUtc <= startUtc) {
-    endDate = nextIsoDate(endDate);
-    endUtc = zonedDayStartIso(endDate, timezone);
-  }
+  const endUtc = zonedDayStartIso(nextIsoDate(date), timezone);
+  // Skipped-date semantics (Pacific/Apia 2011-12-30 class): the skipped
+  // date's start and the following date's start both resolve to the
+  // transition instant, so the window is naturally zero-width. Keep it
+  // that way: a date that never occurred contributes to no daily total
+  // (daysOverlappingWeek drops zero-width days) and a connector sync for
+  // it fetches nothing. Pushing the end forward to stay non-degenerate
+  // would alias the next real day's interval and double-attribute every
+  // card in it to two daily totals.
   return { startUtc, endUtc };
 }
 

--- a/packages/remnic-core/src/activity/timeline/weekly.test.ts
+++ b/packages/remnic-core/src/activity/timeline/weekly.test.ts
@@ -213,3 +213,32 @@ test("equal durations sort by categoryId ascending", () => {
     ["beta", "development", "alpha"],
   );
 });
+
+test("a card is attributed to exactly one daily total across an entirely skipped civil date", () => {
+  // Pacific/Apia skipped local 2011-12-30 at the date-line jump. The
+  // skipped date owns a zero-width window, so it appears as no day entry,
+  // and the 31st's card lands on exactly one daily total — never also on
+  // the skipped date, which pre-fix shared the 31st's interval.
+  const summary = buildWeeklyActivitySummary(
+    [
+      // Dec 29 10:00-11:00 local (-10:00).
+      card({ id: "before-jump", startUtc: "2011-12-29T20:00:00.000Z", endUtc: "2011-12-29T21:00:00.000Z" }),
+      // Dec 31 02:00-03:00 local (+14:00).
+      card({ id: "after-jump", startUtc: "2011-12-30T12:00:00.000Z", endUtc: "2011-12-30T13:00:00.000Z" }),
+    ],
+    options({
+      timezone: "Pacific/Apia",
+      weekStartUtc: "2011-12-26T10:00:00.000Z",
+      weekEndUtc: "2012-01-02T10:00:00.000Z",
+    }),
+  );
+  assert.equal(summary.days.some((day) => day.date === "2011-12-30"), false);
+  const activeDays = summary.days.filter((day) => day.activeMs > 0);
+  assert.deepEqual(
+    activeDays.map((day) => [day.date, day.activeMs]),
+    [
+      ["2011-12-29", HOUR],
+      ["2011-12-31", HOUR],
+    ],
+  );
+});


### PR DESCRIPTION
Fixes #2793

Three hand-rolled DST-aware day-window copies (fireflies zonedDayStartIso, granola granolaDayWindow, omi zonedDayBounds) and reitti's assertValidIanaTimezone duplicated @remnic/core's canonical activityDayWindow / timezoneOffsetIso / assertValidTimezone. Local copies deleted; imports from core; thin field-mapping only where payloads differ.

- `grep -rn 'zonedDayStartIso|zonedDayBounds|assertValidIanaTimezone' packages/connector-*` → zero
- fireflies 28/28, granola 27/27, omi 27/27, reitti 44/44; DST spring-forward fixtures byte-identical; one new omi DST-boundary test
- `check:pre-push` green; normalize.ts files shrank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone-aware activity filtering across Fireflies, Granola, and Omi, including daylight-saving transitions and skipped local dates.
  * Preserved UTC fallback behavior for invalid Omi timezones.
  * Standardized timezone validation for Reitti timeline and visit requests.

* **API Updates**
  * Added Omi day-window utilities while preserving legacy exports with deprecation warnings.
  * Added the Reitti timezone validation export while retaining the existing validation alias.
  * Consolidated timezone and day-window behavior for more consistent results across connectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->