### PR TITLE
fix(core): repair main regressions from #2969 and #2980 test seams

### DIFF
--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -2770,6 +2770,11 @@ test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV
   const orchestrator = Object.create(Orchestrator.prototype) as any;
   let updateArg: string[] | undefined;
   const abortController = new AbortController();
+  // #2980 fences startup work by lifecycle epoch: deferredInitialize() now
+  // begins an epoch that resets the gate fields the selfDeps seam fail-fasts
+  // on (PR #1801 set-trap contract). Prototype fakes must declare them.
+  orchestrator.deferredInitAbort = null;
+  orchestrator.deferredSyncSucceeded = false;
   const memoryDir = path.join(os.tmpdir(), "remnic-startup-maintenance-nhzev");
   const dynamicNamespace = "project-origin-dynamic";
   const dynamicStorageDir = path.join(
@@ -2838,6 +2843,8 @@ test("deferredInitialize startup sync falls back to configured set on catalog re
   const orchestrator = Object.create(Orchestrator.prototype) as any;
   let updateArg: string[] | undefined;
   const abortController = new AbortController();
+  orchestrator.deferredInitAbort = null;
+  orchestrator.deferredSyncSucceeded = false;
 
   orchestrator.config = {
     namespacesEnabled: true,

--- a/tests/fallback-llm-parse.test.ts
+++ b/tests/fallback-llm-parse.test.ts
@@ -6,28 +6,49 @@ import { FallbackLlmClient } from "../src/fallback-llm.ts";
 test("FallbackLlmClient.parseWithSchema extracts the correct JSON when multiple JSON blocks exist", async () => {
   const Schema = z.object({ ok: z.literal(true) });
 
-  const client = new FallbackLlmClient({} as any);
-
-  // Stub: simulate an LLM response that includes an example JSON block and then the real answer.
-  (client as any).chatCompletion = async () => ({
-    content:
-      "Here is an example:\n" +
-      "```json\n" +
-      "{ \"ok\": false }\n" +
-      "```\n\n" +
-      "And here is the real answer:\n" +
-      "{ \"ok\": true }",
-    modelUsed: "stub/model",
+  // Configure a real provider and stub the transport (same seam as
+  // fallback-llm-parse-failure.test.ts): since #2969 parseWithSchema routes
+  // through the private completeChat() for typed failure outcomes, so an
+  // instance-level chatCompletion override no longer intercepts it.
+  const client = new FallbackLlmClient({
+    agents: { defaults: { model: { primary: "openai/test-model" } } },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "key",
+          models: [],
+        },
+      },
+    },
   });
+  const content =
+    "Here is an example:\n" +
+    "```json\n" +
+    '{ "ok": false }\n' +
+    "```\n\n" +
+    "And here is the real answer:\n" +
+    '{ "ok": true }';
 
-  const out = await client.parseWithSchema(
-    [
-      { role: "system", content: "Return JSON." },
-      { role: "user", content: "Do the thing." },
-    ],
-    { parse: (d: unknown) => Schema.parse(d) },
-  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({ choices: [{ message: { content } }] }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )) as typeof fetch;
 
-  assert.deepEqual(out, { ok: true });
+  try {
+    const out = await client.parseWithSchema(
+      [
+        { role: "system", content: "Return JSON." },
+        { role: "user", content: "Do the thing." },
+      ],
+      { parse: (d: unknown) => Schema.parse(d) },
+    );
+
+    assert.deepEqual(out, { ok: true });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
-


### PR DESCRIPTION
## Main-regression repair — unblocks the open PR queue

Two regressions merged into main tonight fail on every open PR merge commit. This repairs both so the remaining queue can merge.

### 1. `tests/fallback-llm-parse.test.ts` — 0 pass / 1 fail on main

**Cause:** #2969 routes `parseWithSchema` through the new private `completeChat()` so structured parse returns typed failure outcomes (#2968). The test stubbed an instance-level `chatCompletion` override, which that routing bypasses; with an empty config the chain resolves zero models and parse returns `null`.

**Product behavior is intact.** Verified by driving the real transport with the exact multi-block content from the test: `parseWithSchema` returns `{"ok":true}` — the schema-valid block wins over the fenced example. Only the stub seam moved, and that move is the intended contract: the typed-outcome discriminant cannot survive the null-collapsing public `chatCompletion`, and #2969's own suite (`fallback-llm-parse-failure.test.ts`) pins the fetch-stub seam. So this adjusts the test, explicitly: it now configures a test provider and stubs `globalThis.fetch`, same as the sibling suite. Assertion unchanged.

### 2. `orchestrator-flush.test.ts` NHZEV — 2 failures on main (verified 0 pass / 2 fail before, 2/2 after)

**Cause:** #2980 fences startup work by lifecycle epoch; `deferredInitialize()` now begins an epoch that resets `deferredInitAbort` and `deferredSyncSucceeded` through the `selfDeps` seam. The seam's set trap fail-fasts on writes to undeclared properties **by design** (PR #1801), and the NHZEV fakes (`Object.create(Orchestrator.prototype)`) never ran the constructor, so the first write throws `'set' on proxy: trap returned falsish for property 'deferredInitAbort'`. Pre-#2980 these fakes already violated the same contract — the `deferredSyncSucceeded` write was swallowed by the sync try/catch and the in-stub abort masked it.

**Product behavior is intact and the new behavior is the intended contract:** #2980's own 1,539-line suite drives real `Orchestrator` instances, and no production path writes undeclared fields. Test fix only: seed the two gate fields on each fake. The union-of-cataloged-namespaces and catalog-failure-fallback assertions pass unchanged.

### Verification

- `node scripts/test-file.mjs tests/fallback-llm-parse.test.ts` — 1/1 pass (was 0/1 on main)
- `node scripts/test-file.mjs packages/remnic-core/src/orchestrator-flush.test.ts` — 55/55 pass (NHZEV was 0/2 on main)
- `node scripts/test-file.mjs packages/remnic-core/src/fallback-llm.test.ts` — 36/36 pass
- `node scripts/test-file.mjs packages/remnic-core/src/fallback-llm-parse-failure.test.ts packages/remnic-core/src/orchestrator-init.test.ts` — 21/21 pass (regression-source suites, no collateral)
- `node scripts/check-ratchets.mjs` — OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated startup synchronization tests to reflect the current initialization lifecycle.
  * Improved fallback parsing coverage by testing through the configured provider and simulated network response.
  * Ensured network stubs are reliably restored after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->