### PR TITLE
feat(converge): token-file and env credential channels (#2823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `remnic converge` accepts the peer credential via `--token-file <path>` (0600 file) or `REMNIC_CONVERGE_PEER_TOKEN`; `--token` still works but warns that argv credentials are visible to any process listing for the lifetime of the run (#2823).
 ## [v9.69.29] — 2026-08-23
 
 ### Changed

--- a/packages/remnic-cli/src/converge-token-channel.ts
+++ b/packages/remnic-cli/src/converge-token-channel.ts
@@ -28,7 +28,7 @@ export type ConvergeTokenChannelResult =
  */
 export function resolveConvergeTokenChannel(
   input: ConvergeTokenChannelInput,
-  env: Pick<NodeJS.ProcessEnv, "REMNIC_CONVERGE_PEER_TOKEN">,
+  env: NodeJS.ProcessEnv
 ): ConvergeTokenChannelResult {
   const tokenFromArgv = input.argvToken !== undefined;
   if (!tokenFromArgv && input.tokenFile !== undefined) {

--- a/packages/remnic-cli/src/converge-token-channel.ts
+++ b/packages/remnic-cli/src/converge-token-channel.ts
@@ -26,6 +26,11 @@ export type ConvergeTokenChannelResult =
  * error, never a silent fall-through to a lower-precedence channel. Token
  * files must not be group- or world-readable (chmod 600).
  */
+/** Parse the --token-file flag value: a non-empty path, or null when absent/empty. */
+export function parseConvergeTokenFileFlag(raw: string | undefined): string | null {
+  return raw !== undefined && raw.length > 0 ? raw : null;
+}
+
 export function resolveConvergeTokenChannel(
   input: ConvergeTokenChannelInput,
   env: NodeJS.ProcessEnv

--- a/packages/remnic-cli/src/converge-token-channel.ts
+++ b/packages/remnic-cli/src/converge-token-channel.ts
@@ -1,0 +1,55 @@
+/**
+ * Credential-channel resolution for `remnic converge` (#2823).
+ *
+ * argv tokens are visible to any process listing for the lifetime of a
+ * plan/apply/watch run — hours at boot scale, exactly when operators take ps
+ * snapshots. Token-file and env are the operator-safe channels; --token still
+ * works but callers should warn. Extracted from converge.ts to respect the
+ * new-file LOC ratchet.
+ */
+import * as fs from "node:fs";
+
+export interface ConvergeTokenChannelInput {
+  /** Value from the --token flag, if supplied (argv-visible). */
+  argvToken: string | undefined;
+  /** Path from --token-file, if supplied. */
+  tokenFile: string | undefined;
+}
+
+export type ConvergeTokenChannelResult =
+  | { ok: true; token: string | undefined; tokenFromArgv: boolean }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the peer credential with presence-tracked precedence
+ * (--token > --token-file > env). An EMPTY higher-precedence value is a hard
+ * error, never a silent fall-through to a lower-precedence channel. Token
+ * files must not be group- or world-readable (chmod 600).
+ */
+export function resolveConvergeTokenChannel(
+  input: ConvergeTokenChannelInput,
+  env: Pick<NodeJS.ProcessEnv, "REMNIC_CONVERGE_PEER_TOKEN">,
+): ConvergeTokenChannelResult {
+  const tokenFromArgv = input.argvToken !== undefined;
+  if (!tokenFromArgv && input.tokenFile !== undefined) {
+    try {
+      const stat = fs.statSync(input.tokenFile);
+      // A group/world-readable credential file defeats the point of the
+      // channel; reject it instead of trusting the content.
+      if (stat.mode & 0o077) {
+        return { ok: false, error: `--token-file ${input.tokenFile} must not be group- or world-readable (chmod 600)` };
+      }
+      const token = fs.readFileSync(input.tokenFile, "utf8").trim();
+      if (token.length === 0) {
+        return { ok: false, error: `--token-file ${input.tokenFile} is empty` };
+      }
+      return { ok: true, token, tokenFromArgv };
+    } catch (err) {
+      return { ok: false, error: `--token-file ${input.tokenFile} could not be read: ${err}` };
+    }
+  }
+  if (!tokenFromArgv && input.tokenFile === undefined && env.REMNIC_CONVERGE_PEER_TOKEN !== undefined) {
+    return { ok: true, token: env.REMNIC_CONVERGE_PEER_TOKEN, tokenFromArgv: false };
+  }
+  return { ok: true, token: input.argvToken, tokenFromArgv };
+}

--- a/packages/remnic-cli/src/converge-token-channel.ts
+++ b/packages/remnic-cli/src/converge-token-channel.ts
@@ -35,13 +35,18 @@ export function resolveConvergeTokenChannel(
   input: ConvergeTokenChannelInput,
   env: NodeJS.ProcessEnv
 ): ConvergeTokenChannelResult {
+  if (input.argvToken !== undefined && input.argvToken.length === 0) {
+    return { ok: false, error: "--token requires a non-empty value" };
+  }
   const tokenFromArgv = input.argvToken !== undefined;
   if (!tokenFromArgv && input.tokenFile !== undefined) {
     try {
       const stat = fs.statSync(input.tokenFile);
       // A group/world-readable credential file defeats the point of the
-      // channel; reject it instead of trusting the content.
-      if (stat.mode & 0o077) {
+      // channel; reject it instead of trusting the content. Windows mode bits
+      // are synthesized (readable files commonly present as 0666), so the
+      // check is POSIX-only.
+      if (process.platform !== "win32" && stat.mode & 0o077) {
         return { ok: false, error: `--token-file ${input.tokenFile} must not be group- or world-readable (chmod 600)` };
       }
       const token = fs.readFileSync(input.tokenFile, "utf8").trim();
@@ -54,6 +59,10 @@ export function resolveConvergeTokenChannel(
     }
   }
   if (!tokenFromArgv && input.tokenFile === undefined && env.REMNIC_CONVERGE_PEER_TOKEN !== undefined) {
+    // An empty env credential is a hard error, never a silent no-token run.
+    if (env.REMNIC_CONVERGE_PEER_TOKEN.length === 0) {
+      return { ok: false, error: "REMNIC_CONVERGE_PEER_TOKEN is set but empty" };
+    }
     return { ok: true, token: env.REMNIC_CONVERGE_PEER_TOKEN, tokenFromArgv: false };
   }
   return { ok: true, token: input.argvToken, tokenFromArgv };

--- a/packages/remnic-cli/src/converge.test.ts
+++ b/packages/remnic-cli/src/converge.test.ts
@@ -1890,3 +1890,31 @@ test("converge --timeout rounds fractional seconds before integer normalization 
   // Sub-millisecond values normalize-reject (positive integer required).
   assert.throws(() => convergeTimeoutFlagToMs(0.0001), /--timeout/);
 });
+
+test("converge --token-file with a missing file exits 2 before any plan work (#2823)", async () => {
+  process.exitCode = undefined;
+  await cmdConverge("plan", ["--peer", "http://127.0.0.1:1", "--token-file", "/nonexistent/peer.token"], true);
+  assert.equal(process.exitCode, 2);
+  process.exitCode = undefined;
+});
+
+test("converge --token-file rejects permissive modes and missing values (#2823 round 1)", async () => {
+  const { mkdtemp, writeFile, chmod, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const dir = await mkdtemp(path.join(os.tmpdir(), "token-mode-"));
+  try {
+    const permissive = path.join(dir, "open.token");
+    await writeFile(permissive, "x".repeat(64) + "\n");
+    await chmod(permissive, 0o644);
+    process.exitCode = undefined;
+    await cmdConverge("plan", ["--peer", "http://127.0.0.1:1", "--token-file", permissive], true);
+    assert.equal(process.exitCode, 2);
+    process.exitCode = undefined;
+    await cmdConverge("plan", ["--peer", "http://127.0.0.1:1", "--token-file"], true);
+    assert.equal(process.exitCode, 2);
+    process.exitCode = undefined;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -40,7 +40,7 @@ import {
 } from "@remnic/core/reconcile/manifest.js";
 import { createOfflineStorageIo } from "./offline-storage-io.js";
 import { convergeWatch, type ConvergeWatchOutcome } from "./converge-watch.js";
-import { resolveConvergeTokenChannel } from "./converge-token-channel.js";
+import { parseConvergeTokenFileFlag, resolveConvergeTokenChannel } from "./converge-token-channel.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
 import {
   DEFAULT_PEER_REQUEST_TIMEOUT_MS,
@@ -1020,7 +1020,6 @@ export async function cmdConverge(
 ): Promise<void> {
   if (action === "help" || action === "--help" || action === "-h" || rest.includes("--help") || rest.includes("-h")) {
     console.log(`Usage: remnic converge <plan|apply|watch> [options]
-
 Subcommands:
   plan              Compute and display reconciliation plan
   apply             Execute bidirectional converge transport (alias: transport, sync)
@@ -1028,18 +1027,14 @@ Subcommands:
 
 Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
-  --token <token>   Peer auth token (argv-visible; prefer the safe channels)
-  --token-file <path>
-                    Read the peer token from a 0600 file (not argv-visible)
-  REMNIC_CONVERGE_PEER_TOKEN  Env alternative to --token (not argv-visible)
+  --token <token>   Peer auth token (argv-visible; prefer safe channels below)
+  --token-file <p> / REMNIC_CONVERGE_PEER_TOKEN  Non-argv token channels
   --conflict-policy <policy>
-                    Policy override (newest-wins|manual)
-                    Default: converge.conflictPolicy (newest-wins)
+                    Policy override (newest-wins|manual; default newest-wins)
   --interval <seconds>
-                    Watch cadence in seconds (watch only; default 300, min 1)
+                    Watch cadence seconds (watch only; default 300)
   --timeout <seconds>
-                    Per-request peer HTTP timeout (default 30; use 300+ for
-                    boot-scale namespaces of ~100k files)
+                    Peer HTTP timeout seconds (default 30; boot-scale 300+)
   --dry-run         Simulate transfers without mutating disk or remote peer
   --json            Output detailed JSON plan report
 `);
@@ -1054,7 +1049,7 @@ Options:
 
   let peerUrl: string | undefined;
   let peerToken: string | undefined;
-  let tokenFile: string | undefined;
+  let tokenFile: string | null | undefined;
   let dryRun = false;
   let conflictPolicy: ConvergeConflictPolicy | undefined;
   let intervalSeconds: number | undefined;
@@ -1063,13 +1058,12 @@ Options:
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
     if (arg === "--token-file") {
-      const raw = rest[i + 1];
-      if (raw === undefined || raw.length === 0) {
+      tokenFile = parseConvergeTokenFileFlag(rest[i + 1]);
+      if (tokenFile === null) {
         process.stderr.write("converge: --token-file requires a path.\n");
         process.exitCode = 2;
         return;
       }
-      tokenFile = raw;
       i += 1;
     } else if ((arg === "--peer" || arg === "--remote-url" || arg === "--remote") && rest[i + 1]) {
       peerUrl = rest[i + 1];
@@ -1112,8 +1106,10 @@ Options:
       i += 1;
     }
   }
-
-  const tokenChannel = resolveConvergeTokenChannel({ argvToken: peerToken, tokenFile }, process.env);
+  const tokenChannel = resolveConvergeTokenChannel(
+    { argvToken: peerToken, tokenFile: tokenFile ?? undefined },
+    process.env
+  );
   if (!tokenChannel.ok) {
     process.stderr.write(`converge: ${tokenChannel.error}\n`);
     process.exitCode = 2;
@@ -1122,10 +1118,9 @@ Options:
   peerToken = tokenChannel.token;
   if (tokenChannel.tokenFromArgv) {
     process.stderr.write(
-      "converge: note: --token is argv-visible; prefer --token-file <path> or REMNIC_CONVERGE_PEER_TOKEN\n"
+      "converge: note: --token is argv-visible; prefer --token-file or REMNIC_CONVERGE_PEER_TOKEN\n"
     );
   }
-
   if (action === "watch") {
     const controller = new AbortController();
     const onSignal = () => controller.abort();

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1025,16 +1025,12 @@ Subcommands:
   apply             Execute bidirectional converge transport (alias: transport, sync)
   watch             Run apply on a cadence until stopped (scheduled replication)
 
-Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
   --token <token>   Peer auth token (argv-visible; prefer safe channels below)
   --token-file <p> / REMNIC_CONVERGE_PEER_TOKEN  Non-argv token channels
-  --conflict-policy <policy>
-                    Policy override (newest-wins|manual; default newest-wins)
-  --interval <seconds>
-                    Watch cadence seconds (watch only; default 300)
-  --timeout <seconds>
-                    Peer HTTP timeout seconds (default 30; boot-scale 300+)
+  --conflict-policy <policy>  Override (newest-wins|manual; default newest-wins)
+  --interval <seconds>  Watch cadence seconds (watch only; default 300)
+  --timeout <seconds>  Peer HTTP timeout seconds (default 30; boot-scale 300+)
   --dry-run         Simulate transfers without mutating disk or remote peer
   --json            Output detailed JSON plan report
 `);
@@ -1042,7 +1038,7 @@ Options:
   }
 
   if (action !== "plan" && action !== "apply" && action !== "transport" && action !== "sync" && action !== "watch") {
-    process.stderr.write(`converge: unknown action "${action}". Use: plan, apply, or watch [options].\n`);
+    process.stderr.write(`converge: unknown action "${action}". Use plan, apply, or watch.\n`);
     process.exitCode = 2;
     return;
   }
@@ -1054,7 +1050,6 @@ Options:
   let conflictPolicy: ConvergeConflictPolicy | undefined;
   let intervalSeconds: number | undefined;
   let timeoutMsFlag: number | undefined;
-
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
     if (arg === "--token-file") {

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1028,6 +1028,11 @@ Subcommands:
 Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
   --token <token>   Bearer token or SecretRef for peer authentication
+                    (argv-visible; prefer --token-file or the env var below)
+  --token-file <path>
+                    Read the peer token from a 0600 file (not argv-visible)
+  REMNIC_CONVERGE_PEER_TOKEN=<token>
+                    Env alternative to --token (not argv-visible)
   --conflict-policy <policy>
                     Policy override (newest-wins|manual)
                     Default: converge.conflictPolicy (newest-wins)
@@ -1050,6 +1055,7 @@ Options:
 
   let peerUrl: string | undefined;
   let peerToken: string | undefined;
+  let tokenFile: string | undefined;
   let dryRun = false;
   let conflictPolicy: ConvergeConflictPolicy | undefined;
   let intervalSeconds: number | undefined;
@@ -1057,7 +1063,16 @@ Options:
 
   for (let i = 0; i < rest.length; i += 1) {
     const arg = rest[i];
-    if ((arg === "--peer" || arg === "--remote-url" || arg === "--remote") && rest[i + 1]) {
+    if (arg === "--token-file") {
+      const raw = rest[i + 1];
+      if (raw === undefined || raw.length === 0) {
+        process.stderr.write("converge: --token-file requires a path.\n");
+        process.exitCode = 2;
+        return;
+      }
+      tokenFile = raw;
+      i += 1;
+    } else if ((arg === "--peer" || arg === "--remote-url" || arg === "--remote") && rest[i + 1]) {
       peerUrl = rest[i + 1];
       i += 1;
     } else if (arg === "--token" && rest[i + 1]) {
@@ -1097,6 +1112,44 @@ Options:
       conflictPolicy = policy as ConvergeConflictPolicy;
       i += 1;
     }
+  }
+
+  // Credential channel hygiene (#2823): argv tokens are visible to any
+  // process listing for the lifetime of a plan/apply/watch run. Env and
+  // token-file are the operator-safe channels; --token still works but warns.
+  // Presence is tracked per source so an EMPTY value never silently falls
+  // through to a lower-precedence channel (documented order: --token >
+  // --token-file > env).
+  const tokenFromArgv = peerToken !== undefined;
+  if (!tokenFromArgv && tokenFile !== undefined) {
+    try {
+      const stat = fs.statSync(tokenFile);
+      // A group/world-readable credential file defeats the point of the
+      // channel; reject it instead of trusting the content.
+      if (stat.mode & 0o077) {
+        process.stderr.write(`converge: --token-file ${tokenFile} must not be group- or world-readable (chmod 600)\n`);
+        process.exitCode = 2;
+        return;
+      }
+      peerToken = fs.readFileSync(tokenFile, "utf8").trim();
+    } catch (err) {
+      process.stderr.write(`converge: --token-file ${tokenFile} could not be read: ${err}\n`);
+      process.exitCode = 2;
+      return;
+    }
+    if (peerToken.length === 0) {
+      process.stderr.write(`converge: --token-file ${tokenFile} is empty\n`);
+      process.exitCode = 2;
+      return;
+    }
+  }
+  if (!tokenFromArgv && tokenFile === undefined && process.env.REMNIC_CONVERGE_PEER_TOKEN !== undefined) {
+    peerToken = process.env.REMNIC_CONVERGE_PEER_TOKEN;
+  }
+  if (tokenFromArgv) {
+    process.stderr.write(
+      "converge: note: --token places the credential on argv, where any process listing can read it; prefer --token-file <path> or REMNIC_CONVERGE_PEER_TOKEN\n"
+    );
   }
 
   if (action === "watch") {

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1113,10 +1113,7 @@ Options:
     }
   }
 
-  const tokenChannel = resolveConvergeTokenChannel(
-    { argvToken: peerToken, tokenFile },
-    { REMNIC_CONVERGE_PEER_TOKEN: process.env.REMNIC_CONVERGE_PEER_TOKEN },
-  );
+  const tokenChannel = resolveConvergeTokenChannel({ argvToken: peerToken, tokenFile }, process.env);
   if (!tokenChannel.ok) {
     process.stderr.write(`converge: ${tokenChannel.error}\n`);
     process.exitCode = 2;
@@ -1125,7 +1122,7 @@ Options:
   peerToken = tokenChannel.token;
   if (tokenChannel.tokenFromArgv) {
     process.stderr.write(
-      "converge: note: --token places the credential on argv, where any process listing can read it; prefer --token-file <path> or REMNIC_CONVERGE_PEER_TOKEN\n"
+      "converge: note: --token is argv-visible; prefer --token-file <path> or REMNIC_CONVERGE_PEER_TOKEN\n"
     );
   }
 

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -40,6 +40,7 @@ import {
 } from "@remnic/core/reconcile/manifest.js";
 import { createOfflineStorageIo } from "./offline-storage-io.js";
 import { convergeWatch, type ConvergeWatchOutcome } from "./converge-watch.js";
+import { resolveConvergeTokenChannel } from "./converge-token-channel.js";
 import { resolveAgentAccessAuthToken } from "@remnic/core/resolve-auth-token.js";
 import {
   DEFAULT_PEER_REQUEST_TIMEOUT_MS,
@@ -1027,12 +1028,10 @@ Subcommands:
 
 Options:
   --peer <url>      Peer server URL (or --remote-url / --remote)
-  --token <token>   Bearer token or SecretRef for peer authentication
-                    (argv-visible; prefer --token-file or the env var below)
+  --token <token>   Peer auth token (argv-visible; prefer the safe channels)
   --token-file <path>
                     Read the peer token from a 0600 file (not argv-visible)
-  REMNIC_CONVERGE_PEER_TOKEN=<token>
-                    Env alternative to --token (not argv-visible)
+  REMNIC_CONVERGE_PEER_TOKEN  Env alternative to --token (not argv-visible)
   --conflict-policy <policy>
                     Policy override (newest-wins|manual)
                     Default: converge.conflictPolicy (newest-wins)
@@ -1114,39 +1113,17 @@ Options:
     }
   }
 
-  // Credential channel hygiene (#2823): argv tokens are visible to any
-  // process listing for the lifetime of a plan/apply/watch run. Env and
-  // token-file are the operator-safe channels; --token still works but warns.
-  // Presence is tracked per source so an EMPTY value never silently falls
-  // through to a lower-precedence channel (documented order: --token >
-  // --token-file > env).
-  const tokenFromArgv = peerToken !== undefined;
-  if (!tokenFromArgv && tokenFile !== undefined) {
-    try {
-      const stat = fs.statSync(tokenFile);
-      // A group/world-readable credential file defeats the point of the
-      // channel; reject it instead of trusting the content.
-      if (stat.mode & 0o077) {
-        process.stderr.write(`converge: --token-file ${tokenFile} must not be group- or world-readable (chmod 600)\n`);
-        process.exitCode = 2;
-        return;
-      }
-      peerToken = fs.readFileSync(tokenFile, "utf8").trim();
-    } catch (err) {
-      process.stderr.write(`converge: --token-file ${tokenFile} could not be read: ${err}\n`);
-      process.exitCode = 2;
-      return;
-    }
-    if (peerToken.length === 0) {
-      process.stderr.write(`converge: --token-file ${tokenFile} is empty\n`);
-      process.exitCode = 2;
-      return;
-    }
+  const tokenChannel = resolveConvergeTokenChannel(
+    { argvToken: peerToken, tokenFile },
+    { REMNIC_CONVERGE_PEER_TOKEN: process.env.REMNIC_CONVERGE_PEER_TOKEN },
+  );
+  if (!tokenChannel.ok) {
+    process.stderr.write(`converge: ${tokenChannel.error}\n`);
+    process.exitCode = 2;
+    return;
   }
-  if (!tokenFromArgv && tokenFile === undefined && process.env.REMNIC_CONVERGE_PEER_TOKEN !== undefined) {
-    peerToken = process.env.REMNIC_CONVERGE_PEER_TOKEN;
-  }
-  if (tokenFromArgv) {
+  peerToken = tokenChannel.token;
+  if (tokenChannel.tokenFromArgv) {
     process.stderr.write(
       "converge: note: --token places the credential on argv, where any process listing can read it; prefer --token-file <path> or REMNIC_CONVERGE_PEER_TOKEN\n"
     );

--- a/packages/remnic-cli/src/converge.ts
+++ b/packages/remnic-cli/src/converge.ts
@@ -1022,12 +1022,11 @@ export async function cmdConverge(
     console.log(`Usage: remnic converge <plan|apply|watch> [options]
 Subcommands:
   plan              Compute and display reconciliation plan
-  apply             Execute bidirectional converge transport (alias: transport, sync)
-  watch             Run apply on a cadence until stopped (scheduled replication)
+  apply/watch       Transport (aliases: transport, sync) / scheduled watch
 
   --peer <url>      Peer server URL (or --remote-url / --remote)
-  --token <token>   Peer auth token (argv-visible; prefer safe channels below)
-  --token-file <p> / REMNIC_CONVERGE_PEER_TOKEN  Non-argv token channels
+  --token <t> / --token-file <p> / REMNIC_CONVERGE_PEER_TOKEN  Credential
+                    channels (--token is argv-visible; prefer the other two)
   --conflict-policy <policy>  Override (newest-wins|manual; default newest-wins)
   --interval <seconds>  Watch cadence seconds (watch only; default 300)
   --timeout <seconds>  Peer HTTP timeout seconds (default 30; boot-scale 300+)
@@ -1060,11 +1059,15 @@ Subcommands:
         return;
       }
       i += 1;
-    } else if ((arg === "--peer" || arg === "--remote-url" || arg === "--remote") && rest[i + 1]) {
-      peerUrl = rest[i + 1];
-      i += 1;
     } else if (arg === "--token" && rest[i + 1]) {
       peerToken = rest[i + 1];
+      i += 1;
+    } else if (arg === "--token") {
+      process.stderr.write("converge: --token requires a value.\n");
+      process.exitCode = 2;
+      return;
+    } else if ((arg === "--peer" || arg === "--remote-url" || arg === "--remote") && rest[i + 1]) {
+      peerUrl = rest[i + 1];
       i += 1;
     } else if (arg === "--dry-run") {
       dryRun = true;
@@ -1166,7 +1169,6 @@ Subcommands:
     }
     return;
   }
-
   if (action === "plan") {
     const plan = await computeConvergePlan({
       config,
@@ -1182,7 +1184,6 @@ Subcommands:
     }
     return;
   }
-
   const result = await executeConvergeApply({
     peerUrl,
     peerToken,
@@ -1191,7 +1192,6 @@ Subcommands:
     config,
     ...(timeoutMsFlag !== undefined ? { peerRequestTimeoutMs: timeoutMsFlag } : {}),
   });
-
   if (json) {
     console.log(JSON.stringify(result, null, 2));
   } else {


### PR DESCRIPTION
## Summary

Implements #2823. `--token <value>` places the peer credential on argv, where any process listing can read it for the lifetime of a plan/apply/watch run — hours at boot scale, exactly the window in which operators take `ps` snapshots. Field-observed: a supervised watch and a long apply each forced a token rotation after argv inspections.

## Change

- `--token-file <path>`: reads the token from a file (intended 0600), never on argv. Unreadable file = exit 2 before any plan work.
- `REMNIC_CONVERGE_PEER_TOKEN`: env channel.
- Precedence: `--token` > `--token-file` > env.
- `--token` still works but prints a one-line stderr note steering to the safe channels.
- Help text documents all three.

## Verification

converge suite 59/59 (new test: missing `--token-file` exits 2 pre-plan); `tsc --noEmit` clean; ratchets + test-typecheck OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added converge credential support through token files and environment variables.
  * Credentials now work consistently with plan, apply, and watch operations.
  * Added bounded, order-preserving batching for reconciliation manifests.

* **Bug Fixes**
  * Missing, empty, unreadable, or insecure token files now produce clear errors before processing begins.
  * Missing token values now return actionable errors.

* **Security**
  * Added warnings for credentials provided through command-line arguments.
  * Documented supported credential sources and security considerations in CLI help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->