### PR TITLE
feat(recall): recognition-index write-path maintenance (layer 3)

### DIFF
--- a/.changeset/2975-recognition-index-write-path.md
+++ b/.changeset/2975-recognition-index-write-path.md
@@ -1,0 +1,22 @@
+---
+"@remnic/core": minor
+---
+
+Recognition-index write-path maintenance (issue #2975): when
+`recallRecognitionTier` is enabled, a namespace memory write upserts the
+memory id into `state/index_recognition.json` so the recall slice's
+`loadRecognitionIndex` sees a fresh entry. Off-path is a proven no-op —
+zero index I/O. Descriptions stay first-line extraction; the
+discriminability tidy pass is a later layer.
+
+- New `maintainRecognitionIndexAfterWrite({ memoryDir, enabled, changes })`.
+  `enabled: false` returns before any read, write, or lock.
+- Extraction persist updates the namespace index through the existing
+  `updateTemporalTagIndexes` post-write hook (capability gates for the
+  temporal/tag indexes stay independent).
+- No new config keys. `saveRecognitionIndex` remains single-writer; this
+  slice serializes with an op chain plus directory lock.
+
+Not in this layer (follow-ups on #2975): storage.ts direct-write hook,
+RetrievalTier += recognition + xray labels, discriminability tidy pass,
+synthetic bench.

--- a/.changeset/2975-recognition-index-write-path.md
+++ b/.changeset/2975-recognition-index-write-path.md
@@ -16,6 +16,10 @@ discriminability tidy pass is a later layer.
   temporal/tag indexes stay independent).
 - No new config keys. `saveRecognitionIndex` remains single-writer; this
   slice serializes with an op chain plus directory lock.
+- A missing index is bootstrapped from the active corpus so the first
+  post-enable write cannot publish a 1-id index that recall would treat
+  as the full working set. Abandoned directory locks older than 60s are
+  reclaimed.
 
 Not in this layer (follow-ups on #2975): storage.ts direct-write hook,
 RetrievalTier += recognition + xray labels, discriminability tidy pass,

--- a/packages/remnic-core/src/orchestration/persistence-index.ts
+++ b/packages/remnic-core/src/orchestration/persistence-index.ts
@@ -7,6 +7,7 @@
  *   - content-hash dedup index add/has/remove/save
  *   - temporal-bounds backfill on dedup hits (bitemporal, #1578)
  *   - temporal tag index updates and persisted-memory indexing
+ *   - recognition-index write-path maintenance when recallRecognitionTier is on
  *   - graph edge construction for newly persisted memories
  *   - semantic dedup candidate lookup
  *
@@ -23,6 +24,7 @@ import { ContentHashIndex, StorageManager } from "../index.js";
 import { log } from "../logger.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { stripCitationForTemplate } from "../source-attribution.js";
+import { maintainRecognitionIndexAfterWrite, type RecognitionIndexChange } from "./recall-recognition-index.js";
 import { clearIndexesAsync, indexesExistAsync } from "../temporal-index.js";
 import { indexMemoriesBatchAsync } from "../temporal-index-batch.js";
 import { normalizeSupersessionKey } from "../temporal-supersession.js";
@@ -447,6 +449,9 @@ export class PersistenceIndexCoordinator {
     storage: StorageManager,
     persistedIds: string[],
   ): Promise<void> {
+    // Recognition-index write-path (issue #2975): independent of temporal
+    // capability gates. Off-path is zero index I/O and cannot block persist.
+    await this.maintainRecognitionIndex(storage, persistedIds);
     const caps = resolveCapabilities(this.deps.config); // #1566 Cluster C
     // Build temporal/tag indexes whenever either consumer is enabled:
     // - queryAwareIndexingEnabled: uses indexes for query-aware prefiltering in recall
@@ -625,4 +630,37 @@ export class PersistenceIndexCoordinator {
     );
     return enriched;
   }
+  /**
+   * Upsert persisted memories into the namespace recognition index.
+   * `recallRecognitionTier !== true` returns before any index I/O.
+   */
+  private async maintainRecognitionIndex(
+    storage: StorageManager,
+    persistedIds: string[],
+  ): Promise<void> {
+    try {
+      if (this.deps.config.recallRecognitionTier !== true) return;
+      if (persistedIds.length === 0) return;
+      const changes: RecognitionIndexChange[] = [];
+      for (const id of persistedIds) {
+        let memory = await storage.getMemoryById(id);
+        if (!memory) {
+          const cold = await storage.getMemoryByIdIncludingArchived(id).catch(() => null);
+          if (cold && isActiveMemoryStatus(cold.frontmatter.status)) memory = cold;
+        }
+        if (!memory || !isActiveMemoryStatus(memory.frontmatter.status)) continue;
+        const memoryId = memory.frontmatter.id;
+        if (typeof memoryId !== "string" || memoryId.trim().length === 0) continue;
+        changes.push({ action: "upsert", id: memoryId, content: memory.content ?? "" });
+      }
+      await maintainRecognitionIndexAfterWrite({
+        memoryDir: storage.dir,
+        enabled: true,
+        changes,
+      });
+    } catch (err) {
+      log.debug(`recognition-index update error (non-fatal): ${err}`);
+    }
+  }
+
 }

--- a/packages/remnic-core/src/orchestration/persistence-index.ts
+++ b/packages/remnic-core/src/orchestration/persistence-index.ts
@@ -23,6 +23,7 @@ import { GraphIndex, type GraphEdge } from "../graph.js";
 import { ContentHashIndex, StorageManager } from "../index.js";
 import { log } from "../logger.js";
 import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
+import { loadRecognitionIndex } from "../recall-recognition-tier.js";
 import { stripCitationForTemplate } from "../source-attribution.js";
 import { maintainRecognitionIndexAfterWrite, type RecognitionIndexChange } from "./recall-recognition-index.js";
 import { clearIndexesAsync, indexesExistAsync } from "../temporal-index.js";
@@ -633,6 +634,9 @@ export class PersistenceIndexCoordinator {
   /**
    * Upsert persisted memories into the namespace recognition index.
    * `recallRecognitionTier !== true` returns before any index I/O.
+   * A missing index is bootstrapped from the active corpus so the first
+   * post-enable write cannot publish a partial index that recall would
+   * treat as the full working set.
    */
   private async maintainRecognitionIndex(
     storage: StorageManager,
@@ -640,18 +644,26 @@ export class PersistenceIndexCoordinator {
   ): Promise<void> {
     try {
       if (this.deps.config.recallRecognitionTier !== true) return;
-      if (persistedIds.length === 0) return;
+      const indexMissing = (await loadRecognitionIndex(storage.dir)) === null;
+      if (!indexMissing && persistedIds.length === 0) return;
       const changes: RecognitionIndexChange[] = [];
+      const pushUpsert = (memory: MemoryFile): void => {
+        if (!isActiveMemoryStatus(memory.frontmatter.status)) return;
+        const memoryId = memory.frontmatter.id;
+        if (typeof memoryId !== "string" || memoryId.trim().length === 0) return;
+        changes.push({ action: "upsert", id: memoryId, content: memory.content ?? "" });
+      };
+      if (indexMissing) {
+        const corpus = await storage.readAllMemories().catch(() => []);
+        for (const memory of corpus) pushUpsert(memory);
+      }
       for (const id of persistedIds) {
         let memory = await storage.getMemoryById(id);
         if (!memory) {
           const cold = await storage.getMemoryByIdIncludingArchived(id).catch(() => null);
           if (cold && isActiveMemoryStatus(cold.frontmatter.status)) memory = cold;
         }
-        if (!memory || !isActiveMemoryStatus(memory.frontmatter.status)) continue;
-        const memoryId = memory.frontmatter.id;
-        if (typeof memoryId !== "string" || memoryId.trim().length === 0) continue;
-        changes.push({ action: "upsert", id: memoryId, content: memory.content ?? "" });
+        if (memory) pushUpsert(memory);
       }
       await maintainRecognitionIndexAfterWrite({
         memoryDir: storage.dir,

--- a/packages/remnic-core/src/orchestration/recall-recognition-index.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-recognition-index.test.ts
@@ -1,0 +1,198 @@
+/**
+ * recall-recognition-index.test.ts — issue #2975 write-path maintenance slice.
+ *
+ * Pins: when recallRecognitionTier is on, a namespace write upserts the
+ * memory id into state/index_recognition.json so loadRecognitionIndex
+ * sees a fresh entry. Gate-off is zero index I/O. Descriptions are the
+ * first non-empty body line (no recognition-trigger generation here).
+ */
+import assert from "node:assert/strict";
+import { mock } from "node:test";
+import os from "node:os";
+import path from "node:path";
+import { promises as fsp } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import test from "node:test";
+
+import { parseConfig } from "../config.js";
+import { loadRecognitionIndex, recognitionIndexPath } from "../recall-recognition-tier.js";
+import { PersistenceIndexCoordinator } from "./persistence-index.js";
+import { maintainRecognitionIndexAfterWrite } from "./recall-recognition-index.js";
+import type { MemoryFile, PluginConfig } from "../types.js";
+
+async function tmpNamespace(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "remnic-recognition-index-"));
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fsp.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("acceptance: gate-off write is zero index I/O", async () => {
+  const dir = await tmpNamespace();
+  const spies = [
+    mock.method(fsp, "readFile"),
+    mock.method(fsp, "writeFile"),
+    mock.method(fsp, "mkdir"),
+    mock.method(fsp, "open"),
+    mock.method(fsp, "rename"),
+    mock.method(fsp, "rm"),
+    mock.method(fsp, "unlink"),
+    mock.method(fsp, "stat"),
+    mock.method(fsp, "access"),
+    mock.method(fsp, "readdir"),
+  ];
+  try {
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: false,
+      changes: [{ action: "upsert", id: "fact-001", content: "SSD inference chips in the lab rack.\nMore body." }],
+    });
+    for (const spy of spies) {
+      assert.equal(spy.mock.calls.length, 0, `${String(spy.mock.calls.length)} unexpected fs calls on the off path`);
+    }
+    assert.equal(await exists(recognitionIndexPath(dir)), false);
+    assert.equal(await loadRecognitionIndex(dir), null);
+  } finally {
+    for (const spy of spies) spy.mock.restore();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("acceptance: gate-on write upserts id so loadRecognitionIndex sees a fresh entry", async () => {
+  const dir = await tmpNamespace();
+  try {
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: true,
+      changes: [
+        {
+          action: "upsert",
+          id: "fact-001",
+          content: "SSD inference chips in the lab rack.\nRunning the model off a local tier.",
+        },
+      ],
+    });
+    const index = await loadRecognitionIndex(dir);
+    assert.ok(index, "index must exist after an enabled write");
+    assert.deepEqual(index.entries, [
+      { id: "fact-001", description: "SSD inference chips in the lab rack." },
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("incremental write updates an existing id in place and appends a new id", async () => {
+  const dir = await tmpNamespace();
+  try {
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: true,
+      changes: [{ action: "upsert", id: "m-001", content: "first line original" }],
+    });
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: true,
+      changes: [
+        { action: "upsert", id: "m-001", content: "first line rewritten\nbody" },
+        { action: "upsert", id: "m-002", content: "second memory trigger" },
+      ],
+    });
+    const index = await loadRecognitionIndex(dir);
+    assert.deepEqual(index?.entries, [
+      { id: "m-001", description: "first line rewritten" },
+      { id: "m-002", description: "second memory trigger" },
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("remove drops the id; blank ids are ignored without writing", async () => {
+  const dir = await tmpNamespace();
+  try {
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: true,
+      changes: [
+        { action: "upsert", id: "keep", content: "kept" },
+        { action: "upsert", id: "drop", content: "gone" },
+      ],
+    });
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: true,
+      changes: [{ action: "remove", id: "drop" }],
+    });
+    assert.deepEqual((await loadRecognitionIndex(dir))?.entries, [
+      { id: "keep", description: "kept" },
+    ]);
+
+    const before = await fsp.readFile(recognitionIndexPath(dir), "utf8");
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: true,
+      changes: [{ action: "upsert", id: "   ", content: "blank id is dropped" }],
+    });
+    assert.equal(await fsp.readFile(recognitionIndexPath(dir), "utf8"), before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+function memory(id: string, content: string): MemoryFile {
+  return {
+    path: `/tmp/${id}.md`,
+    content,
+    frontmatter: { id, category: "fact", created: "2026-08-25T00:00:00.000Z", updated: "2026-08-25T00:00:00.000Z", source: "test", confidence: 1, confidenceTier: "explicit", tags: [] },
+  };
+}
+
+function stubCoordinator(config: PluginConfig) {
+  return new PersistenceIndexCoordinator({
+    config,
+    contentHashIndex: null,
+    contentHashIndexForStorage: async () => null,
+    contentHashIndexesByStorageDir: new Map(),
+    embeddingFallback: { isAvailable: async () => false } as never,
+    graphIndexFor: () => {
+      throw new Error("graph unused");
+    },
+    readAllMemoriesForNamespaces: async () => [],
+    semanticDedupScopeFor: () => ({}),
+  });
+}
+
+test("persist-path: enabled writes update the namespace index; disabled stays quiet", async () => {
+  const dir = await tmpNamespace();
+  const memories = new Map<string, MemoryFile>([
+    ["fact-ssd", memory("fact-ssd", "Running the model off an SSD tier.\nDetails.")],
+  ]);
+  const storage = {
+    dir,
+    getMemoryById: async (id: string) => memories.get(id) ?? null,
+    getMemoryByIdIncludingArchived: async (id: string) => memories.get(id) ?? null,
+    readAllMemories: async () => [...memories.values()],
+    readAllColdMemories: async () => [],
+  };
+  try {
+    const off = stubCoordinator(parseConfig({}));
+    await off.updateTemporalTagIndexes(storage as never, ["fact-ssd"]);
+    assert.equal(await exists(recognitionIndexPath(dir)), false, "off-path persist must not mint an index");
+
+    const on = stubCoordinator(parseConfig({ recallRecognitionTier: true }));
+    await on.updateTemporalTagIndexes(storage as never, ["fact-ssd"]);
+    const index = await loadRecognitionIndex(dir);
+    assert.deepEqual(index?.entries, [
+      { id: "fact-ssd", description: "Running the model off an SSD tier." },
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/orchestration/recall-recognition-index.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-recognition-index.test.ts
@@ -196,3 +196,54 @@ test("persist-path: enabled writes update the namespace index; disabled stays qu
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("persist-path: first post-enable persist bootstraps the active corpus, not just the write", async () => {
+  const dir = await tmpNamespace();
+  const memories = new Map<string, MemoryFile>([
+    ["fact-old", memory("fact-old", "Existing SSD rack layout.\nOlder note.")],
+    ["fact-ssd", memory("fact-ssd", "Running the model off an SSD tier.\nDetails.")],
+  ]);
+  const storage = {
+    dir,
+    getMemoryById: async (id: string) => memories.get(id) ?? null,
+    getMemoryByIdIncludingArchived: async (id: string) => memories.get(id) ?? null,
+    readAllMemories: async () => [...memories.values()],
+    readAllColdMemories: async () => [],
+  };
+  try {
+    const on = stubCoordinator(parseConfig({ recallRecognitionTier: true }));
+    await on.updateTemporalTagIndexes(storage as never, ["fact-ssd"]);
+    const index = await loadRecognitionIndex(dir);
+    assert.deepEqual(
+      index?.entries.map((entry) => entry.id).sort(),
+      ["fact-old", "fact-ssd"],
+    );
+    assert.deepEqual(
+      index?.entries.find((entry) => entry.id === "fact-old"),
+      { id: "fact-old", description: "Existing SSD rack layout." },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("stale recognition-index lock is broken so a later write can publish", async () => {
+  const dir = await tmpNamespace();
+  const lockDir = `${recognitionIndexPath(dir)}.lock.d`;
+  try {
+    await fsp.mkdir(lockDir, { recursive: true });
+    const stale = new Date(Date.now() - 120_000);
+    await fsp.utimes(lockDir, stale, stale);
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: dir,
+      enabled: true,
+      changes: [{ action: "upsert", id: "fact-001", content: "SSD inference chips in the lab rack." }],
+    });
+    const index = await loadRecognitionIndex(dir);
+    assert.deepEqual(index?.entries, [
+      { id: "fact-001", description: "SSD inference chips in the lab rack." },
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/orchestration/recall-recognition-index.ts
+++ b/packages/remnic-core/src/orchestration/recall-recognition-index.ts
@@ -35,6 +35,7 @@ export type RecognitionIndexChange =
 const writeChains = new Map<string, Promise<void>>();
 const LOCK_POLL_MS = 10;
 const LOCK_ATTEMPTS = 50;
+const LOCK_STALE_MS = 60_000;
 
 /**
  * First non-empty line of a memory body. Layer 1 has no description
@@ -58,6 +59,25 @@ function withIndexChain<T>(indexPath: string, op: () => Promise<T>): Promise<T> 
   return run;
 }
 
+async function removeAbandonedRecognitionLock(
+  lockDir: string,
+): Promise<"removed" | "wait" | "blocked"> {
+  try {
+    const info = await fsp.lstat(lockDir);
+    if (info.isSymbolicLink()) return "blocked";
+    if (!info.isDirectory()) {
+      await fsp.rm(lockDir, { force: true });
+      return "removed";
+    }
+    if (Date.now() - info.mtimeMs < LOCK_STALE_MS) return "wait";
+    await fsp.rm(lockDir, { recursive: true, force: true });
+    return "removed";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return "removed";
+    return "blocked";
+  }
+}
+
 async function withRecognitionIndexLock<T>(memoryDir: string, op: () => Promise<T>): Promise<T> {
   const lockDir = `${recognitionIndexPath(memoryDir)}.lock.d`;
   for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
@@ -75,6 +95,11 @@ async function withRecognitionIndexLock<T>(memoryDir: string, op: () => Promise<
         continue;
       }
       if (code !== "EEXIST") throw error;
+      const cleanup = await removeAbandonedRecognitionLock(lockDir);
+      if (cleanup === "blocked") {
+        throw new Error(`recognition index lock blocked at ${lockDir}`);
+      }
+      if (cleanup === "removed") continue;
       await delay(LOCK_POLL_MS);
     }
   }
@@ -133,6 +158,10 @@ export async function maintainRecognitionIndexAfterWrite(args: {
   await withIndexChain(indexPath, () =>
     withRecognitionIndexLock(args.memoryDir, async () => {
       const loaded = await loadRecognitionIndex(args.memoryDir);
+      // `changes` is the full set the caller wants published. Persist-path
+      // bootstraps from the active corpus when the file is absent so a
+      // first post-enable write cannot mint a 1-id index that recall would
+      // treat as authoritative.
       const entries = applyChanges(loaded?.entries ?? [], changes);
       await saveRecognitionIndex(args.memoryDir, buildRecognitionIndex(entries));
     }),

--- a/packages/remnic-core/src/orchestration/recall-recognition-index.ts
+++ b/packages/remnic-core/src/orchestration/recall-recognition-index.ts
@@ -1,0 +1,140 @@
+/**
+ * Recognition-index write-path maintenance (issue #2975).
+ *
+ * Sibling of recall-recognition-search.ts at the memory write-path seam:
+ * when recallRecognitionTier is enabled, a namespace write upserts (or
+ * removes) that memory's id in `<memoryDir>/state/index_recognition.json`
+ * so the recall slice's loadRecognitionIndex sees a fresh entry. Off-path
+ * (`enabled !== true`) returns immediately — zero index I/O.
+ *
+ * Descriptions: layer 1 has no generator. This slice keeps ids current and
+ * fills description from the first non-empty body line (the compact
+ * `id: description` form the tier already renders). Discriminability
+ * rewrite is a later tidy pass.
+ *
+ * Serialization matches temporal-index: an in-process op chain per index
+ * path plus a directory lock around load → mutate → save. saveRecognitionIndex
+ * is single-writer and does not lock on its own.
+ */
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  buildRecognitionIndex,
+  loadRecognitionIndex,
+  recognitionIndexPath,
+  saveRecognitionIndex,
+  type RecognitionIndexEntry,
+} from "../recall-recognition-tier.js";
+
+export type RecognitionIndexChange =
+  | { readonly action: "upsert"; readonly id: string; readonly content: string }
+  | { readonly action: "remove"; readonly id: string };
+
+const writeChains = new Map<string, Promise<void>>();
+const LOCK_POLL_MS = 10;
+const LOCK_ATTEMPTS = 50;
+
+/**
+ * First non-empty line of a memory body. Layer 1 has no description
+ * generator; this is the compact line the tier already renders.
+ */
+export function recognitionDescriptionFromContent(content: string): string {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return "";
+  const newline = trimmed.indexOf("\n");
+  return newline === -1 ? trimmed : trimmed.slice(0, newline).trimEnd();
+}
+
+function withIndexChain<T>(indexPath: string, op: () => Promise<T>): Promise<T> {
+  const previous = writeChains.get(indexPath) ?? Promise.resolve();
+  const run = previous.then(op, op);
+  const tail = run.then(() => undefined, () => undefined);
+  writeChains.set(indexPath, tail);
+  void tail.then(() => {
+    if (writeChains.get(indexPath) === tail) writeChains.delete(indexPath);
+  });
+  return run;
+}
+
+async function withRecognitionIndexLock<T>(memoryDir: string, op: () => Promise<T>): Promise<T> {
+  const lockDir = `${recognitionIndexPath(memoryDir)}.lock.d`;
+  for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+    try {
+      await fsp.mkdir(lockDir);
+      try {
+        return await op();
+      } finally {
+        await fsp.rm(lockDir, { recursive: true, force: true }).catch(() => undefined);
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") {
+        await fsp.mkdir(path.dirname(lockDir), { recursive: true }).catch(() => undefined);
+        continue;
+      }
+      if (code !== "EEXIST") throw error;
+      await delay(LOCK_POLL_MS);
+    }
+  }
+  throw new Error(`recognition index lock timed out at ${lockDir}`);
+}
+
+function applyChanges(
+  entries: readonly RecognitionIndexEntry[],
+  changes: readonly RecognitionIndexChange[],
+): RecognitionIndexEntry[] {
+  const next = entries.map((entry) => ({ id: entry.id, description: entry.description }));
+  const byId = new Map(next.map((entry, index) => [entry.id, index]));
+  for (const change of changes) {
+    const id = change.id.trim();
+    if (id.length === 0) continue;
+    if (change.action === "remove") {
+      const index = byId.get(id);
+      if (index === undefined) continue;
+      next.splice(index, 1);
+      byId.delete(id);
+      for (const [key, value] of byId) {
+        if (value > index) byId.set(key, value - 1);
+      }
+      continue;
+    }
+    const description = recognitionDescriptionFromContent(change.content);
+    const existing = byId.get(id);
+    if (existing !== undefined) {
+      next[existing] = { id, description };
+    } else {
+      byId.set(id, next.length);
+      next.push({ id, description });
+    }
+  }
+  return next;
+}
+
+function meaningfulChanges(changes: readonly RecognitionIndexChange[]): RecognitionIndexChange[] {
+  return changes.filter((change) => change.id.trim().length > 0);
+}
+
+/**
+ * Incrementally maintain a namespace recognition index after memory writes.
+ * `enabled: false` is a proven no-op: no reads, no writes, no locks.
+ */
+export async function maintainRecognitionIndexAfterWrite(args: {
+  memoryDir: string;
+  enabled: boolean;
+  changes: readonly RecognitionIndexChange[];
+}): Promise<void> {
+  if (args.enabled !== true) return;
+  const changes = meaningfulChanges(args.changes);
+  if (changes.length === 0) return;
+
+  const indexPath = recognitionIndexPath(args.memoryDir);
+  await withIndexChain(indexPath, () =>
+    withRecognitionIndexLock(args.memoryDir, async () => {
+      const loaded = await loadRecognitionIndex(args.memoryDir);
+      const entries = applyChanges(loaded?.entries ?? [], changes);
+      await saveRecognitionIndex(args.memoryDir, buildRecognitionIndex(entries));
+    }),
+  );
+}

--- a/packages/remnic-core/src/testing/subjects/recall-recognition-index.test.ts
+++ b/packages/remnic-core/src/testing/subjects/recall-recognition-index.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Recognition-index write-path subject for the scenario-matrix harness
+ * (issue #2975).
+ *
+ * Every canonical row drives the real maintainRecognitionIndexAfterWrite
+ * seam twice: gate off (zero index I/O, no index file) and gate on
+ * (the write's id is visible to loadRecognitionIndex). Restart rows
+ * reload from disk; replay rows prove an id upsert is idempotent.
+ */
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { promises as fsp } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { loadRecognitionIndex, recognitionIndexPath } from "../../recall-recognition-tier.js";
+import { maintainRecognitionIndexAfterWrite } from "../../orchestration/recall-recognition-index.js";
+import { type LifecycleSubject, type MatrixRow, runLifecycleMatrix } from "../lifecycle-matrix.js";
+
+interface IndexState {
+  rowId: string;
+  dir: string;
+  restart: boolean;
+  dedupeOrReplay: boolean;
+}
+
+const subject: LifecycleSubject<IndexState> = {
+  async setup(row: MatrixRow): Promise<IndexState> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-recognition-index-subject-"));
+    return {
+      rowId: String(row.id),
+      dir,
+      restart: row.dimensions.restart,
+      dedupeOrReplay: row.dimensions.dedupeOrReplay,
+    };
+  },
+
+  async exercise(state): Promise<void> {
+    const id = `fact-${state.rowId}`;
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: state.dir,
+      enabled: false,
+      changes: [{ action: "upsert", id, content: `off-path body for ${state.rowId}` }],
+    });
+    assert.equal(await loadRecognitionIndex(state.dir), null);
+    try {
+      await fsp.access(recognitionIndexPath(state.dir));
+      assert.fail("off-path must not create the recognition index file");
+    } catch (err) {
+      assert.equal((err as NodeJS.ErrnoException).code, "ENOENT");
+    }
+
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: state.dir,
+      enabled: true,
+      changes: [{ action: "upsert", id, content: `SSD inference chips — ${state.rowId}\nbody` }],
+    });
+    if (state.dedupeOrReplay) {
+      await maintainRecognitionIndexAfterWrite({
+        memoryDir: state.dir,
+        enabled: true,
+        changes: [{ action: "upsert", id, content: `SSD inference chips — ${state.rowId} replayed\nbody` }],
+      });
+    }
+  },
+
+  async invariants(state): Promise<void> {
+    const id = `fact-${state.rowId}`;
+    const index = await loadRecognitionIndex(state.dir);
+    assert.ok(index, "enabled write must persist an index loadable after the row");
+    assert.equal(index.entries.length, 1);
+    assert.equal(index.entries[0]?.id, id);
+    const expected = state.dedupeOrReplay
+      ? `SSD inference chips — ${state.rowId} replayed`
+      : `SSD inference chips — ${state.rowId}`;
+    assert.equal(index.entries[0]?.description, expected);
+
+    if (state.restart) {
+      const reloaded = await loadRecognitionIndex(state.dir);
+      assert.deepEqual(reloaded, index, "restart must see the same on-disk index");
+    }
+
+    const before = { ...index };
+    await maintainRecognitionIndexAfterWrite({
+      memoryDir: state.dir,
+      enabled: false,
+      changes: [{ action: "remove", id }],
+    });
+    assert.deepEqual(await loadRecognitionIndex(state.dir), before, "off-path after on-path must not mutate the index");
+  },
+
+  async teardown(state): Promise<void> {
+    await rm(state.dir, { recursive: true, force: true });
+  },
+};
+
+runLifecycleMatrix("recall-recognition-index", subject);

--- a/scripts/lifecycle-matrix/coverage.json
+++ b/scripts/lifecycle-matrix/coverage.json
@@ -150,7 +150,8 @@
     "packages/remnic-core/src/maintenance/rebuild-memory-projection.ts",
     "packages/remnic-core/src/orchestration/projection-rebuild-schedule.ts",
     "packages/plugin-openclaw/src/delegate-runtime.ts",
-    "packages/remnic-core/src/orchestration/recall-recognition-search.ts"
+    "packages/remnic-core/src/orchestration/recall-recognition-search.ts",
+    "packages/remnic-core/src/orchestration/recall-recognition-index.ts"
   ],
   "coverage": {
     "packages/plugin-openclaw/src/delegate-runtime.ts": "openclaw-delegate-runtime",
@@ -193,6 +194,7 @@
     "packages/remnic-core/src/orchestration/recall-internal-deps.ts": "recall-budget",
     "packages/remnic-core/src/orchestration/recall-profile-storage.ts": "recall-profile-storage",
     "packages/remnic-core/src/orchestration/recall-recognition-search.ts": "recall-recognition-tier",
+    "packages/remnic-core/src/orchestration/recall-recognition-index.ts": "recall-recognition-index",
     "packages/remnic-core/src/orchestration/recall-search-prefilter.ts": "recall-search-prefilter",
     "packages/remnic-core/src/orchestration/recall-section-coordinator.ts": "recall-budget",
     "packages/remnic-core/src/orchestration/semantic-merge-commit-effects.ts": "semantic-merge-lifecycle",


### PR DESCRIPTION
Refs #2975 — **layer 3 of ~5; the issue stays open.** When `recallRecognitionTier` is enabled, a namespace memory write upserts the memory id into `state/index_recognition.json` so the recall slice's `loadRecognitionIndex` sees a fresh entry. Off-path proven: `enabled !== true` returns before any index read, write, lock, or mkdir. Descriptions stay first-line extraction (layer 1 has no generator); the discriminability tidy pass is later. Extraction persist updates the namespace index through the existing `updateTemporalTagIndexes` post-write hook; temporal/tag capability gates stay independent.

Gates: 5/5 focused (fail-before: module missing / `ERR_MODULE_NOT_FOUND`; pass-after: write updates index when on, zero I/O when off, in-place update + append, remove, persist-path wiring); neighbors `recall-recognition-tier` + `recall-recognition-search` + existing recall-recognition-tier matrix subject clean (29/29); new lifecycle-matrix subject `recall-recognition-index` (9/9 rows); tsc exit 0; ratchets OK, no baseline bumps.

Deferred: `storage.ts` direct-write hook, RetrievalTier += recognition + xray labels, discriminability tidy pass, synthetic bench.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition indexing for persisted memories when the recognition tier is enabled.
  * Memory updates support incremental additions, replacements, and removals while preserving index consistency.
  * Index entries include concise descriptions derived from memory content.
  * Missing indexes are automatically rebuilt from the active memory corpus.

* **Bug Fixes**
  * Disabled recognition indexing performs no index file operations.
  * Stale index locks are safely recovered.
  * Recognition-index failures no longer interrupt memory persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->