### PR TITLE
perf(storage): offline-sync writes skip the blocked-capture index rebuild when nothing is blocked

### DIFF
--- a/.changeset/2856-offline-sync-write-index-cost.md
+++ b/.changeset/2856-offline-sync-write-index-cost.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+An offline-sync (converge) file write where neither the existing file nor the incoming memory is tombstone-blocked no longer rebuilds the tombstone-blocked capture index. The index only holds blocked explicit-capture keys, so those writes cannot change it, but the unconditional rebuild re-read the whole corpus per replicated file — measured 15-31s per write against a ~190k-file corpus, turning a boot-scale `converge apply` into a multi-week projection. Blocked, unblocked, and blocked-to-active transitions still rebuild as before.

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-index.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-index.ts
@@ -533,6 +533,17 @@ export class TombstoneBlockedCaptureIndex {
     await this.failOpen("invalidateMemory", () => this.rebuildIfLoaded(ownedMarker));
   }
 
+  /**
+   * Drop an already-committed write marker without re-reading the corpus. The
+   * offline-sync mutation path commits its marker around the file write, then
+   * must clear it even when the write cannot have changed the blocked key set
+   * (neither side tombstone-blocked) — otherwise the marker lingers until some
+   * later rebuild clears it. Mirrors the tail of `add`/`sync`.
+   */
+  async clearCommittedWriteMarker(rebuildMarker: string): Promise<void> {
+    await this.clearRebuildRequired([rebuildMarker]);
+  }
+
   async syncUpdatedMemory(
     before: MemoryFile,
     frontmatter: MemoryFrontmatter,

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-index.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-index.ts
@@ -542,6 +542,10 @@ export class TombstoneBlockedCaptureIndex {
    */
   async clearCommittedWriteMarker(rebuildMarker: string): Promise<void> {
     await this.clearRebuildRequired([rebuildMarker]);
+    // getIndex() may have rebuilt while this marker was still pending and
+    // left authoritative=false. After the marker is gone, restore authority
+    // if no other uncommitted marker remains.
+    await this.setAuthoritative(true);
   }
 
   async syncUpdatedMemory(

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
@@ -508,7 +508,12 @@ export abstract class TombstoneBlockedCaptureIndexHost {
       // per write against a ~190k-file corpus, which turns a boot-scale
       // `converge apply` into a multi-week run. Clear the committed marker and
       // keep the index as-is.
-      await this.getTombstoneBlockedCaptureIndex().clearCommittedWriteMarker(ownedMarker);
+      try {
+        await this.getTombstoneBlockedCaptureIndex().clearCommittedWriteMarker(ownedMarker);
+      } catch (err) {
+        this.getTombstoneBlockedCaptureIndex().markUntrusted();
+        log.warn(`storage.offlineSyncFile committed write succeeded; marker cleanup failed: ${err}`);
+      }
     }
     if (filePath.includes(`${path.sep}artifacts${path.sep}`)) {
       this.bumpArtifactWriteVersion();

--- a/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
+++ b/packages/remnic-core/src/storage/tombstone-blocked-capture-sync.ts
@@ -244,7 +244,7 @@ export abstract class TombstoneBlockedCaptureIndexHost {
 
   async withMemorySnapshotsIfUnchanged<T>(
     expected: readonly MemoryFile[],
-    task: (memories: MemoryFile[]) => Promise<T>,
+    task: (memories: MemoryFile[]) => Promise<T>
   ): Promise<T | null> {
     if (expected.length === 0) return await task([]);
     const pathnames = [...new Set(expected.map((memory) => memory.path))];
@@ -490,7 +490,8 @@ export abstract class TombstoneBlockedCaptureIndexHost {
   private async invalidateAfterOfflineSyncMutation(
     filePath: string,
     ownedMarker?: string,
-    archiveChanged = true
+    archiveChanged = true,
+    blockedKeySetMayHaveChanged = true
   ): Promise<void> {
     this.invalidateAllMemoriesCache();
     this.invalidateKnowledgeIndexCache();
@@ -498,7 +499,17 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     if (filePath.includes(`${path.sep}cold${path.sep}`)) {
       this.invalidateColdMemoriesCache();
     }
-    await this.rebuildTombstoneBlockedCaptureAfterInvalidationForPath(filePath, ownedMarker);
+    if (blockedKeySetMayHaveChanged) {
+      await this.rebuildTombstoneBlockedCaptureAfterInvalidationForPath(filePath, ownedMarker);
+    } else if (ownedMarker !== undefined) {
+      // The index only holds tombstone-blocked explicit-capture keys, so a
+      // write where neither side is blocked cannot have changed it. Rebuilding
+      // here re-reads the whole corpus per replicated file — measured 15-31s
+      // per write against a ~190k-file corpus, which turns a boot-scale
+      // `converge apply` into a multi-week run. Clear the committed marker and
+      // keep the index as-is.
+      await this.getTombstoneBlockedCaptureIndex().clearCommittedWriteMarker(ownedMarker);
+    }
     if (filePath.includes(`${path.sep}artifacts${path.sep}`)) {
       this.bumpArtifactWriteVersion();
     }
@@ -675,7 +686,12 @@ export abstract class TombstoneBlockedCaptureIndexHost {
               log.warn(`storage.offlineSyncFile committed write marker failed: ${err}`);
             }
           }
-          await this.invalidateAfterOfflineSyncMutation(target, marker, changed !== false);
+          await this.invalidateAfterOfflineSyncMutation(
+            target,
+            marker,
+            changed !== false,
+            this.isTombstoneBlockedMemory(current) || this.isTombstoneBlockedMemory(after)
+          );
         } catch (err) {
           if (marker && !durable) {
             try {
@@ -704,10 +720,8 @@ export abstract class TombstoneBlockedCaptureIndexHost {
     const options = this.tombstoneBlockedCaptureIndexOptions();
     const after = options.parseMemory?.(target, content) ?? null;
     await withRawEntityPageMutation(path.dirname(options.stateDir), target, async () => {
-      await this.runTombstoneBlockedOfflineSyncMutation(
-        target,
-        after,
-        () => this.writeManagedStorageFile(target, () => this.writeStorageSecureFile(target, content))
+      await this.runTombstoneBlockedOfflineSyncMutation(target, after, () =>
+        this.writeManagedStorageFile(target, () => this.writeStorageSecureFile(target, content))
       );
     });
   }

--- a/tests/offline-sync-write-index-cost.test.ts
+++ b/tests/offline-sync-write-index-cost.test.ts
@@ -21,6 +21,10 @@ class CountingStorage extends StorageManager {
     this.readAllMemoriesCalls += 1;
     return super.readAllMemories();
   }
+
+  captureIndex() {
+    return this.getTombstoneBlockedCaptureIndex();
+  }
 }
 
 function memoryMarkdown(id: string, body: string, extra = ""): string {
@@ -64,6 +68,11 @@ test("offline-sync write of an unblocked memory does not re-read the corpus", as
       storage.readAllMemoriesCalls,
       before,
       "an unblocked offline-sync write must not trigger a full corpus rebuild"
+    );
+    assert.equal(
+      await storage.captureIndex().isAuthoritative(),
+      true,
+      "clearing the committed marker must restore index authority"
     );
     const stored = await storage.readMemoryByPath(target);
     assert.equal(stored?.frontmatter.id, "repl-1", "the replicated file must still be written");
@@ -122,5 +131,20 @@ test("unblocking via offline-sync write rebuilds and drops the key", async () =>
       false,
       "the unblocked key must be gone"
     );
+  });
+});
+
+test("clearing a committed marker restores authority after a mid-write rebuild", async () => {
+  await withStorage(async (storage) => {
+    await storage.hasTombstoneBlockedExplicitCapture("nothing", "fact");
+    const index = storage.captureIndex();
+    assert.equal(await index.isAuthoritative(), true);
+
+    const marker = await index.prepareWrite();
+    await index.check("nothing", "fact");
+    assert.equal(await index.isAuthoritative(), false, "a pending marker must make the index non-authoritative");
+
+    await index.clearCommittedWriteMarker(marker);
+    assert.equal(await index.isAuthoritative(), true, "clearing the last pending marker must restore authority");
   });
 });

--- a/tests/offline-sync-write-index-cost.test.ts
+++ b/tests/offline-sync-write-index-cost.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { StorageManager } from "../packages/remnic-core/src/storage.js";
+
+/**
+ * Regression: an offline-sync (converge) write of an ordinary active memory
+ * must not rebuild the tombstone-blocked capture index. The index only holds
+ * tombstone-blocked explicit-capture keys, so a write where neither the
+ * pre-write file nor the incoming memory is blocked cannot change it — but the
+ * invalidation path rebuilt it unconditionally, re-reading the whole corpus per
+ * replicated file (measured 15-31s per write against a ~190k-file corpus,
+ * which turned a boot-scale `converge apply` into a multi-week projection).
+ */
+class CountingStorage extends StorageManager {
+  readAllMemoriesCalls = 0;
+
+  override async readAllMemories(): Promise<ReturnType<StorageManager["readAllMemories"]>> {
+    this.readAllMemoriesCalls += 1;
+    return super.readAllMemories();
+  }
+}
+
+function memoryMarkdown(id: string, body: string, extra = ""): string {
+  return [
+    "---",
+    `id: ${id}`,
+    "category: fact",
+    "created: 2026-01-01T00:00:00.000Z",
+    "updated: 2026-01-01T00:00:00.000Z",
+    "status: active",
+    extra,
+    "---",
+    body,
+  ].join("\n");
+}
+
+async function withStorage(run: (storage: CountingStorage, dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "offline-sync-index-cost-"));
+  const storage = new CountingStorage(dir);
+  try {
+    await run(storage, dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("offline-sync write of an unblocked memory does not re-read the corpus", async () => {
+  await withStorage(async (storage, dir) => {
+    await mkdir(path.join(dir, "facts", "2026-01-01"), { recursive: true });
+    await writeFile(path.join(dir, "facts", "2026-01-01", "seed.md"), memoryMarkdown("seed-1", "seed body"));
+
+    // Load the capture index the way a running daemon would (any blocked check).
+    await storage.hasTombstoneBlockedExplicitCapture("nothing", "fact");
+    const before = storage.readAllMemoriesCalls;
+    assert.ok(before >= 1, "index warm-up must have read the corpus at least once");
+
+    const target = path.join(dir, "facts", "2026-01-01", "replicated.md");
+    await storage.writeOfflineSyncFile(target, Buffer.from(memoryMarkdown("repl-1", "replicated body")));
+
+    assert.equal(
+      storage.readAllMemoriesCalls,
+      before,
+      "an unblocked offline-sync write must not trigger a full corpus rebuild"
+    );
+    const stored = await storage.readMemoryByPath(target);
+    assert.equal(stored?.frontmatter.id, "repl-1", "the replicated file must still be written");
+  });
+});
+
+test("offline-sync write of a tombstone-blocked memory still rebuilds the index", async () => {
+  await withStorage(async (storage, dir) => {
+    await mkdir(path.join(dir, "facts", "2026-01-01"), { recursive: true });
+    await storage.hasTombstoneBlockedExplicitCapture("nothing", "fact");
+    const before = storage.readAllMemoriesCalls;
+
+    const blocked = memoryMarkdown(
+      "blocked-1",
+      "blocked explicit capture body",
+      "status: pending_review\nblockedBy: tomb-1"
+    ).replace("status: active\n", "");
+    const target = path.join(dir, "facts", "2026-01-01", "blocked.md");
+    await storage.writeOfflineSyncFile(target, Buffer.from(blocked));
+
+    assert.ok(
+      storage.readAllMemoriesCalls > before,
+      "a blocked offline-sync write must still update the index via rebuild"
+    );
+    assert.equal(
+      await storage.hasTombstoneBlockedExplicitCapture("blocked explicit capture body", "fact"),
+      true,
+      "the blocked key must be indexed"
+    );
+  });
+});
+
+test("unblocking via offline-sync write rebuilds and drops the key", async () => {
+  await withStorage(async (storage, dir) => {
+    await mkdir(path.join(dir, "facts", "2026-01-01"), { recursive: true });
+    const blocked = [
+      "---",
+      "id: blocked-2",
+      "category: fact",
+      "created: 2026-01-01T00:00:00.000Z",
+      "updated: 2026-01-01T00:00:00.000Z",
+      "status: pending_review",
+      "blockedBy: tomb-2",
+      "---",
+      "body that was blocked",
+    ].join("\n");
+    const target = path.join(dir, "facts", "2026-01-01", "flip.md");
+    await storage.writeOfflineSyncFile(target, Buffer.from(blocked));
+    assert.equal(await storage.hasTombstoneBlockedExplicitCapture("body that was blocked", "fact"), true);
+
+    const before = storage.readAllMemoriesCalls;
+    await storage.writeOfflineSyncFile(target, Buffer.from(memoryMarkdown("blocked-2", "body that was blocked")));
+    assert.ok(storage.readAllMemoriesCalls > before, "blocked -> active transition must rebuild");
+    assert.equal(
+      await storage.hasTombstoneBlockedExplicitCapture("body that was blocked", "fact"),
+      false,
+      "the unblocked key must be gone"
+    );
+  });
+});


### PR DESCRIPTION
## What

Every applied offline-sync (converge) file write to a memory directory rebuilt the tombstone-blocked capture index from the whole corpus. The index only ever holds tombstone-blocked explicit-capture keys (`status: pending_review` + `blockedBy`), so a write where neither the pre-write file nor the incoming memory is blocked cannot change it. This skips the rebuild for that case and clears the already-committed write marker instead. Blocked writes, deletions of blocked files, and blocked<->active transitions rebuild exactly as before.

## Why it matters (measured)

Bootstrap convergence of a large two-host primary/failover corpus was measured at **15.4s per applied write** against a 182k-file failover copy and **20-31s** against a 194k-file primary — a ~130k-file apply projected to multiple weeks, which is not deployable. `strace` during a write plus a controlled HTTP probe isolated the cost to the per-write index rebuild (`readAllMemories` + `readAllColdMemories` over the full corpus inside `invalidateAfterOfflineSyncMutation`). A control write to `transcripts/` — which does not trigger the rebuild — lands in **19-30ms** on the same daemon.

Root-cause chain, for the record:

1. `runTombstoneBlockedOfflineSyncMutation` -> `invalidateAfterOfflineSyncMutation` -> `rebuildTombstoneBlockedCaptureAfterInvalidationForPath` fires for every memory-dir path.
2. `rebuildIfLoaded` -> `rebuild()` streams `readAllMemories()` + `readAllColdMemories()`.
3. The mutation already knows both sides of the write (`current` pre-write state, `after` parsed incoming memory) and already computes blockedness for the marker path (`affectsBlockedIndex`) — the rebuild just never used it.

## Change

- `TombstoneBlockedCaptureIndex.clearCommittedWriteMarker(marker)` — drops an already-committed write marker without re-reading the corpus, mirroring the tail of `add`/`sync`.
- `invalidateAfterOfflineSyncMutation` takes `blockedKeySetMayHaveChanged`; when false it clears the committed marker and keeps the index as-is.
- The offline-sync mutation passes `isTombstoneBlockedMemory(current) || isTombstoneBlockedMemory(after)`.

## Tests

`tests/offline-sync-write-index-cost.test.ts` counts `readAllMemories` invocations through a StorageManager subclass:

- an unblocked offline-sync write adds **zero** corpus reads (fails against the previous code — verified by reverting the single call-site argument);
- a tombstone-blocked write still rebuilds and the key is indexed;
- a blocked -> active overwrite rebuilds and the key is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary index rebuilding for offline-sync writes that do not change blocked records.
  * Continued updating the index when records become blocked, are unblocked, or otherwise require changes.

* **Bug Fixes**
  * Improved index state recovery after committed write markers are cleared.

* **Tests**
  * Added coverage for offline-sync writes, blocked-record transitions, and index restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->