### PR TITLE
fix(journal): repair command type contracts

### DIFF
--- a/packages/remnic-cli/src/commands/journal.test.ts
+++ b/packages/remnic-cli/src/commands/journal.test.ts
@@ -11,9 +11,11 @@ import {
   createJournalMemoryWriter,
   parseConfig,
   readJournalForDate,
+  type FallbackLlmOptions,
   type JournalExtractionDeps,
   type PluginConfig,
 } from "@remnic/core";
+import type { ExtractionResult } from "@remnic/core/types.js";
 import { createJournalCommandDeps, runJournalBinaryCommand, runJournalCommand, type JournalCommandDeps } from "./journal.js";
 
 const START = "<!-- remnic:timeline:start -->";
@@ -194,7 +196,8 @@ function reviewMemoryDirConfigFor(memoryDir: string): PluginConfig {
 
 interface RecordedWrite {
   status: string;
-  tags: string[];
+  /** SealedMemoryEnvelope.tags is readonly; the recorder only observes it. */
+  tags: readonly string[];
 }
 
 function fakeExtractionDeps(
@@ -555,6 +558,19 @@ test("production extract invokes the configured gateway provider and model", asy
     fs.mkdirSync(path.dirname(dayFile), { recursive: true });
     fs.writeFileSync(dayFile, "I decided the configured gateway must reach extraction.\n");
     const customPrimary = "journal-gw-test/custom-extract";
+    const fixtureResult: ExtractionResult = {
+      facts: [
+        {
+          content: "I decided the configured gateway must reach extraction.",
+          category: "decision",
+          confidence: 0.9,
+          tags: [],
+        },
+      ],
+      profileUpdates: [],
+      entities: [],
+      questions: [],
+    };
     const config = parseConfig({
       memoryDir,
       modelSource: "gateway",
@@ -583,33 +599,22 @@ test("production extract invokes the configured gateway provider and model", asy
         timeline: { journal: { enabled: true, source: "memoryDir", extractionMode: "review" } },
       },
     });
-    FallbackLlmClient.prototype.parseWithSchemaDetailed = async function (
+    // Mocked against the real parseWithSchemaDetailed signature (AGENTS.md
+    // §21 — Test Mock Signature Fidelity) so contract drift surfaces here.
+    FallbackLlmClient.prototype.parseWithSchemaDetailed = async function <T>(
       this: FallbackLlmClient,
-      _messages,
-      _schema,
-      options,
+      _messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+      _schema: { parse: (data: unknown) => T },
+      options?: FallbackLlmOptions,
     ) {
-      const gatewayConfig = (this as unknown as { gatewayConfig?: {
+      // Unchecked cast: gatewayConfig exists on the runtime instance but not
+      // the public type; the mock reads it only to assert agent wiring.
+      const holder = this as unknown as { gatewayConfig?: {
         agents?: { list?: Array<{ id: string; model?: { primary?: string } }> };
-      } }).gatewayConfig;
-      const persona = gatewayConfig?.agents?.list?.find((agent) => agent.id === "journal-extract-agent");
+      } };
+      const persona = holder.gatewayConfig?.agents?.list?.find((agent) => agent.id === "journal-extract-agent");
       seen.push({ primary: persona?.model?.primary, agentId: options?.agentId });
-      return {
-        modelUsed: customPrimary,
-        result: {
-          facts: [
-            {
-              content: "I decided the configured gateway must reach extraction.",
-              category: "decision",
-              confidence: 0.9,
-              tags: [],
-            },
-          ],
-          profileUpdates: [],
-          entities: [],
-          questions: [],
-        },
-      };
+      return { modelUsed: customPrimary, result: fixtureResult as unknown as T };
     };
     const storage = new StorageManager(config.memoryDir);
     const result = await capture(

--- a/packages/remnic-cli/src/commands/journal.ts
+++ b/packages/remnic-cli/src/commands/journal.ts
@@ -37,10 +37,10 @@ import {
   runJournalReviewExtraction,
   seedJournal,
   withJournalDateLock,
-  type BufferTurn,
   type JournalExtractionDeps,
   type PluginConfig,
 } from "@remnic/core";
+import type { BufferTurn } from "@remnic/core/types.js";
 import { resolveConfigPath } from "../config-path.js";
 
 export interface JournalCommandIo {

--- a/scripts/check-test-types.mjs
+++ b/scripts/check-test-types.mjs
@@ -38,15 +38,19 @@ export const normalizeDiagnostics = (value, root = repoRoot) =>
     .join("\n")
     .trim();
 
-const ignoredToolingWarningPattern =
-  /^\[WARN\] The "pnpm" field in package\.json is no longer read by pnpm\./;
+const ignoredToolingWarningPatterns = [
+  /^\[WARN\] The "pnpm" field in package\.json is no longer read by pnpm\./,
+  // pnpm prints per-package WARN lines (e.g. unsupported optional platform
+  // builds) into the same captured stream as tsc output in CI.
+  /^packages\/\S+\s*\|\s*WARN\s/,
+];
 
 export function nonDiagnosticFailureLines(value, root = repoRoot) {
   const lines = [];
   let sawDiagnostic = false;
   for (const rawLine of normalizeOutputLines(value, root)) {
     const line = rawLine.trim();
-    if (line.length === 0 || ignoredToolingWarningPattern.test(line)) continue;
+    if (line.length === 0 || ignoredToolingWarningPatterns.some((pattern) => pattern.test(line))) continue;
     if (diagnosticHeaderPattern.test(line)) {
       sawDiagnostic = true;
       continue;

--- a/scripts/check-test-types.mjs
+++ b/scripts/check-test-types.mjs
@@ -40,9 +40,8 @@ export const normalizeDiagnostics = (value, root = repoRoot) =>
 
 const ignoredToolingWarningPatterns = [
   /^\[WARN\] The "pnpm" field in package\.json is no longer read by pnpm\./,
-  // pnpm prints per-package WARN lines (e.g. unsupported optional platform
-  // builds) into the same captured stream as tsc output in CI.
-  /^packages\/\S+\s*\|\s*WARN\s/,
+  // pnpm optional-dependency platform notice; exact prefix from CI logs.
+  /^packages\/\S+\s+\|\s+WARN\s+Unsupported platform: wanted:/,
 ];
 
 export function nonDiagnosticFailureLines(value, root = repoRoot) {

--- a/tests/check-test-types-script.test.ts
+++ b/tests/check-test-types-script.test.ts
@@ -107,6 +107,32 @@ describe("check-test-types wrapper", () => {
     assert.match(result.details ?? "", /wrapper\.js/);
   });
 
+  it("ignores pnpm unsupported-platform warnings next to baseline diagnostics", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: `${BASELINE_DIAGNOSTIC}\npackages/capture-native-darwin-arm64     |  WARN Unsupported platform: wanted: {"cpu":["arm64"]} (current: {"os":"linux"})\n`,
+      expectedText: `${BASELINE_DIAGNOSTIC}\n`,
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, true);
+  });
+
+  it("rejects unrelated package WARN lines so the baseline is not rewritten", () => {
+    const stdout = `${BASELINE_DIAGNOSTIC}\npackages/secret-pkg | WARN something else entirely\n`;
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout,
+      expectedText: `${BASELINE_DIAGNOSTIC}\n`,
+      root: ROOT,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.message, /non-diagnostic output/);
+
+    const update = evaluateTestTypecheckUpdate({ status: 2, stdout, root: ROOT });
+    assert.equal(update.ok, false);
+  });
+
   it("rejects tsc failures with no TypeScript diagnostics", () => {
     const result = evaluateTestTypecheckResult({
       status: 2,

--- a/tests/offline-sync-write-index-cost.test.ts
+++ b/tests/offline-sync-write-index-cost.test.ts
@@ -17,9 +17,9 @@ import { StorageManager } from "../packages/remnic-core/src/storage.js";
 class CountingStorage extends StorageManager {
   readAllMemoriesCalls = 0;
 
-  override async readAllMemories(): Promise<ReturnType<StorageManager["readAllMemories"]>> {
+  override async readAllMemories(options?: Parameters<StorageManager["readAllMemories"]>[0]) {
     this.readAllMemoriesCalls += 1;
-    return super.readAllMemories();
+    return super.readAllMemories(options);
   }
 
   captureIndex() {


### PR DESCRIPTION
Fixes #2939

## Summary

The three pre-existing type errors that fail the required `checks` job
Typecheck step on `main`, all in the journal command surface:

1. `src/commands/journal.ts` imported `BufferTurn` from the `@remnic/core`
   main entry, which does not re-export it. The type's canonical defining
   module is `core/src/types.ts`, which the package already exposes as the
   public `@remnic/core/types.js` subpath — the same import convention
   already used by other CLI modules for type-only imports. No new export,
   no duplicate type.
2. `RecordedWrite.tags` declared a mutable `string[]` while
   `SealedMemoryEnvelope.tags` is `readonly string[]`. Widened the recorder
   contract to `readonly string[]` — the only consumer is a `deepEqual`
   read, so nothing mutates it.
3. The `FallbackLlmClient.prototype.parseWithSchemaDetailed` mock used
   contextually-typed parameters and returned a concrete object, which is
   not assignable to the generic `() => { result: T; modelUsed } | { result:
   null; failureReason }` signature. Rewrote the mock against the real
   signature (generic `<T>`, explicit parameter types, fixture typed as
   `ExtractionResult` cast through `T`), matching the canonical gateway
   fixture pattern in `extraction-scope-source-agent.test.ts` (AGENTS.md
   §21 — Test Mock Signature Fidelity). The `gatewayConfig` read moved to a
   named cast with a reason instead of inline member access.

Runtime behavior is unchanged: the mock returns the same fixture, records
the same `seen` entries, and restores the original prototype method in
`finally`.

## Verification

- `@remnic/core` `check-types`: clean
- `@remnic/cli` `check-types`: clean (was failing on all three errors)
- `npm run test:file packages/remnic-cli/src/commands/journal.test.ts`:
  18/18 pass, including the rewritten gateway-mock test
- `npm run check:pre-push`: all cheap CI gates pass (ratchets, regex
  safety, envelope belt, config contract, lifecycle-matrix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated journal extraction tests to reflect current parsing and type behavior.
  * Improved coverage for gateway extraction results, schema parsing, fallback options, and model configuration.
  * Updated offline synchronization regression tests for parameterized storage reads.
  * Refined validation to ignore only recognized unsupported-platform warnings while preserving detection of unrelated warnings.

* **Refactor**
  * Reorganized internal type imports without changing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->