### PR TITLE
feat(recall): surface injected-memory degradation on composition, x-ray, and audit (layer 2)

### DIFF
--- a/.changeset/2972-composition-surface.md
+++ b/.changeset/2972-composition-surface.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Surface injected-memory degradation on the recall composition path, x-ray snapshot, and audit entry. Healthy recalls stay marker-free. Part of #2972.

--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -83,7 +83,20 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     query: T_STRING,
     namespace: T_STRING,
     context: T_STRING,
-    contextComposition: objectSchema({ context: T_STRING, footer: T_STRING }),
+    contextComposition: objectSchema({
+      context: T_STRING,
+      footer: T_STRING,
+      degradation: objectSchema({
+        state: T_STRING,
+        reason: T_STRING,
+        detail: T_STRING,
+        budget: objectSchema({
+          contextBudget: T_NUMBER,
+          fullChars: T_NUMBER,
+          deliveredChars: T_NUMBER,
+        }),
+      }),
+    }),
     count: T_NUMBER,
     memoryIds: T_ARRAY,
     results: T_ARRAY,

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -276,6 +276,9 @@ export async function assembleRecallResponse(
         plannerMode: snapshot?.plannerMode ?? mode,
         requestedMode: mode,
         fallbackUsed: snapshot?.fallbackUsed ?? false,
+        ...(effectiveComposition.degradation
+          ? { degradation: effectiveComposition.degradation }
+          : {}),
       };
       const auditResult = await deps.auditAdapter.record(
         resolvedAgentId || "__anonymous__",

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -469,6 +469,7 @@ export {
 export type { ResolveSecretRefFn } from "./resolve-auth-token.js";
 export type { SecretRef, AgentAccessAuthToken } from "./types.js";
 export * from "./recall-context-composition.js";
+export * from "./recall-composition-decision.js";
 // Recall X-ray CLI helpers (issue #570).  Exported so the standalone
 // `@remnic/cli` binary can wire the `remnic xray` command without
 // reimporting core-internal modules by relative path (CLAUDE.md rule 26).

--- a/packages/remnic-core/src/orchestration/recall-entry.ts
+++ b/packages/remnic-core/src/orchestration/recall-entry.ts
@@ -22,7 +22,12 @@ import type { RecallResultFormatter } from "./recall-result-formatter.js";
 import type { IdentityInjectionMode, PluginConfig, QmdSearchResult } from "../types.js";
 import { stateViewPacketActive } from "../recall-state-view-anchors.js";
 import { resultStateViewKey, stateViewPacketKeys } from "../recall-state-view.js";
- import { applyRecallStateViews } from "../recall-state-view-wire.js";
+import { applyRecallStateViews } from "../recall-state-view-wire.js";
+import { composeRecallContext } from "../recall-context-composition.js";
+import {
+  notifyContextComposition,
+  recallFailureComposition,
+} from "../recall-composition-decision.js";
 
 export interface RecallEntryDeps {
   appendRecallSection(
@@ -197,7 +202,12 @@ export class RecallEntryCoordinator {
       // endTrace() is safe here: if no trace is active (disabled or already
       // closed by recallInternal's try/finally), it returns null immediately.
       this.deps.profiler.endTrace();
-      return ""; // Return empty context on timeout/error
+      const missing = recallFailureComposition(err);
+      if (!missing) return "";
+      notifyContextComposition(options.onContextComposition, missing, (observerErr) => {
+        log.warn("recall: context composition observer failed open", observerErr);
+      });
+      return composeRecallContext(missing);
     } finally {
       options.abortSignal?.removeEventListener("abort", onAbort);
     }

--- a/packages/remnic-core/src/orchestration/recall-entry.ts
+++ b/packages/remnic-core/src/orchestration/recall-entry.ts
@@ -202,7 +202,11 @@ export class RecallEntryCoordinator {
       // endTrace() is safe here: if no trace is active (disabled or already
       // closed by recallInternal's try/finally), it returns null immediately.
       this.deps.profiler.endTrace();
-      const missing = recallFailureComposition(err);
+      // Caller-cancelled recalls stay quiet: the failure was the caller's
+      // abort, not a recall degradation (issue #2972 contract).
+      const missing = options.abortSignal?.aborted
+        ? null
+        : recallFailureComposition(err);
       if (!missing) return "";
       notifyContextComposition(options.onContextComposition, missing, (observerErr) => {
         log.warn("recall: context composition observer failed open", observerErr);

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -45,9 +45,14 @@ import { buildQmdRecallCacheKey, getCachedQmdRecall, setCachedQmdRecall } from "
 import { MEMORY_ID_PATTERN } from "../recall-handles.js";
 import { shouldRecordRecallAuthorityHistory } from "../recall-navigation-config.js";
 import {
-  boundRecallContextComposition, composeRecallContext, contextBudgetForFooter,
+  contextBudgetForFooter,
   formatCuriosityFooter, renderAuthorityBoundContent, selectCuriosityQuestion,
 } from "../recall-context-composition.js";
+import {
+  compactRecallContextFromBuckets,
+  decideRecallContextComposition,
+  notifyContextComposition,
+} from "../recall-composition-decision.js";
 import {
   createBoundedCoreSectionRunner,
   createRecallSectionMetricRecorder,
@@ -4951,23 +4956,16 @@ export class RecallInternalCoordinator {
       recalledMemoryNamespaces,
     );
     const recalledContext = assembledRecall.sections.join("\n\n---\n\n");
-    const composition = boundRecallContextComposition({
-      context: recalledContext, footer: curiosityFooter, maxChars: recallBudgetChars,
-    });
-    const context = composeRecallContext(composition);
-    try {
-      const observerResult = options.onContextComposition?.(composition);
-      if (observerResult && typeof observerResult.then === "function") {
-        void Promise.resolve(observerResult).catch((err) => log.warn(
-          "recall: context composition observer rejected", err,
-        ));
-      }
-    } catch (err) {
+    const { composition, context, truncated: compositionTruncated } =
+      decideRecallContextComposition({
+        context: recalledContext,
+        compactContext: compactRecallContextFromBuckets(sectionBuckets),
+        footer: curiosityFooter,
+        maxChars: recallBudgetChars,
+      });
+    notifyContextComposition(options.onContextComposition, composition, (err) => {
       log.warn("recall: context composition observer failed open", err);
-    }
-    const compositionTruncated = context.length < composeRecallContext({
-      context: recalledContext, footer: curiosityFooter,
-    }).length;
+    });
     const includedSections = [...assembledRecall.includedIds];
     const omittedSections = [...assembledRecall.omittedIds];
     if (composition.footer && !includedSections.includes("questions")) includedSections.push("questions");
@@ -5202,6 +5200,9 @@ export class RecallInternalCoordinator {
             chars: this.deps.getRecallBudgetChars(options.budgetCharsOverride),
             used: context.length,
           },
+          ...(composition.degradation
+            ? { degradation: composition.degradation }
+            : {}),
           sessionKey,
           namespace: selfNamespace,
           traceId,

--- a/packages/remnic-core/src/recall-audit.test.ts
+++ b/packages/remnic-core/src/recall-audit.test.ts
@@ -49,3 +49,37 @@ test("pruneRecallAuditEntries removes day directories older than retention", asy
   assert.equal((await stat(keepDir)).isDirectory(), true);
   await assert.rejects(stat(deleteDir));
 });
+
+test("#2972 audit entry persists degradation when present and omits it otherwise", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-recall-audit-deg-"));
+  const healthy = {
+    ts: "2026-04-12T14:30:12.445Z",
+    sessionKey: "agent/main:session/healthy",
+    agentId: "main",
+    trigger: "access-surface",
+    queryText: "How did the CI outage resolve?",
+    candidateMemoryIds: ["mem_1"],
+    summary: "CI recovered.",
+    injectedChars: 12,
+    toggleState: "enabled" as const,
+  };
+  const degraded = {
+    ...healthy,
+    sessionKey: "agent/main:session/degraded",
+    degradation: {
+      state: "degraded" as const,
+      reason: "budget-compacted" as const,
+      budget: { contextBudget: 80, fullChars: 200, deliveredChars: 80 },
+    },
+  };
+
+  await appendRecallAuditEntry(root, healthy);
+  await appendRecallAuditEntry(root, degraded);
+
+  const healthyPath = buildRecallAuditPath(root, healthy.ts, healthy.sessionKey);
+  const degradedPath = buildRecallAuditPath(root, degraded.ts, degraded.sessionKey);
+  assert.deepEqual(JSON.parse((await readFile(healthyPath, "utf8")).trim()), healthy);
+  assert.equal("degradation" in JSON.parse((await readFile(healthyPath, "utf8")).trim()), false);
+  assert.deepEqual(JSON.parse((await readFile(degradedPath, "utf8")).trim()), degraded);
+});
+

--- a/packages/remnic-core/src/recall-audit.ts
+++ b/packages/remnic-core/src/recall-audit.ts
@@ -2,6 +2,8 @@ import type { Dirent } from "node:fs";
 import { appendFile, mkdir, readdir, rm } from "node:fs/promises";
 import path from "node:path";
 
+import type { RecallContextDegradation } from "./recall-context-composition.js";
+
 export interface RecallAuditEntry {
   ts: string;
   sessionKey: string;
@@ -16,6 +18,8 @@ export interface RecallAuditEntry {
   plannerMode?: string;
   requestedMode?: string;
   fallbackUsed?: boolean;
+  /** Injected-context degradation (#2972). Absent on a healthy recall. */
+  degradation?: RecallContextDegradation;
 }
 
 function formatIsoDate(ts: string): string {

--- a/packages/remnic-core/src/recall-composition-decision.test.ts
+++ b/packages/remnic-core/src/recall-composition-decision.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { abortError } from "./abort-error.js";
+import {
+  compactRecallContextFromBuckets,
+  decideRecallContextComposition,
+  notifyContextComposition,
+  recallFailureComposition,
+} from "./recall-composition-decision.js";
+
+test("#2972 healthy recall composition carries no degradation marker", () => {
+  const { composition, truncated } = decideRecallContextComposition({
+    context: "A remembered deployment decision.",
+    maxChars: 512,
+  });
+
+  assert.equal("degradation" in composition, false);
+  assert.equal(truncated, false);
+  assert.ok(!JSON.stringify(composition).includes("degradation"));
+});
+
+test("#2972 empty recall stays marker-free", () => {
+  const { composition, context } = decideRecallContextComposition({
+    context: "",
+    maxChars: 512,
+  });
+
+  assert.equal(context, "");
+  assert.equal("degradation" in composition, false);
+});
+
+test("#2972 compact form from section buckets is preferred over clipping", () => {
+  const longOne = "full-form entry one with a long body ".repeat(6).trim();
+  const longTwo = "full-form entry two with a long body ".repeat(6).trim();
+  const buckets = new Map<string, Array<string | { content: string }>>([
+    [
+      "memories",
+      [
+        "## Relevant Memories",
+        { content: `[1] notes/one.md (score: 0.900)\n${longOne}` },
+        { content: `[2] notes/two.md (score: 0.800)\n${longTwo}` },
+      ],
+    ],
+  ]);
+  const compactContext = compactRecallContextFromBuckets(buckets);
+  assert.equal(
+    compactContext,
+    "## Relevant Memories\n[1] notes/one.md (score: 0.900)\n[2] notes/two.md (score: 0.800)",
+  );
+
+  const fullContext = `[1] notes/one.md (score: 0.900)\n${longOne}\n\n[2] notes/two.md (score: 0.800)\n${longTwo}`;
+  assert.ok(fullContext.length > compactContext.length);
+  assert.ok(compactContext.length <= 90);
+
+  const { composition, truncated } = decideRecallContextComposition({
+    context: fullContext,
+    compactContext,
+    maxChars: 90,
+  });
+
+  assert.equal(composition.context, compactContext);
+  assert.equal(composition.degradation?.state, "degraded");
+  assert.equal(composition.degradation?.reason, "budget-compacted");
+  assert.equal(truncated, true);
+});
+
+test("#2972 whitespace-only context stays marker-free", () => {
+  const { composition, context, truncated } = decideRecallContextComposition({
+    context: "   ",
+    maxChars: 512,
+  });
+
+  assert.equal(context, "");
+  assert.equal("degradation" in composition, false);
+  assert.equal(truncated, false);
+});
+
+test("#2972 recall failure composition is missing, abort stays silent", () => {
+  const timeout = recallFailureComposition(new Error("recall timeout"));
+  assert.equal(timeout?.degradation?.state, "missing");
+  assert.equal(timeout?.degradation?.reason, "backend-unavailable");
+  assert.equal(timeout?.degradation?.detail, "timeout");
+  assert.match(timeout?.context ?? "", /memory context unavailable/i);
+
+  const failed = recallFailureComposition(new Error("qmd exploded"));
+  assert.equal(failed?.degradation?.detail, "recall_failed");
+
+  assert.equal(recallFailureComposition(abortError("recall aborted")), null);
+});
+
+test("#2972 composition observer is fail-open", async () => {
+  const seen: unknown[] = [];
+  notifyContextComposition(
+    (composition) => {
+      seen.push(composition.context);
+    },
+    { context: "ok" },
+    () => {
+      throw new Error("onError must not run on success");
+    },
+  );
+  assert.deepEqual(seen, ["ok"]);
+
+  const errors: unknown[] = [];
+  notifyContextComposition(
+    () => {
+      throw new Error("observer boom");
+    },
+    { context: "ok" },
+    (err) => {
+      errors.push(err);
+    },
+  );
+  assert.equal(errors.length, 1);
+
+  await new Promise<void>((resolve, reject) => {
+    notifyContextComposition(
+      async () => {
+        throw new Error("async boom");
+      },
+      { context: "ok" },
+      (err) => {
+        try {
+          assert.equal((err as Error).message, "async boom");
+          resolve();
+        } catch (caught) {
+          reject(caught);
+        }
+      },
+    );
+  });
+});
+

--- a/packages/remnic-core/src/recall-composition-decision.ts
+++ b/packages/remnic-core/src/recall-composition-decision.ts
@@ -1,0 +1,113 @@
+/**
+ * Recall composition decision (#2972 layer 2).
+ *
+ * Extracted from recall-internal so that file stays under its ratchet
+ * ceiling. Classifies injected memory context as complete / degraded /
+ * missing, builds the compact (first-line) form from section buckets,
+ * and turns outer-recall failures into the missing-note instead of "".
+ */
+
+import { isAbortError } from "./abort-error.js";
+import {
+  boundRecallContextComposition,
+  composeMissingMemoryContext,
+  composeRecallContext,
+  RECALL_CONTEXT_SEPARATOR,
+  type RecallContextComposition,
+} from "./recall-context-composition.js";
+
+export type RecallCompositionChunk = string | { readonly content: string };
+
+export interface DecideRecallContextCompositionInput {
+  context: string;
+  compactContext?: string;
+  footer?: string;
+  maxChars: number;
+}
+
+export interface DecidedRecallContextComposition {
+  composition: RecallContextComposition;
+  context: string;
+  truncated: boolean;
+}
+
+function firstLine(content: string): string {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return "";
+  const newline = trimmed.indexOf("\n");
+  return newline === -1 ? trimmed : trimmed.slice(0, newline).trimEnd();
+}
+
+function chunkContent(chunk: RecallCompositionChunk): string {
+  return typeof chunk === "string" ? chunk : chunk.content;
+}
+
+/**
+ * Shallow form of every section chunk: the first line of each entry,
+ * so a budget miss prefers breadth-complete-but-shallow over a clipped
+ * tail. Empty chunks contribute nothing.
+ */
+export function compactRecallContextFromBuckets(
+  buckets: Iterable<readonly [unknown, readonly RecallCompositionChunk[]]>,
+): string {
+  const sections: string[] = [];
+  for (const [, chunks] of buckets) {
+    const lines: string[] = [];
+    for (const chunk of chunks) {
+      const line = firstLine(chunkContent(chunk));
+      if (line.length > 0) lines.push(line);
+    }
+    if (lines.length > 0) sections.push(lines.join("\n"));
+  }
+  return sections.join(RECALL_CONTEXT_SEPARATOR);
+}
+
+export function decideRecallContextComposition(
+  input: DecideRecallContextCompositionInput,
+): DecidedRecallContextComposition {
+  const composition = boundRecallContextComposition({
+    context: input.context,
+    footer: input.footer,
+    maxChars: input.maxChars,
+    compactContext: input.compactContext,
+  });
+  return {
+    composition,
+    context: composeRecallContext(composition),
+    truncated:
+      composition.degradation?.reason === "budget-clipped" ||
+      composition.degradation?.reason === "budget-compacted",
+  };
+}
+
+export function notifyContextComposition(
+  onContextComposition:
+    | ((composition: RecallContextComposition) => void | PromiseLike<void>)
+    | undefined,
+  composition: RecallContextComposition,
+  onError: (err: unknown) => void,
+): void {
+  if (!onContextComposition) return;
+  try {
+    const result = onContextComposition(composition);
+    if (result && typeof result.then === "function") {
+      void Promise.resolve(result).catch(onError);
+    }
+  } catch (err) {
+    onError(err);
+  }
+}
+
+/**
+ * Outer-recall failure: abort stays silent (empty string). Timeout and
+ * other errors become the missing-note so a failed query is never
+ * indistinguishable from "no matches".
+ */
+export function recallFailureComposition(err: unknown): RecallContextComposition | null {
+  if (isAbortError(err)) return null;
+  const detail =
+    err instanceof Error && err.message === "recall timeout"
+      ? "timeout"
+      : "recall_failed";
+  return composeMissingMemoryContext({ detail });
+}

--- a/packages/remnic-core/src/recall-xray-renderer.test.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.test.ts
@@ -615,3 +615,20 @@ test("renderXrayText tier-explain block matches shared helper output", async () 
     assert.ok(nullText.includes(line));
   }
 });
+
+test("#2972 xray text and markdown surface degradation only when present", () => {
+  const healthy = minimalSnapshot();
+  const degraded = {
+    ...minimalSnapshot(),
+    degradation: {
+      state: "degraded" as const,
+      reason: "budget-clipped" as const,
+    },
+  };
+  const healthyText = renderXrayText(healthy);
+  assert.equal(healthyText.includes("degradation:"), false);
+  assert.match(renderXrayText(degraded), /degradation: degraded\/budget-clipped/);
+  assert.equal(renderXrayMarkdown(healthy).includes("| Degradation |"), false);
+  assert.match(renderXrayMarkdown(degraded), /\| Degradation \| degraded\/budget-clipped \|/);
+});
+

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -108,6 +108,11 @@ export function renderXrayText(snapshot: RecallXraySnapshot | null): string {
   lines.push(
     `budget: ${snapshot.budget.used} / ${snapshot.budget.chars} chars`,
   );
+  if (snapshot.degradation) {
+    lines.push(
+      `degradation: ${snapshot.degradation.state}/${snapshot.degradation.reason}`,
+    );
+  }
 
   lines.push("");
   lines.push("--- filters ---");
@@ -247,6 +252,11 @@ export function renderXrayMarkdown(
   lines.push(
     `| Budget | ${snapshot.budget.used} / ${snapshot.budget.chars} chars |`,
   );
+  if (snapshot.degradation) {
+    lines.push(
+      `| Degradation | ${snapshot.degradation.state}/${snapshot.degradation.reason} |`,
+    );
+  }
 
   lines.push("");
   lines.push("## Filters");

--- a/packages/remnic-core/src/recall-xray.test.ts
+++ b/packages/remnic-core/src/recall-xray.test.ts
@@ -650,3 +650,31 @@ test("RecallXrayBuilder clones the trust projection so the snapshot surfaces it 
     "quarantine reason preserved so exclusion never looks like 'no result' (rule 34)",
   );
 });
+
+test("#2972 healthy xray snapshot omits the degradation marker", () => {
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.equal("degradation" in snapshot, false);
+  assert.ok(!JSON.stringify(snapshot).includes("degradation"));
+});
+
+test("#2972 xray snapshot copies degradation and isolates caller mutation", () => {
+  const degradation = {
+    state: "degraded" as const,
+    reason: "budget-clipped" as const,
+    budget: { contextBudget: 20, fullChars: 100, deliveredChars: 20 },
+  };
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    degradation,
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.deepEqual(snapshot.degradation, degradation);
+  degradation.budget.deliveredChars = 0;
+  assert.equal(snapshot.degradation?.budget?.deliveredChars, 20);
+});
+

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -24,6 +24,7 @@ import { estimateTokenCount } from "./token-estimate.js";
 import type { RecallDisclosure, RecallTierExplain } from "./types.js";
 import type { StateLabel } from "./recall-state-view.js";
 import { isRecallDisclosure } from "./types.js";
+import type { RecallContextDegradation } from "./recall-context-composition.js";
 
 /**
  * Estimate token cost of a payload for X-ray disclosure accounting.
@@ -282,6 +283,12 @@ export interface RecallXraySnapshot {
    * absent) means no peer profile was injected.
    */
   peerProfileInjection?: RecallXrayPeerProfileInjection | null;
+  /**
+   * Injected-context degradation (#2972). Absent on a healthy recall so
+   * the snapshot stays byte-stable. Budget warnings ride here, never
+   * in the injected text.
+   */
+  degradation?: RecallContextDegradation;
 }
 
 // ─── Builder ──────────────────────────────────────────────────────────────
@@ -300,6 +307,8 @@ export interface BuildXraySnapshotInput {
   traceId?: string;
   /** Peer-profile injection metadata (issue #679 completion). */
   peerProfileInjection?: RecallXrayPeerProfileInjection | null;
+  /** Injected-context degradation (#2972). Omit on a healthy recall. */
+  degradation?: RecallContextDegradation;
   /** Optional injected timestamp for deterministic tests. */
   now?: () => number;
   /** Optional injected id generator for deterministic tests. */
@@ -374,6 +383,12 @@ export function buildXraySnapshot(
   };
   if (peerProfileInjection !== undefined) {
     out.peerProfileInjection = peerProfileInjection;
+  }
+  if (input.degradation && typeof input.degradation === "object") {
+    out.degradation = { ...input.degradation };
+    if (input.degradation.budget) {
+      out.degradation.budget = { ...input.degradation.budget };
+    }
   }
   return out;
 }

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -411,7 +411,10 @@ test("recall aborts the in-flight pipeline when the outer timeout fires", async 
         abortSignal: callerAbortController.signal,
       },
     );
-    assert.equal(result, "");
+    // Explicit degradation contract (#2972): an outer timeout is a recall
+    // failure, so the injected context names it instead of silently
+    // omitting memory context.
+    assert.match(result, /Memory context unavailable/);
     assert.ok(observedAbortSignal);
     assert.notEqual(observedAbortSignal, callerAbortController.signal);
     assert.equal(observedAbortSignal?.aborted, true);


### PR DESCRIPTION
Part of #2972 — **composition/x-ray/audit/MCP surface**. Layer 1 already merged as #3002. The issue stays open for layer 3.

## What this does

Extracts `packages/remnic-core/src/recall-composition-decision.ts` so `recall-internal.ts` stays under its ratchet (5339 / 5344).

- Compact form is built from section-bucket first lines (`compactRecallContextFromBuckets`) and preferred over a clipped tail (`budget-compacted`).
- The missing-note is composed only on the **outer catch path** (`recallFailureComposition`: timeout / `recall_failed`). Abort still returns `""`.
- In-pipeline empties, including QMD skip / `backend_unavailable`, stay marker-free so curiosity footers are not dropped.
- When present, `degradation` is copied onto the x-ray snapshot, audit entry, and MCP `contextComposition` schema. Healthy paths omit the field.

No new config keys. `fetchQmdMemoryResultsWithArtifactTopUp` is untouched (owned by the #2975 recognition-tier layer).

## Remaining from #3002

Layer 3: OpenClaw `delegate-runtime.ts` forwarding `degradation`.

## Verification

- Focused composition / curiosity / x-ray / audit suites (83 pass)
- `npx tsc -p packages/remnic-core --noEmit`
- `node scripts/check-ratchets.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recall context now uses bounded composition to preserve the most relevant information when content exceeds limits.
  * Recall failures provide a clear missing-memory indication when appropriate, while cancellations remain quiet.
  * Added optional public degradation metadata for recall results, audit entries, and diagnostic snapshots.

* **Improvements**
  * Diagnostic text and Markdown outputs now show when recall context was compacted or unavailable.
  * Healthy recalls remain unchanged and omit degradation indicators.

* **Tests**
  * Added coverage for degraded, healthy, failed, and cancelled recall scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->