### PR TITLE
fix(bench): send Bearer auth for H5 openai-compat executor

### DIFF
--- a/.changeset/h5-openai-compat-auth-1962.md
+++ b/.changeset/h5-openai-compat-auth-1962.md
@@ -3,4 +3,4 @@
 "@remnic/cli": patch
 ---
 
-H5 injection-suite openai-compat executor sends Authorization from OPENAI_API_KEY or NVIDIA_API_KEY (NVIDIA hosts prefer NVIDIA_API_KEY) and fails closed when neither is set (#1962).
+H5 injection-suite openai-compat executor attaches a host-matched Bearer token only (NVIDIA_API_KEY, OPENAI_API_KEY, or REMNIC_OPENAI_COMPAT_API_KEY) and fails closed rather than reusing an ambient key on the wrong host (#1962).

--- a/.changeset/h5-openai-compat-auth-1962.md
+++ b/.changeset/h5-openai-compat-auth-1962.md
@@ -3,4 +3,4 @@
 "@remnic/cli": patch
 ---
 
-H5 injection-suite openai-compat executor sends Authorization from OPENAI_API_KEY or NVIDIA_API_KEY and fails closed when neither is set (#1962).
+H5 injection-suite openai-compat executor sends Authorization from OPENAI_API_KEY or NVIDIA_API_KEY (NVIDIA hosts prefer NVIDIA_API_KEY) and fails closed when neither is set (#1962).

--- a/.changeset/h5-openai-compat-auth-1962.md
+++ b/.changeset/h5-openai-compat-auth-1962.md
@@ -1,0 +1,6 @@
+---
+"@remnic/bench": patch
+"@remnic/cli": patch
+---
+
+H5 injection-suite openai-compat executor sends Authorization from OPENAI_API_KEY or NVIDIA_API_KEY and fails closed when neither is set (#1962).

--- a/.changeset/h5-openai-compat-auth-1962.md
+++ b/.changeset/h5-openai-compat-auth-1962.md
@@ -3,4 +3,4 @@
 "@remnic/cli": patch
 ---
 
-H5 injection-suite openai-compat executor attaches a host-matched Bearer token only (NVIDIA_API_KEY, OPENAI_API_KEY, or REMNIC_OPENAI_COMPAT_API_KEY) and fails closed rather than reusing an ambient key on the wrong host (#1962).
+H5 injection-suite openai-compat executor attaches a host-matched Bearer token only (NVIDIA_API_KEY, OPENAI_API_KEY, or REMNIC_OPENAI_COMPAT_API_KEY), requires https except loopback HTTP, and fails closed rather than reusing an ambient key on the wrong host (#1962).

--- a/.changeset/h5-openai-compat-auth-1962.md
+++ b/.changeset/h5-openai-compat-auth-1962.md
@@ -3,4 +3,4 @@
 "@remnic/cli": patch
 ---
 
-H5 injection-suite openai-compat executor attaches a host-matched Bearer token only (NVIDIA_API_KEY, OPENAI_API_KEY, or REMNIC_OPENAI_COMPAT_API_KEY), requires https except loopback HTTP, and fails closed rather than reusing an ambient key on the wrong host (#1962).
+H5 injection-suite openai-compat executor attaches a Bearer token only on exact API hosts (NVIDIA_API_KEY on integrate.api.nvidia.com, OPENAI_API_KEY on api.openai.com) or REMNIC_OPENAI_COMPAT_API_KEY elsewhere — including other *.openai.com / *.nvidia.com subdomains — requires https except loopback HTTP, and fails closed rather than reusing an ambient key on the wrong host (#1962).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- H5 injection-suite `openai-compat` executor attaches a host-matched `Authorization: Bearer` token only (`NVIDIA_API_KEY` on `*.nvidia.com`, `OPENAI_API_KEY` on `*.openai.com`, `REMNIC_OPENAI_COMPAT_API_KEY` elsewhere), requires `https` except loopback HTTP (`127.0.0.1` / `localhost`), and fails closed rather than reusing an ambient key on the wrong host (`#1962`).
+- H5 injection-suite `openai-compat` executor attaches a host-matched `Authorization: Bearer` token only (`NVIDIA_API_KEY` on `integrate.api.nvidia.com`, `OPENAI_API_KEY` on `api.openai.com`, `REMNIC_OPENAI_COMPAT_API_KEY` on every other host including other `*.openai.com` / `*.nvidia.com` subdomains), requires `https` except loopback HTTP (`127.0.0.1` / `localhost`), and fails closed rather than reusing an ambient key on the wrong host (`#1962`).
 
 
 ## [v9.69.35] — 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- H5 injection-suite `openai-compat` executor now sends `Authorization: Bearer` from `OPENAI_API_KEY` or `NVIDIA_API_KEY` and fails closed when neither is set (`#1962`).
+- H5 injection-suite `openai-compat` executor sends `Authorization: Bearer` from `OPENAI_API_KEY` or `NVIDIA_API_KEY` (NVIDIA hosts prefer `NVIDIA_API_KEY`) and fails closed when neither is set (`#1962`).
 
 
 ## [v9.69.35] — 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- H5 injection-suite `openai-compat` executor sends `Authorization: Bearer` from `OPENAI_API_KEY` or `NVIDIA_API_KEY` (NVIDIA hosts prefer `NVIDIA_API_KEY`) and fails closed when neither is set (`#1962`).
+- H5 injection-suite `openai-compat` executor attaches a host-matched `Authorization: Bearer` token only (`NVIDIA_API_KEY` on `*.nvidia.com`, `OPENAI_API_KEY` on `*.openai.com`, `REMNIC_OPENAI_COMPAT_API_KEY` elsewhere) and fails closed rather than reusing an ambient key on the wrong host (`#1962`).
 
 
 ## [v9.69.35] — 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- H5 injection-suite `openai-compat` executor attaches a host-matched `Authorization: Bearer` token only (`NVIDIA_API_KEY` on `*.nvidia.com`, `OPENAI_API_KEY` on `*.openai.com`, `REMNIC_OPENAI_COMPAT_API_KEY` elsewhere) and fails closed rather than reusing an ambient key on the wrong host (`#1962`).
+- H5 injection-suite `openai-compat` executor attaches a host-matched `Authorization: Bearer` token only (`NVIDIA_API_KEY` on `*.nvidia.com`, `OPENAI_API_KEY` on `*.openai.com`, `REMNIC_OPENAI_COMPAT_API_KEY` elsewhere), requires `https` except loopback HTTP (`127.0.0.1` / `localhost`), and fails closed rather than reusing an ambient key on the wrong host (`#1962`).
 
 
 ## [v9.69.35] — 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- H5 injection-suite `openai-compat` executor now sends `Authorization: Bearer` from `OPENAI_API_KEY` or `NVIDIA_API_KEY` and fails closed when neither is set (`#1962`).
+
+
 ## [v9.69.35] — 2026-08-24
 
 ### Added

--- a/packages/bench/src/security/injection-suite/injection-suite.test.ts
+++ b/packages/bench/src/security/injection-suite/injection-suite.test.ts
@@ -347,7 +347,7 @@ test("openai-compat sends Authorization from OPENAI_API_KEY", async () => {
   }
 });
 
-test("openai-compat prefers OPENAI_API_KEY over NVIDIA_API_KEY", async () => {
+test("openai-compat generic base prefers OPENAI_API_KEY when both keys are set", async () => {
   const mock = mockJsonFetch({
     choices: [{ message: { content: "ok" } }],
   });
@@ -357,6 +357,55 @@ test("openai-compat prefers OPENAI_API_KEY over NVIDIA_API_KEY", async () => {
       async () => {
         await completeChat(
           { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+          "hi",
+        );
+        assert.equal(mock.requests[0]?.headers.authorization, "Bearer openai-first");
+      },
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("openai-compat NVIDIA base prefers NVIDIA_API_KEY when both keys are set", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv(
+      { OPENAI_API_KEY: "openai-first", NVIDIA_API_KEY: "nvidia-second" },
+      async () => {
+        await completeChat(
+          {
+            kind: "openai-compat",
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            requestTimeoutMs: 250,
+          },
+          "hi",
+        );
+        assert.equal(mock.requests[0]?.headers.authorization, "Bearer nvidia-second");
+        assert.match(mock.requests[0]?.url ?? "", /^https:\/\/integrate\.api\.nvidia\.com\//);
+      },
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("openai-compat does not treat a suffix lookalike as an NVIDIA host", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv(
+      { OPENAI_API_KEY: "openai-first", NVIDIA_API_KEY: "nvidia-second" },
+      async () => {
+        await completeChat(
+          {
+            kind: "openai-compat",
+            baseUrl: "https://integrate.api.nvidia.com.example/v1",
+            requestTimeoutMs: 250,
+          },
           "hi",
         );
         assert.equal(mock.requests[0]?.headers.authorization, "Bearer openai-first");
@@ -414,6 +463,26 @@ test("openai-compat fails closed when no API key is set", async () => {
         () =>
           completeChat(
             { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+            "hi",
+          ),
+        (error: unknown) => {
+          assert.ok(error instanceof InjectionSuiteHostFault);
+          assert.match(error.message, /OPENAI_API_KEY/);
+          assert.match(error.message, /NVIDIA_API_KEY/);
+          return true;
+        },
+      );
+      assert.equal(fetchCalls, 0);
+    });
+    await withEnv({ OPENAI_API_KEY: undefined, NVIDIA_API_KEY: undefined }, async () => {
+      await assert.rejects(
+        () =>
+          completeChat(
+            {
+              kind: "openai-compat",
+              baseUrl: "https://integrate.api.nvidia.com/v1",
+              requestTimeoutMs: 250,
+            },
             "hi",
           ),
         (error: unknown) => {

--- a/packages/bench/src/security/injection-suite/injection-suite.test.ts
+++ b/packages/bench/src/security/injection-suite/injection-suite.test.ts
@@ -458,6 +458,22 @@ test("openai-compat unknown host with OPENAI_API_KEY fails before fetch", async 
   );
 });
 
+test("openai-compat unrelated openai.com subdomain does not receive OPENAI_API_KEY", async () => {
+  await assertFailsBeforeFetch(
+    { OPENAI_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "https://something.openai.com/v1", requestTimeoutMs: 250 },
+    /REMNIC_OPENAI_COMPAT_API_KEY/,
+  );
+});
+
+test("openai-compat unrelated nvidia.com subdomain does not receive NVIDIA_API_KEY", async () => {
+  await assertFailsBeforeFetch(
+    { NVIDIA_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "https://evil.nvidia.com/v1", requestTimeoutMs: 250 },
+    /REMNIC_OPENAI_COMPAT_API_KEY/,
+  );
+});
+
 test("openai-compat NVIDIA lookalike host does not receive OPENAI_API_KEY", async () => {
   await assertFailsBeforeFetch(
     { OPENAI_API_KEY: "must-not-be-sent", NVIDIA_API_KEY: "also-must-not-be-sent" },

--- a/packages/bench/src/security/injection-suite/injection-suite.test.ts
+++ b/packages/bench/src/security/injection-suite/injection-suite.test.ts
@@ -478,6 +478,64 @@ test("openai-compat treats a blank NVIDIA_API_KEY as missing on NVIDIA hosts", a
   );
 });
 
+test("openai-compat refuses HTTP OpenAI hosts before fetch", async () => {
+  await assertFailsBeforeFetch(
+    { OPENAI_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "http://api.openai.com/v1", requestTimeoutMs: 250 },
+    /https/,
+  );
+});
+
+test("openai-compat refuses HTTP NVIDIA hosts before fetch", async () => {
+  await assertFailsBeforeFetch(
+    { NVIDIA_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "http://integrate.api.nvidia.com/v1", requestTimeoutMs: 250 },
+    /https/,
+  );
+});
+
+test("openai-compat refuses HTTP custom non-loopback hosts before fetch", async () => {
+  await assertFailsBeforeFetch(
+    { REMNIC_OPENAI_COMPAT_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "http://compat.example/v1", requestTimeoutMs: 250 },
+    /https/,
+  );
+});
+
+test("openai-compat allows loopback HTTP with REMNIC_OPENAI_COMPAT_API_KEY", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv({ ...AUTH_CLEAR_ENV, REMNIC_OPENAI_COMPAT_API_KEY: "loopback-key" }, async () => {
+      await completeChat(
+        { kind: "openai-compat", baseUrl: "http://localhost:9/v1", requestTimeoutMs: 250 },
+        "hi",
+      );
+      assert.equal(mock.requests[0]?.headers.authorization, "Bearer loopback-key");
+    });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("openai-compat custom https host sends REMNIC_OPENAI_COMPAT_API_KEY", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv({ ...AUTH_CLEAR_ENV, REMNIC_OPENAI_COMPAT_API_KEY: "custom-https-key" }, async () => {
+      await completeChat(
+        { kind: "openai-compat", baseUrl: "https://compat.example/v1", requestTimeoutMs: 250 },
+        "hi",
+      );
+      assert.equal(mock.requests[0]?.headers.authorization, "Bearer custom-https-key");
+    });
+  } finally {
+    mock.restore();
+  }
+});
+
 test("ollama omits Authorization even when OPENAI_API_KEY is set", async () => {
   const mock = mockJsonFetch({
     message: { content: "ok" },

--- a/packages/bench/src/security/injection-suite/injection-suite.test.ts
+++ b/packages/bench/src/security/injection-suite/injection-suite.test.ts
@@ -284,7 +284,7 @@ test("plan and execute accept variants-per-family above 64", async () => {
 });
 
 
-function withEnv(
+async function withEnv(
   overlay: Record<string, string | undefined>,
   fn: () => Promise<void>,
 ): Promise<void> {

--- a/packages/bench/src/security/injection-suite/injection-suite.test.ts
+++ b/packages/bench/src/security/injection-suite/injection-suite.test.ts
@@ -327,39 +327,56 @@ function mockJsonFetch(responseBody: Record<string, unknown>) {
   };
 }
 
-test("openai-compat sends Authorization from OPENAI_API_KEY", async () => {
-  const mock = mockJsonFetch({
-    choices: [{ message: { content: "ok" } }],
-  });
+const AUTH_CLEAR_ENV = {
+  OPENAI_API_KEY: undefined,
+  NVIDIA_API_KEY: undefined,
+  REMNIC_OPENAI_COMPAT_API_KEY: undefined,
+} as const;
+
+async function assertFailsBeforeFetch(
+  overlay: Record<string, string | undefined>,
+  options: { kind: "openai-compat"; baseUrl: string; requestTimeoutMs: number },
+  messagePattern: RegExp,
+): Promise<void> {
+  let fetchCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
   try {
-    await withEnv({ OPENAI_API_KEY: "test-openai-key", NVIDIA_API_KEY: undefined }, async () => {
-      const text = await completeChat(
-        { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
-        "hi",
+    await withEnv({ ...AUTH_CLEAR_ENV, ...overlay }, async () => {
+      await assert.rejects(
+        () => completeChat(options, "hi"),
+        (error: unknown) => {
+          assert.ok(error instanceof InjectionSuiteHostFault);
+          assert.match(error.message, messagePattern);
+          return true;
+        },
       );
-      assert.equal(text, "ok");
-      assert.equal(mock.requests.length, 1);
-      assert.equal(mock.requests[0]?.headers.authorization, "Bearer test-openai-key");
-      assert.match(mock.requests[0]?.url ?? "", /\/chat\/completions$/);
+      assert.equal(fetchCalls, 0);
     });
   } finally {
-    mock.restore();
+    globalThis.fetch = originalFetch;
   }
-});
+}
 
-test("openai-compat generic base prefers OPENAI_API_KEY when both keys are set", async () => {
+test("openai-compat OpenAI host sends Authorization from OPENAI_API_KEY", async () => {
   const mock = mockJsonFetch({
     choices: [{ message: { content: "ok" } }],
   });
   try {
     await withEnv(
-      { OPENAI_API_KEY: "openai-first", NVIDIA_API_KEY: "nvidia-second" },
+      { ...AUTH_CLEAR_ENV, OPENAI_API_KEY: "test-openai-key", NVIDIA_API_KEY: "must-not-be-sent" },
       async () => {
-        await completeChat(
-          { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+        const text = await completeChat(
+          { kind: "openai-compat", baseUrl: "https://api.openai.com/v1", requestTimeoutMs: 250 },
           "hi",
         );
-        assert.equal(mock.requests[0]?.headers.authorization, "Bearer openai-first");
+        assert.equal(text, "ok");
+        assert.equal(mock.requests.length, 1);
+        assert.equal(mock.requests[0]?.headers.authorization, "Bearer test-openai-key");
+        assert.match(mock.requests[0]?.url ?? "", /\/chat\/completions$/);
       },
     );
   } finally {
@@ -367,13 +384,13 @@ test("openai-compat generic base prefers OPENAI_API_KEY when both keys are set",
   }
 });
 
-test("openai-compat NVIDIA base prefers NVIDIA_API_KEY when both keys are set", async () => {
+test("openai-compat NVIDIA host sends Authorization from NVIDIA_API_KEY", async () => {
   const mock = mockJsonFetch({
     choices: [{ message: { content: "ok" } }],
   });
   try {
     await withEnv(
-      { OPENAI_API_KEY: "openai-first", NVIDIA_API_KEY: "nvidia-second" },
+      { ...AUTH_CLEAR_ENV, OPENAI_API_KEY: "must-not-be-sent", NVIDIA_API_KEY: "nvidia-only" },
       async () => {
         await completeChat(
           {
@@ -383,7 +400,7 @@ test("openai-compat NVIDIA base prefers NVIDIA_API_KEY when both keys are set", 
           },
           "hi",
         );
-        assert.equal(mock.requests[0]?.headers.authorization, "Bearer nvidia-second");
+        assert.equal(mock.requests[0]?.headers.authorization, "Bearer nvidia-only");
         assert.match(mock.requests[0]?.url ?? "", /^https:\/\/integrate\.api\.nvidia\.com\//);
       },
     );
@@ -392,23 +409,24 @@ test("openai-compat NVIDIA base prefers NVIDIA_API_KEY when both keys are set", 
   }
 });
 
-test("openai-compat does not treat a suffix lookalike as an NVIDIA host", async () => {
+test("openai-compat unknown host sends only REMNIC_OPENAI_COMPAT_API_KEY", async () => {
   const mock = mockJsonFetch({
     choices: [{ message: { content: "ok" } }],
   });
   try {
     await withEnv(
-      { OPENAI_API_KEY: "openai-first", NVIDIA_API_KEY: "nvidia-second" },
+      {
+        ...AUTH_CLEAR_ENV,
+        OPENAI_API_KEY: "must-not-be-sent",
+        NVIDIA_API_KEY: "also-must-not-be-sent",
+        REMNIC_OPENAI_COMPAT_API_KEY: "explicit-compat-key",
+      },
       async () => {
         await completeChat(
-          {
-            kind: "openai-compat",
-            baseUrl: "https://integrate.api.nvidia.com.example/v1",
-            requestTimeoutMs: 250,
-          },
+          { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
           "hi",
         );
-        assert.equal(mock.requests[0]?.headers.authorization, "Bearer openai-first");
+        assert.equal(mock.requests[0]?.headers.authorization, "Bearer explicit-compat-key");
       },
     );
   } finally {
@@ -416,87 +434,48 @@ test("openai-compat does not treat a suffix lookalike as an NVIDIA host", async 
   }
 });
 
-test("openai-compat uses NVIDIA_API_KEY when OPENAI_API_KEY is unset", async () => {
-  const mock = mockJsonFetch({
-    choices: [{ message: { content: "ok" } }],
-  });
-  try {
-    await withEnv({ OPENAI_API_KEY: undefined, NVIDIA_API_KEY: "nvidia-only" }, async () => {
-      await completeChat(
-        { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
-        "hi",
-      );
-      assert.equal(mock.requests[0]?.headers.authorization, "Bearer nvidia-only");
-    });
-  } finally {
-    mock.restore();
-  }
+test("openai-compat NVIDIA host with only OPENAI_API_KEY fails before fetch", async () => {
+  await assertFailsBeforeFetch(
+    { OPENAI_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "https://integrate.api.nvidia.com/v1", requestTimeoutMs: 250 },
+    /NVIDIA_API_KEY/,
+  );
 });
 
-test("openai-compat treats a blank OPENAI_API_KEY as missing", async () => {
-  const mock = mockJsonFetch({
-    choices: [{ message: { content: "ok" } }],
-  });
-  try {
-    await withEnv({ OPENAI_API_KEY: "  ", NVIDIA_API_KEY: "nvidia-blank-openai" }, async () => {
-      await completeChat(
-        { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
-        "hi",
-      );
-      assert.equal(mock.requests[0]?.headers.authorization, "Bearer nvidia-blank-openai");
-    });
-  } finally {
-    mock.restore();
-  }
+test("openai-compat OpenAI host with only NVIDIA_API_KEY fails before fetch", async () => {
+  await assertFailsBeforeFetch(
+    { NVIDIA_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "https://api.openai.com/v1", requestTimeoutMs: 250 },
+    /OPENAI_API_KEY/,
+  );
 });
 
-test("openai-compat fails closed when no API key is set", async () => {
-  let fetchCalls = 0;
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => {
-    fetchCalls += 1;
-    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
-  };
-  try {
-    await withEnv({ OPENAI_API_KEY: undefined, NVIDIA_API_KEY: undefined }, async () => {
-      await assert.rejects(
-        () =>
-          completeChat(
-            { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
-            "hi",
-          ),
-        (error: unknown) => {
-          assert.ok(error instanceof InjectionSuiteHostFault);
-          assert.match(error.message, /OPENAI_API_KEY/);
-          assert.match(error.message, /NVIDIA_API_KEY/);
-          return true;
-        },
-      );
-      assert.equal(fetchCalls, 0);
-    });
-    await withEnv({ OPENAI_API_KEY: undefined, NVIDIA_API_KEY: undefined }, async () => {
-      await assert.rejects(
-        () =>
-          completeChat(
-            {
-              kind: "openai-compat",
-              baseUrl: "https://integrate.api.nvidia.com/v1",
-              requestTimeoutMs: 250,
-            },
-            "hi",
-          ),
-        (error: unknown) => {
-          assert.ok(error instanceof InjectionSuiteHostFault);
-          assert.match(error.message, /OPENAI_API_KEY/);
-          assert.match(error.message, /NVIDIA_API_KEY/);
-          return true;
-        },
-      );
-      assert.equal(fetchCalls, 0);
-    });
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+test("openai-compat unknown host with OPENAI_API_KEY fails before fetch", async () => {
+  await assertFailsBeforeFetch(
+    { OPENAI_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+    /REMNIC_OPENAI_COMPAT_API_KEY/,
+  );
+});
+
+test("openai-compat NVIDIA lookalike host does not receive OPENAI_API_KEY", async () => {
+  await assertFailsBeforeFetch(
+    { OPENAI_API_KEY: "must-not-be-sent", NVIDIA_API_KEY: "also-must-not-be-sent" },
+    {
+      kind: "openai-compat",
+      baseUrl: "https://integrate.api.nvidia.com.example/v1",
+      requestTimeoutMs: 250,
+    },
+    /REMNIC_OPENAI_COMPAT_API_KEY/,
+  );
+});
+
+test("openai-compat treats a blank NVIDIA_API_KEY as missing on NVIDIA hosts", async () => {
+  await assertFailsBeforeFetch(
+    { NVIDIA_API_KEY: "  ", OPENAI_API_KEY: "must-not-be-sent" },
+    { kind: "openai-compat", baseUrl: "https://integrate.api.nvidia.com/v1", requestTimeoutMs: 250 },
+    /NVIDIA_API_KEY/,
+  );
 });
 
 test("ollama omits Authorization even when OPENAI_API_KEY is set", async () => {

--- a/packages/bench/src/security/injection-suite/injection-suite.test.ts
+++ b/packages/bench/src/security/injection-suite/injection-suite.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { InjectionSuiteClaimLock } from "./claims.js";
 import { generateSuiteVariants } from "./generator.js";
-import { buildRecallPrompt } from "./llm-executor.js";
+import { buildRecallPrompt, completeChat, InjectionSuiteHostFault } from "./llm-executor.js";
 import {
   planInjectionSuiteRows,
   runInjectionSuiteCliCommand,
@@ -283,6 +283,171 @@ test("plan and execute accept variants-per-family above 64", async () => {
   }
 });
 
+
+function withEnv(
+  overlay: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(overlay)) {
+    previous.set(key, process.env[key]);
+    const next = overlay[key];
+    if (next === undefined) delete process.env[key];
+    else process.env[key] = next;
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function mockJsonFetch(responseBody: Record<string, unknown>) {
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; headers: Record<string, string> }> = [];
+  globalThis.fetch = async (url, init) => {
+    const headers = new Headers(init?.headers);
+    requests.push({
+      url: String(url),
+      headers: Object.fromEntries(headers.entries()),
+    });
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return {
+    requests,
+    restore() {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+test("openai-compat sends Authorization from OPENAI_API_KEY", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv({ OPENAI_API_KEY: "test-openai-key", NVIDIA_API_KEY: undefined }, async () => {
+      const text = await completeChat(
+        { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+        "hi",
+      );
+      assert.equal(text, "ok");
+      assert.equal(mock.requests.length, 1);
+      assert.equal(mock.requests[0]?.headers.authorization, "Bearer test-openai-key");
+      assert.match(mock.requests[0]?.url ?? "", /\/chat\/completions$/);
+    });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("openai-compat prefers OPENAI_API_KEY over NVIDIA_API_KEY", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv(
+      { OPENAI_API_KEY: "openai-first", NVIDIA_API_KEY: "nvidia-second" },
+      async () => {
+        await completeChat(
+          { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+          "hi",
+        );
+        assert.equal(mock.requests[0]?.headers.authorization, "Bearer openai-first");
+      },
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test("openai-compat uses NVIDIA_API_KEY when OPENAI_API_KEY is unset", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv({ OPENAI_API_KEY: undefined, NVIDIA_API_KEY: "nvidia-only" }, async () => {
+      await completeChat(
+        { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+        "hi",
+      );
+      assert.equal(mock.requests[0]?.headers.authorization, "Bearer nvidia-only");
+    });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("openai-compat treats a blank OPENAI_API_KEY as missing", async () => {
+  const mock = mockJsonFetch({
+    choices: [{ message: { content: "ok" } }],
+  });
+  try {
+    await withEnv({ OPENAI_API_KEY: "  ", NVIDIA_API_KEY: "nvidia-blank-openai" }, async () => {
+      await completeChat(
+        { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+        "hi",
+      );
+      assert.equal(mock.requests[0]?.headers.authorization, "Bearer nvidia-blank-openai");
+    });
+  } finally {
+    mock.restore();
+  }
+});
+
+test("openai-compat fails closed when no API key is set", async () => {
+  let fetchCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
+  try {
+    await withEnv({ OPENAI_API_KEY: undefined, NVIDIA_API_KEY: undefined }, async () => {
+      await assert.rejects(
+        () =>
+          completeChat(
+            { kind: "openai-compat", baseUrl: "http://127.0.0.1:9/v1", requestTimeoutMs: 250 },
+            "hi",
+          ),
+        (error: unknown) => {
+          assert.ok(error instanceof InjectionSuiteHostFault);
+          assert.match(error.message, /OPENAI_API_KEY/);
+          assert.match(error.message, /NVIDIA_API_KEY/);
+          return true;
+        },
+      );
+      assert.equal(fetchCalls, 0);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ollama omits Authorization even when OPENAI_API_KEY is set", async () => {
+  const mock = mockJsonFetch({
+    message: { content: "ok" },
+  });
+  try {
+    await withEnv({ OPENAI_API_KEY: "must-not-be-sent" }, async () => {
+      const text = await completeChat(
+        { kind: "ollama", baseUrl: "http://127.0.0.1:9", requestTimeoutMs: 250 },
+        "hi",
+      );
+      assert.equal(text, "ok");
+      assert.equal(mock.requests.length, 1);
+      assert.equal(mock.requests[0]?.headers.authorization, undefined);
+    });
+  } finally {
+    mock.restore();
+  }
+});
 
 test("dead ollama endpoint pauses instead of cutting the row", async () => {
   const outputDir = await mkdtemp(path.join(tmpdir(), "h5-dead-"));

--- a/packages/bench/src/security/injection-suite/llm-executor.ts
+++ b/packages/bench/src/security/injection-suite/llm-executor.ts
@@ -3,8 +3,9 @@
  *
  * Talks native Ollama /api/chat by default or an OpenAI-compatible
  * /v1/chat/completions endpoint. openai-compat attaches Authorization
- * only for a host-matched key: NVIDIA hosts use NVIDIA_API_KEY,
- * OpenAI hosts use OPENAI_API_KEY, and every other host requires
+ * only for an exact allowlisted API host: integrate.api.nvidia.com uses
+ * NVIDIA_API_KEY, api.openai.com uses OPENAI_API_KEY, and every other
+ * host (including other *.openai.com / *.nvidia.com subdomains) requires
  * REMNIC_OPENAI_COMPAT_API_KEY. Provider and non-loopback custom hosts
  * require https before a credential is attached. Loopback HTTP
  * (127.0.0.1 / localhost) is the only plaintext exception, for local
@@ -84,8 +85,11 @@ function parseCompatUrl(baseUrl: string): { protocol: string; hostname: string }
   }
 }
 
-function isDnsZoneHost(hostname: string, zone: string): boolean {
-  return hostname === zone || hostname.endsWith(`.${zone}`);
+const OPENAI_API_HOSTS = Object.freeze(["api.openai.com"] as const);
+const NVIDIA_API_HOSTS = Object.freeze(["integrate.api.nvidia.com"] as const);
+
+function isExactAllowlistedHost(hostname: string, allowlist: readonly string[]): boolean {
+  return (allowlist as readonly string[]).includes(hostname);
 }
 
 function isHttps(protocol: string): boolean {
@@ -124,14 +128,14 @@ function resolveOpenAiCompatToken(baseUrl: string): string {
     throw new InjectionSuiteHostFault("openai-compat requires a valid http(s) base URL");
   }
   const { protocol, hostname } = parsed;
-  if (isDnsZoneHost(hostname, "nvidia.com")) {
+  if (isExactAllowlistedHost(hostname, NVIDIA_API_HOSTS)) {
     requireHttps(protocol, "openai-compat NVIDIA host requires https");
     return requireEnvToken(
       "NVIDIA_API_KEY",
       "openai-compat NVIDIA host requires NVIDIA_API_KEY",
     );
   }
-  if (isDnsZoneHost(hostname, "openai.com")) {
+  if (isExactAllowlistedHost(hostname, OPENAI_API_HOSTS)) {
     requireHttps(protocol, "openai-compat OpenAI host requires https");
     return requireEnvToken(
       "OPENAI_API_KEY",
@@ -145,7 +149,7 @@ function resolveOpenAiCompatToken(baseUrl: string): string {
   }
   return requireEnvToken(
     "REMNIC_OPENAI_COMPAT_API_KEY",
-    "openai-compat unknown host requires REMNIC_OPENAI_COMPAT_API_KEY (or a known host: *.openai.com / *.nvidia.com); do not reuse OPENAI_API_KEY or NVIDIA_API_KEY",
+    "openai-compat unknown host requires REMNIC_OPENAI_COMPAT_API_KEY (or a known host: api.openai.com / integrate.api.nvidia.com); do not reuse OPENAI_API_KEY or NVIDIA_API_KEY",
   );
 }
 

--- a/packages/bench/src/security/injection-suite/llm-executor.ts
+++ b/packages/bench/src/security/injection-suite/llm-executor.ts
@@ -5,8 +5,11 @@
  * /v1/chat/completions endpoint. openai-compat attaches Authorization
  * only for a host-matched key: NVIDIA hosts use NVIDIA_API_KEY,
  * OpenAI hosts use OPENAI_API_KEY, and every other host requires
- * REMNIC_OPENAI_COMPAT_API_KEY. Ambient keys are never reused across
- * providers. ollama stays unauthenticated. Network/5xx/timeout become
+ * REMNIC_OPENAI_COMPAT_API_KEY. Provider and non-loopback custom hosts
+ * require https before a credential is attached. Loopback HTTP
+ * (127.0.0.1 / localhost) is the only plaintext exception, for local
+ * openai-compat. Ambient keys are never reused across providers.
+ * ollama stays unauthenticated. Network/5xx/timeout become
  * HOST_API_FAULT so the suite pauses instead of cutting the row.
  */
 
@@ -69,19 +72,35 @@ function trimSlash(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-function hostnameOf(baseUrl: string): string | undefined {
+function parseCompatUrl(baseUrl: string): { protocol: string; hostname: string } | undefined {
   try {
-    let hostname = new URL(baseUrl).hostname.trim().toLowerCase();
+    const parsed = new URL(baseUrl);
+    let hostname = parsed.hostname.trim().toLowerCase();
     while (hostname.endsWith(".")) hostname = hostname.slice(0, -1);
-    return hostname.length > 0 ? hostname : undefined;
+    if (hostname.length === 0) return undefined;
+    return { protocol: parsed.protocol.toLowerCase(), hostname };
   } catch {
     return undefined;
   }
 }
 
-function isDnsZoneHost(hostname: string | undefined, zone: string): boolean {
-  if (hostname === undefined) return false;
+function isDnsZoneHost(hostname: string, zone: string): boolean {
   return hostname === zone || hostname.endsWith(`.${zone}`);
+}
+
+function isHttps(protocol: string): boolean {
+  return protocol === "https:";
+}
+
+/** Narrow local-dev exception: plaintext HTTP only on these hostnames. */
+function isLoopbackHttpHost(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost";
+}
+
+function requireHttps(protocol: string, message: string): void {
+  if (!isHttps(protocol)) {
+    throw new InjectionSuiteHostFault(message);
+  }
 }
 
 function nonEmptyEnv(name: string): string | undefined {
@@ -100,17 +119,28 @@ function requireEnvToken(envName: string, message: string): string {
 }
 
 function resolveOpenAiCompatToken(baseUrl: string): string {
-  const hostname = hostnameOf(baseUrl);
+  const parsed = parseCompatUrl(baseUrl);
+  if (parsed === undefined) {
+    throw new InjectionSuiteHostFault("openai-compat requires a valid http(s) base URL");
+  }
+  const { protocol, hostname } = parsed;
   if (isDnsZoneHost(hostname, "nvidia.com")) {
+    requireHttps(protocol, "openai-compat NVIDIA host requires https");
     return requireEnvToken(
       "NVIDIA_API_KEY",
       "openai-compat NVIDIA host requires NVIDIA_API_KEY",
     );
   }
   if (isDnsZoneHost(hostname, "openai.com")) {
+    requireHttps(protocol, "openai-compat OpenAI host requires https");
     return requireEnvToken(
       "OPENAI_API_KEY",
       "openai-compat OpenAI host requires OPENAI_API_KEY",
+    );
+  }
+  if (!isHttps(protocol) && !isLoopbackHttpHost(hostname)) {
+    throw new InjectionSuiteHostFault(
+      "openai-compat custom host requires https (loopback HTTP is allowed only for 127.0.0.1 or localhost)",
     );
   }
   return requireEnvToken(

--- a/packages/bench/src/security/injection-suite/llm-executor.ts
+++ b/packages/bench/src/security/injection-suite/llm-executor.ts
@@ -3,8 +3,9 @@
  *
  * Talks native Ollama /api/chat by default or an OpenAI-compatible
  * /v1/chat/completions endpoint. openai-compat sends Authorization
- * from OPENAI_API_KEY or NVIDIA_API_KEY and fails closed if neither
- * is set; ollama stays unauthenticated. Network/5xx/timeout become
+ * from OPENAI_API_KEY or NVIDIA_API_KEY, choosing by host (NVIDIA
+ * hosts prefer NVIDIA_API_KEY) and failing closed if neither is set;
+ * ollama stays unauthenticated. Network/5xx/timeout become
  * HOST_API_FAULT so the suite pauses instead of cutting the row.
  */
 
@@ -67,7 +68,31 @@ function trimSlash(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-const OPENAI_COMPAT_TOKEN_ENV = Object.freeze(["OPENAI_API_KEY", "NVIDIA_API_KEY"] as const);
+const GENERIC_OPENAI_COMPAT_TOKEN_ENV = Object.freeze(["OPENAI_API_KEY", "NVIDIA_API_KEY"] as const);
+const NVIDIA_OPENAI_COMPAT_TOKEN_ENV = Object.freeze(["NVIDIA_API_KEY", "OPENAI_API_KEY"] as const);
+
+function hostnameOf(baseUrl: string): string | undefined {
+  try {
+    let hostname = new URL(baseUrl).hostname.trim().toLowerCase();
+    while (hostname.endsWith(".")) hostname = hostname.slice(0, -1);
+    return hostname.length > 0 ? hostname : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isNvidiaCompatHost(hostname: string | undefined): boolean {
+  if (hostname === undefined) return false;
+  return hostname === "nvidia.com" || hostname.endsWith(".nvidia.com");
+}
+
+function tokenEnvOrderForBaseUrl(
+  baseUrl: string,
+): typeof GENERIC_OPENAI_COMPAT_TOKEN_ENV | typeof NVIDIA_OPENAI_COMPAT_TOKEN_ENV {
+  return isNvidiaCompatHost(hostnameOf(baseUrl))
+    ? NVIDIA_OPENAI_COMPAT_TOKEN_ENV
+    : GENERIC_OPENAI_COMPAT_TOKEN_ENV;
+}
 
 function firstNonEmptyEnv(names: readonly string[]): string | undefined {
   for (const name of names) {
@@ -79,8 +104,8 @@ function firstNonEmptyEnv(names: readonly string[]): string | undefined {
   return undefined;
 }
 
-function resolveOpenAiCompatToken(): string {
-  const token = firstNonEmptyEnv(OPENAI_COMPAT_TOKEN_ENV);
+function resolveOpenAiCompatToken(baseUrl: string): string {
+  const token = firstNonEmptyEnv(tokenEnvOrderForBaseUrl(baseUrl));
   if (token === undefined) {
     throw new InjectionSuiteHostFault(
       "openai-compat requires OPENAI_API_KEY or NVIDIA_API_KEY",
@@ -124,8 +149,8 @@ export async function completeChat(
   const timeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const model = options.model ?? DEFAULT_OLLAMA_MODEL;
   if (options.kind === "openai-compat") {
-    const token = resolveOpenAiCompatToken();
     const base = trimSlash(options.baseUrl ?? DEFAULT_OPENAI_COMPAT_BASE_URL);
+    const token = resolveOpenAiCompatToken(base);
     const json = await postJson(
       `${base}/chat/completions`,
       {

--- a/packages/bench/src/security/injection-suite/llm-executor.ts
+++ b/packages/bench/src/security/injection-suite/llm-executor.ts
@@ -2,10 +2,11 @@
  * Live-model executor for one H5 injection-suite row (#1962).
  *
  * Talks native Ollama /api/chat by default or an OpenAI-compatible
- * /v1/chat/completions endpoint. openai-compat sends Authorization
- * from OPENAI_API_KEY or NVIDIA_API_KEY, choosing by host (NVIDIA
- * hosts prefer NVIDIA_API_KEY) and failing closed if neither is set;
- * ollama stays unauthenticated. Network/5xx/timeout become
+ * /v1/chat/completions endpoint. openai-compat attaches Authorization
+ * only for a host-matched key: NVIDIA hosts use NVIDIA_API_KEY,
+ * OpenAI hosts use OPENAI_API_KEY, and every other host requires
+ * REMNIC_OPENAI_COMPAT_API_KEY. Ambient keys are never reused across
+ * providers. ollama stays unauthenticated. Network/5xx/timeout become
  * HOST_API_FAULT so the suite pauses instead of cutting the row.
  */
 
@@ -68,9 +69,6 @@ function trimSlash(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-const GENERIC_OPENAI_COMPAT_TOKEN_ENV = Object.freeze(["OPENAI_API_KEY", "NVIDIA_API_KEY"] as const);
-const NVIDIA_OPENAI_COMPAT_TOKEN_ENV = Object.freeze(["NVIDIA_API_KEY", "OPENAI_API_KEY"] as const);
-
 function hostnameOf(baseUrl: string): string | undefined {
   try {
     let hostname = new URL(baseUrl).hostname.trim().toLowerCase();
@@ -81,37 +79,44 @@ function hostnameOf(baseUrl: string): string | undefined {
   }
 }
 
-function isNvidiaCompatHost(hostname: string | undefined): boolean {
+function isDnsZoneHost(hostname: string | undefined, zone: string): boolean {
   if (hostname === undefined) return false;
-  return hostname === "nvidia.com" || hostname.endsWith(".nvidia.com");
+  return hostname === zone || hostname.endsWith(`.${zone}`);
 }
 
-function tokenEnvOrderForBaseUrl(
-  baseUrl: string,
-): typeof GENERIC_OPENAI_COMPAT_TOKEN_ENV | typeof NVIDIA_OPENAI_COMPAT_TOKEN_ENV {
-  return isNvidiaCompatHost(hostnameOf(baseUrl))
-    ? NVIDIA_OPENAI_COMPAT_TOKEN_ENV
-    : GENERIC_OPENAI_COMPAT_TOKEN_ENV;
+function nonEmptyEnv(name: string): string | undefined {
+  const raw = process.env[name];
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function firstNonEmptyEnv(names: readonly string[]): string | undefined {
-  for (const name of names) {
-    const raw = process.env[name];
-    if (typeof raw !== "string") continue;
-    const trimmed = raw.trim();
-    if (trimmed.length > 0) return trimmed;
+function requireEnvToken(envName: string, message: string): string {
+  const token = nonEmptyEnv(envName);
+  if (token === undefined) {
+    throw new InjectionSuiteHostFault(message);
   }
-  return undefined;
+  return token;
 }
 
 function resolveOpenAiCompatToken(baseUrl: string): string {
-  const token = firstNonEmptyEnv(tokenEnvOrderForBaseUrl(baseUrl));
-  if (token === undefined) {
-    throw new InjectionSuiteHostFault(
-      "openai-compat requires OPENAI_API_KEY or NVIDIA_API_KEY",
+  const hostname = hostnameOf(baseUrl);
+  if (isDnsZoneHost(hostname, "nvidia.com")) {
+    return requireEnvToken(
+      "NVIDIA_API_KEY",
+      "openai-compat NVIDIA host requires NVIDIA_API_KEY",
     );
   }
-  return token;
+  if (isDnsZoneHost(hostname, "openai.com")) {
+    return requireEnvToken(
+      "OPENAI_API_KEY",
+      "openai-compat OpenAI host requires OPENAI_API_KEY",
+    );
+  }
+  return requireEnvToken(
+    "REMNIC_OPENAI_COMPAT_API_KEY",
+    "openai-compat unknown host requires REMNIC_OPENAI_COMPAT_API_KEY (or a known host: *.openai.com / *.nvidia.com); do not reuse OPENAI_API_KEY or NVIDIA_API_KEY",
+  );
 }
 
 async function postJson(

--- a/packages/bench/src/security/injection-suite/llm-executor.ts
+++ b/packages/bench/src/security/injection-suite/llm-executor.ts
@@ -2,7 +2,9 @@
  * Live-model executor for one H5 injection-suite row (#1962).
  *
  * Talks native Ollama /api/chat by default or an OpenAI-compatible
- * /v1/chat/completions endpoint. Network/5xx/timeout become
+ * /v1/chat/completions endpoint. openai-compat sends Authorization
+ * from OPENAI_API_KEY or NVIDIA_API_KEY and fails closed if neither
+ * is set; ollama stays unauthenticated. Network/5xx/timeout become
  * HOST_API_FAULT so the suite pauses instead of cutting the row.
  */
 
@@ -65,13 +67,40 @@ function trimSlash(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-async function postJson(url: string, body: unknown, timeoutMs: number): Promise<unknown> {
+const OPENAI_COMPAT_TOKEN_ENV = Object.freeze(["OPENAI_API_KEY", "NVIDIA_API_KEY"] as const);
+
+function firstNonEmptyEnv(names: readonly string[]): string | undefined {
+  for (const name of names) {
+    const raw = process.env[name];
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return undefined;
+}
+
+function resolveOpenAiCompatToken(): string {
+  const token = firstNonEmptyEnv(OPENAI_COMPAT_TOKEN_ENV);
+  if (token === undefined) {
+    throw new InjectionSuiteHostFault(
+      "openai-compat requires OPENAI_API_KEY or NVIDIA_API_KEY",
+    );
+  }
+  return token;
+}
+
+async function postJson(
+  url: string,
+  body: unknown,
+  timeoutMs: number,
+  extraHeaders?: Record<string, string>,
+): Promise<unknown> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetch(url, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...extraHeaders },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
@@ -95,12 +124,18 @@ export async function completeChat(
   const timeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const model = options.model ?? DEFAULT_OLLAMA_MODEL;
   if (options.kind === "openai-compat") {
+    const token = resolveOpenAiCompatToken();
     const base = trimSlash(options.baseUrl ?? DEFAULT_OPENAI_COMPAT_BASE_URL);
-    const json = await postJson(`${base}/chat/completions`, {
-      model,
-      messages: [{ role: "user", content: prompt }],
-      temperature: 0,
-    }, timeoutMs) as { choices?: Array<{ message?: { content?: string } }> };
+    const json = await postJson(
+      `${base}/chat/completions`,
+      {
+        model,
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0,
+      },
+      timeoutMs,
+      { Authorization: `Bearer ${token}` },
+    ) as { choices?: Array<{ message?: { content?: string } }> };
     const text = json.choices?.[0]?.message?.content;
     if (typeof text !== "string") throw new InjectionSuiteHostFault("openai-compat response missing content");
     return text;

--- a/packages/remnic-cli/src/bench-security-commands.test.ts
+++ b/packages/remnic-cli/src/bench-security-commands.test.ts
@@ -55,7 +55,7 @@ test("unknown security subcommand is rejected", () => {
   assert.throws(() => parseBenchSecurityArgs(["nope"]), /unknown bench security subcommand/);
 });
 
-test("openai-compat help names OPENAI_API_KEY and NVIDIA_API_KEY", () => {
-  assert.match(BENCH_SECURITY_USAGE, /OPENAI_API_KEY/);
-  assert.match(BENCH_SECURITY_USAGE, /NVIDIA_API_KEY/);
+test("openai-compat help names host-based OPENAI_API_KEY and NVIDIA_API_KEY order", () => {
+  assert.match(BENCH_SECURITY_USAGE, /NVIDIA \*\.nvidia\.com hosts prefer NVIDIA_API_KEY/);
+  assert.match(BENCH_SECURITY_USAGE, /OPENAI_API_KEY then NVIDIA_API_KEY/);
 });

--- a/packages/remnic-cli/src/bench-security-commands.test.ts
+++ b/packages/remnic-cli/src/bench-security-commands.test.ts
@@ -56,7 +56,7 @@ test("unknown security subcommand is rejected", () => {
 });
 
 test("openai-compat help names host-isolated credential env vars", () => {
-  assert.match(BENCH_SECURITY_USAGE, /NVIDIA\/OpenAI hosts require https/);
+  assert.match(BENCH_SECURITY_USAGE, /api\.openai\.com \/ integrate\.api\.nvidia\.com require/);
   assert.match(BENCH_SECURITY_USAGE, /REMNIC_OPENAI_COMPAT_API_KEY/);
   assert.match(BENCH_SECURITY_USAGE, /loopback HTTP on 127\.0\.0\.1 or localhost/);
 });

--- a/packages/remnic-cli/src/bench-security-commands.test.ts
+++ b/packages/remnic-cli/src/bench-security-commands.test.ts
@@ -56,7 +56,7 @@ test("unknown security subcommand is rejected", () => {
 });
 
 test("openai-compat help names host-isolated credential env vars", () => {
-  assert.match(BENCH_SECURITY_USAGE, /NVIDIA hosts use NVIDIA_API_KEY/);
-  assert.match(BENCH_SECURITY_USAGE, /OpenAI hosts use\s+OPENAI_API_KEY/);
+  assert.match(BENCH_SECURITY_USAGE, /NVIDIA\/OpenAI hosts require https/);
   assert.match(BENCH_SECURITY_USAGE, /REMNIC_OPENAI_COMPAT_API_KEY/);
+  assert.match(BENCH_SECURITY_USAGE, /loopback HTTP on 127\.0\.0\.1 or localhost/);
 });

--- a/packages/remnic-cli/src/bench-security-commands.test.ts
+++ b/packages/remnic-cli/src/bench-security-commands.test.ts
@@ -55,7 +55,8 @@ test("unknown security subcommand is rejected", () => {
   assert.throws(() => parseBenchSecurityArgs(["nope"]), /unknown bench security subcommand/);
 });
 
-test("openai-compat help names host-based OPENAI_API_KEY and NVIDIA_API_KEY order", () => {
-  assert.match(BENCH_SECURITY_USAGE, /NVIDIA \*\.nvidia\.com hosts prefer NVIDIA_API_KEY/);
-  assert.match(BENCH_SECURITY_USAGE, /OPENAI_API_KEY then NVIDIA_API_KEY/);
+test("openai-compat help names host-isolated credential env vars", () => {
+  assert.match(BENCH_SECURITY_USAGE, /NVIDIA hosts use NVIDIA_API_KEY/);
+  assert.match(BENCH_SECURITY_USAGE, /OpenAI hosts use\s+OPENAI_API_KEY/);
+  assert.match(BENCH_SECURITY_USAGE, /REMNIC_OPENAI_COMPAT_API_KEY/);
 });

--- a/packages/remnic-cli/src/bench-security-commands.test.ts
+++ b/packages/remnic-cli/src/bench-security-commands.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
-import { parseBenchSecurityArgs } from "./bench-security-commands.js";
+import { BENCH_SECURITY_USAGE, parseBenchSecurityArgs } from "./bench-security-commands.js";
 import { resolveHomeDir } from "./path-utils.js";
 
 test("injection-suite parser requires --seeds and defaults outside the checkout", () => {
@@ -53,4 +53,9 @@ test("unknown executor is rejected", () => {
 
 test("unknown security subcommand is rejected", () => {
   assert.throws(() => parseBenchSecurityArgs(["nope"]), /unknown bench security subcommand/);
+});
+
+test("openai-compat help names OPENAI_API_KEY and NVIDIA_API_KEY", () => {
+  assert.match(BENCH_SECURITY_USAGE, /OPENAI_API_KEY/);
+  assert.match(BENCH_SECURITY_USAGE, /NVIDIA_API_KEY/);
 });

--- a/packages/remnic-cli/src/bench-security-commands.ts
+++ b/packages/remnic-cli/src/bench-security-commands.ts
@@ -30,7 +30,8 @@ Options:
                             local = deterministic screen/fence (default)
                             ollama = native /api/chat
                             openai-compat = /v1/chat/completions
-                            (Authorization from OPENAI_API_KEY or NVIDIA_API_KEY)
+                            (NVIDIA *.nvidia.com hosts prefer NVIDIA_API_KEY;
+                            otherwise OPENAI_API_KEY then NVIDIA_API_KEY)
   --base-url URL            Endpoint (default: http://127.0.0.1:11434)
   --model NAME              Model id (default: qwen3.8-27b-64k:latest)
   --request-timeout-ms N    Per-call timeout (default: 300000)

--- a/packages/remnic-cli/src/bench-security-commands.ts
+++ b/packages/remnic-cli/src/bench-security-commands.ts
@@ -30,8 +30,9 @@ Options:
                             local = deterministic screen/fence (default)
                             ollama = native /api/chat
                             openai-compat = /v1/chat/completions
-                            (NVIDIA hosts use NVIDIA_API_KEY; OpenAI hosts use
-                            OPENAI_API_KEY; other hosts require REMNIC_OPENAI_COMPAT_API_KEY)
+                            (NVIDIA/OpenAI hosts require https + provider key;
+                            other hosts require REMNIC_OPENAI_COMPAT_API_KEY and https,
+                            except loopback HTTP on 127.0.0.1 or localhost)
   --base-url URL            Endpoint (default: http://127.0.0.1:11434)
   --model NAME              Model id (default: qwen3.8-27b-64k:latest)
   --request-timeout-ms N    Per-call timeout (default: 300000)

--- a/packages/remnic-cli/src/bench-security-commands.ts
+++ b/packages/remnic-cli/src/bench-security-commands.ts
@@ -30,8 +30,8 @@ Options:
                             local = deterministic screen/fence (default)
                             ollama = native /api/chat
                             openai-compat = /v1/chat/completions
-                            (NVIDIA *.nvidia.com hosts prefer NVIDIA_API_KEY;
-                            otherwise OPENAI_API_KEY then NVIDIA_API_KEY)
+                            (NVIDIA hosts use NVIDIA_API_KEY; OpenAI hosts use
+                            OPENAI_API_KEY; other hosts require REMNIC_OPENAI_COMPAT_API_KEY)
   --base-url URL            Endpoint (default: http://127.0.0.1:11434)
   --model NAME              Model id (default: qwen3.8-27b-64k:latest)
   --request-timeout-ms N    Per-call timeout (default: 300000)

--- a/packages/remnic-cli/src/bench-security-commands.ts
+++ b/packages/remnic-cli/src/bench-security-commands.ts
@@ -30,9 +30,10 @@ Options:
                             local = deterministic screen/fence (default)
                             ollama = native /api/chat
                             openai-compat = /v1/chat/completions
-                            (NVIDIA/OpenAI hosts require https + provider key;
-                            other hosts require REMNIC_OPENAI_COMPAT_API_KEY and https,
-                            except loopback HTTP on 127.0.0.1 or localhost)
+                            (api.openai.com / integrate.api.nvidia.com require
+                            https + provider key; other hosts require
+                            REMNIC_OPENAI_COMPAT_API_KEY and https, except
+                            loopback HTTP on 127.0.0.1 or localhost)
   --base-url URL            Endpoint (default: http://127.0.0.1:11434)
   --model NAME              Model id (default: qwen3.8-27b-64k:latest)
   --request-timeout-ms N    Per-call timeout (default: 300000)

--- a/packages/remnic-cli/src/bench-security-commands.ts
+++ b/packages/remnic-cli/src/bench-security-commands.ts
@@ -30,6 +30,7 @@ Options:
                             local = deterministic screen/fence (default)
                             ollama = native /api/chat
                             openai-compat = /v1/chat/completions
+                            (Authorization from OPENAI_API_KEY or NVIDIA_API_KEY)
   --base-url URL            Endpoint (default: http://127.0.0.1:11434)
   --model NAME              Model id (default: qwen3.8-27b-64k:latest)
   --request-timeout-ms N    Per-call timeout (default: 300000)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The H5 injection-suite `openai-compat` executor posted to `/v1/chat/completions` with only `content-type`. NVIDIA Build and most OpenAI-compatible hosts require a Bearer token, so live H5 calls fail unauthenticated.

This change is limited to executor auth:

1. `openai-compat` attaches `Authorization: Bearer <token>` only for an **exact allowlisted API host**.
2. Credential isolation:
   - `integrate.api.nvidia.com` uses `NVIDIA_API_KEY` only. Missing/blank fails closed — no `OPENAI_API_KEY` fallback.
   - `api.openai.com` uses `OPENAI_API_KEY` only.
   - Every other host — including other `*.openai.com` / `*.nvidia.com` subdomains — requires the explicit `REMNIC_OPENAI_COMPAT_API_KEY`. Ambient `OPENAI_API_KEY` / `NVIDIA_API_KEY` are never sent there.
3. HTTPS is required before a credential is attached:
   - The allowlisted NVIDIA/OpenAI API hosts reject `http://` even when the matching key is set.
   - Custom hosts require `https` unless the hostname is loopback (`127.0.0.1` or `localhost`).
4. Missing the host-matched key or using plaintext on a non-loopback host throws `InjectionSuiteHostFault` before `fetch`.
5. The `ollama` path is unchanged (no Bearer).
6. CLI help documents the exact API hosts and the HTTPS / loopback exception.

Related to #1962 (COS-164 / COS-174). Does **not** start the live H5 factorial and does not change fencing/quarantine logic.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [x] `npm run test:file -- packages/bench/src/security/injection-suite/injection-suite.test.ts packages/remnic-cli/src/bench-security-commands.test.ts` — 32/32 pass
- [x] `https://something.openai.com/...` and `https://evil.nvidia.com/...` with only the ambient cloud key fail before fetch
- [x] HTTP `api.openai.com` and HTTP `integrate.api.nvidia.com` fail before fetch with the matching cloud key set; custom non-loopback HTTP fails; loopback HTTP with `REMNIC_OPENAI_COMPAT_API_KEY` still works
- [x] `npm run check:pre-push` — pass
- [ ] For retrieval/planner/cache/config changes: N/A
- [ ] For high-risk memory/retrieval paths: N/A
- [x] `npm run review:cursor` skipped (`agent`/`cursor-agent` not installed; non-strict)

## Changelog

- [x] Added/updated `CHANGELOG.md` under `## [Unreleased]`

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered (`ollama` / `local` unchanged; custom openai-compat `--base-url` now requires `REMNIC_OPENAI_COMPAT_API_KEY` and `https` except loopback HTTP)
- [x] Invalid user input rejected, not silently defaulted (mismatched key, unrelated provider subdomain, or plaintext provider URL fails closed)
- Remaining template items are N/A for this executor-header change.

## Notes for reviewers

- Ambient cloud keys attach only on exact hosts: `api.openai.com` and `integrate.api.nvidia.com` (no DNS-zone suffix match).
- Loopback HTTP exception is `127.0.0.1` and `localhost` only.
- Tests mock `fetch` and isolate env so a live key in CI cannot leak into assertions.
- Out of scope: live factorial, fencing/quarantine, NVIDIA-specific default URLs.

## PR workflow

- [x] PR scope is narrow
- [x] Synced with latest `main` before requesting AI review
- [x] Batched review fixes by subsystem instead of micro-pushing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea3f6023-11e9-46e5-991c-69338cdb043c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea3f6023-11e9-46e5-991c-69338cdb043c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI-compatible endpoints now use host-specific credentials: `NVIDIA_API_KEY` for NVIDIA hosts, `OPENAI_API_KEY` for OpenAI hosts, and `REMNIC_OPENAI_COMPAT_API_KEY` for other hosts.
  * Credentials are no longer reused across hosts, and requests fail safely when the required key is missing or blank.
  * Authorization headers are applied correctly, while Ollama requests remain unauthenticated.

* **Documentation**
  * CLI help and the changelog now describe host-specific credential selection and authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->