### PR TITLE
feat(remnic-hermes): follow persisted Hermes model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `remnic-hermes` policy-bound LLM bridge supports the server-owned `active-hermes` provider sentinel. It resolves only Hermes' persisted main provider, model, and optional base URL per completion while retaining a stable `hermes-active` OpenAI-compatible alias; client request routing fields remain ignored.
+
 ## [v9.69.40] — 2026-08-25
 
 ### Fixed

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -195,13 +195,15 @@ Create a local policy file, for example `~/.remnic/hermes-llm-bridge/policy.json
 
 ```json
 {
-  "provider": "openai-codex",
-  "model": "gpt-5.6-terra",
+  "provider": "active-hermes",
+  "model": "hermes-active",
   "timeout_seconds": 90
 }
 ```
 
-These are the only accepted policy keys. The bridge rejects policy files containing credential-bearing or unrecognized fields, exposes only the policy model from `GET /v1/models`, ignores a client-supplied model selector, requires the launch-scoped bearer token on all provider-facing endpoints, and binds only `127.0.0.1`.
+These are the only accepted policy keys. `provider: "active-hermes"` is a server-owned sentinel: for each completion the bridge loads Hermes' persisted `model.provider`, `model.default`, and optional `model.base_url`, then sends the request through Hermes' normal provider authentication and routing. `model: "hermes-active"` is the required stable OpenAI-compatible name advertised by `/v1/models` and returned by completion responses; a request cannot select another provider or model. An unavailable or invalid persisted route returns a retryable `503` without routing the request. Session-only model switches are intentionally out of scope because the bridge is a separate process; persist the intended Hermes main model first.
+
+Static policies such as `openai-codex` plus `gpt-5.6-terra` remain supported. Both modes reject credential-bearing or unrecognized policy fields, require the launch-scoped bearer token on all provider-facing endpoints, and bind only `127.0.0.1`.
 
 ### Remnic daemon configuration
 
@@ -212,7 +214,7 @@ In the **Remnic daemon configuration** (not the `remnic:` block in Hermes' `conf
   "remnic": {
     "localLlmEnabled": true,
     "localLlmUrl": "http://127.0.0.1:4329/v1",
-    "localLlmModel": "gpt-5.6-terra",
+    "localLlmModel": "hermes-active",
     "localLlmApiKeyEnv": "REMNIC_HERMES_BRIDGE_TOKEN",
     "localLlmAuthHeader": true,
     "localLlmFallback": false,

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -93,7 +93,7 @@ For deferred Remnic LLM work, `remnic-hermes` also provides two opt-in commands:
 - `remnic-hermes-bridge` exposes one policy-selected Hermes provider as a **loopback-only** OpenAI-compatible endpoint.
 - `remnic-hermes-supervisor` starts that bridge, authenticates the supervised Remnic daemon with a launch-scoped request token, proves the exact bridge instance is ready with a separate per-launch secret, gives the daemon no provider environment variables, and stops the peer if either child exits.
 
-The policy has exactly three fields — `provider`, `model`, and `timeout_seconds`. It must not contain a provider API key or OAuth token: each request is resolved by Hermes' own `agent.auxiliary_client.call_llm()` routing and auth machinery.
+The policy has exactly three fields — `provider`, `model`, and `timeout_seconds`. It must not contain a provider API key or OAuth token: each request is resolved by Hermes' own `agent.auxiliary_client.call_llm()` routing and auth machinery. Use `provider: "active-hermes"` with the required `model: "hermes-active"` when Remnic should follow Hermes' persisted main provider/model/base URL; `/v1/models` and completion responses retain that public alias while client requests cannot choose an alternate route. Fixed provider/model policies remain supported.
 
 Use this only with Remnic's deferred extraction/consolidation paths. Keep recall-critical reranking and planner LLM calls disabled when their latency budget cannot accommodate a routed provider. Full configuration and lifecycle guidance is in [docs/plugins/hermes.md](../../docs/plugins/hermes.md).
 

--- a/packages/plugin-hermes/remnic_hermes/hermes_llm_bridge.py
+++ b/packages/plugin-hermes/remnic_hermes/hermes_llm_bridge.py
@@ -25,6 +25,10 @@ class PolicyError(ValueError):
     """A bridge request or policy exceeds the documented contract."""
 
 
+class RuntimeConfigurationError(PolicyError):
+    """Persisted Hermes routing is unavailable or invalid for a dynamic policy."""
+
+
 class ProviderResponseError(RuntimeError):
     """Hermes returned a response that cannot satisfy the OpenAI-compatible contract."""
 
@@ -35,6 +39,7 @@ _ALLOWED_POLICY_KEYS = frozenset({"provider", "model", "timeout_seconds"})
 _ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 _MAX_REQUEST_BYTES = 1_000_000
 _MAX_COMPLETION_TOKENS = 16_384
+_ACTIVE_HERMES_MODEL = "hermes-active"
 
 
 @dataclass(frozen=True)
@@ -57,6 +62,8 @@ class BridgePolicy:
             raise PolicyError("provider must be a normalized provider identifier")
         if not isinstance(model, str) or not _MODEL_RE.fullmatch(model):
             raise PolicyError("model must be a normalized model identifier")
+        if provider == "active-hermes" and model != _ACTIVE_HERMES_MODEL:
+            raise PolicyError(f"active-hermes policy model must be {_ACTIVE_HERMES_MODEL}")
         if isinstance(timeout, bool) or not isinstance(timeout, int) or not 5 <= timeout <= 300:
             raise PolicyError("timeout_seconds must be an integer from 5 through 300")
         return cls(provider=provider, model=model, timeout_seconds=timeout)
@@ -98,6 +105,39 @@ def _content_from_response(response: Any) -> str:
     raise ProviderResponseError("Hermes provider returned empty completion content")
 
 
+def _resolve_runtime(policy: BridgePolicy) -> tuple[str, str, str | None]:
+    """Resolve a fixed policy or the persisted main Hermes model safely."""
+    if policy.provider != "active-hermes":
+        return policy.provider, policy.model, None
+
+    try:
+        import importlib
+
+        config_module = importlib.import_module("hermes_cli.config")
+        loader = getattr(config_module, "load_config_readonly", None) or getattr(config_module, "load_config", None)
+        if not callable(loader):
+            raise TypeError("Hermes config loader is unavailable")
+        config = loader()
+        model_config = config.get("model") if isinstance(config, dict) else None
+        if not isinstance(model_config, dict):
+            raise TypeError("Hermes model configuration is unavailable")
+        provider = model_config.get("provider")
+        model = model_config.get("default")
+        base_url = model_config.get("base_url")
+    except Exception as exc:
+        raise RuntimeConfigurationError("active Hermes model configuration is unavailable") from exc
+
+    if not isinstance(provider, str) or not _PROVIDER_RE.fullmatch(provider):
+        raise RuntimeConfigurationError("active Hermes model provider is invalid")
+    if not isinstance(model, str) or not _MODEL_RE.fullmatch(model):
+        raise RuntimeConfigurationError("active Hermes model identifier is invalid")
+    if base_url in (None, ""):
+        return provider, model, None
+    if not isinstance(base_url, str) or not base_url.startswith(("https://", "http://")):
+        raise RuntimeConfigurationError("active Hermes model base URL is invalid")
+    return provider, model, base_url.rstrip("/")
+
+
 def invoke_completion(
     body: dict[str, Any],
     policy: BridgePolicy,
@@ -121,14 +161,18 @@ def invoke_completion(
     ):
         raise PolicyError(f"max_tokens must be an integer from 1 through {_MAX_COMPLETION_TOKENS}")
 
-    response = call_llm(
-        provider=policy.provider,
-        model=policy.model,
-        messages=messages,
-        temperature=temperature,
-        max_tokens=max_tokens,
-        timeout=policy.timeout_seconds,
-    )
+    provider, model, base_url = _resolve_runtime(policy)
+    call_kwargs: dict[str, object] = {
+        "provider": provider,
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "timeout": policy.timeout_seconds,
+    }
+    if base_url is not None:
+        call_kwargs["base_url"] = base_url
+    response = call_llm(**call_kwargs)
     return {
         "id": "chatcmpl-remnic-hermes",
         "object": "chat.completion",
@@ -257,6 +301,8 @@ def make_handler(
                 self._send_json(HTTPStatus.OK, invoke_completion(body, load_policy(policy_path), call_llm=call_llm))
             except ProviderResponseError:
                 self._send_json(HTTPStatus.BAD_GATEWAY, {"error": {"message": "Hermes provider call failed"}})
+            except RuntimeConfigurationError as exc:
+                self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": {"message": str(exc)}})
             except (PolicyError, ValueError, json.JSONDecodeError) as exc:
                 self._send_json(HTTPStatus.BAD_REQUEST, {"error": {"message": str(exc)}})
             except Exception:

--- a/packages/plugin-hermes/remnic_hermes/hermes_llm_bridge.py
+++ b/packages/plugin-hermes/remnic_hermes/hermes_llm_bridge.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 import re
 from typing import Any, Callable, Type, cast
+from urllib.parse import urlsplit
 
 
 class PolicyError(ValueError):
@@ -133,9 +134,23 @@ def _resolve_runtime(policy: BridgePolicy) -> tuple[str, str, str | None]:
         raise RuntimeConfigurationError("active Hermes model identifier is invalid")
     if base_url in (None, ""):
         return provider, model, None
-    if not isinstance(base_url, str) or not base_url.startswith(("https://", "http://")):
+    if not isinstance(base_url, str) or not _is_absolute_http_url(base_url):
         raise RuntimeConfigurationError("active Hermes model base URL is invalid")
     return provider, model, base_url.rstrip("/")
+
+
+def _is_absolute_http_url(value: str) -> bool:
+    """Accept only an absolute http(s) URL that carries a non-empty authority.
+
+    A prefix test alone admits values such as "https://", which carry no host and
+    would otherwise reach the provider as a malformed endpoint instead of failing
+    closed as invalid persisted routing.
+    """
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.hostname)
 
 
 def invoke_completion(

--- a/packages/plugin-hermes/remnic_hermes/hermes_llm_bridge.py
+++ b/packages/plugin-hermes/remnic_hermes/hermes_llm_bridge.py
@@ -140,15 +140,20 @@ def _resolve_runtime(policy: BridgePolicy) -> tuple[str, str, str | None]:
 
 
 def _is_absolute_http_url(value: str) -> bool:
-    """Accept only an absolute http(s) URL that carries a non-empty authority.
+    """Accept only an absolute http(s) URL that carries a usable authority.
 
     A prefix test alone admits values such as "https://", which carry no host and
     would otherwise reach the provider as a malformed endpoint instead of failing
-    closed as invalid persisted routing.
+    closed as invalid persisted routing. The port is read inside the guard because
+    urlsplit defers port parsing: an out-of-range or non-numeric port raises only
+    on attribute access, and port 0 parses cleanly while being unusable.
     """
     try:
         parsed = urlsplit(value)
+        port = parsed.port
     except ValueError:
+        return False
+    if port == 0:
         return False
     return parsed.scheme in ("http", "https") and bool(parsed.hostname)
 

--- a/packages/plugin-hermes/tests/test_hermes_llm_bridge.py
+++ b/packages/plugin-hermes/tests/test_hermes_llm_bridge.py
@@ -478,3 +478,49 @@ def test_active_hermes_policy_rejects_an_unstable_public_alias():
                 "timeout_seconds": 90,
             }
         )
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://",
+        "http://",
+        "https:///v1",
+        "https://:8080/v1",
+        "ftp://example.invalid/v1",
+        "example.invalid/v1",
+    ],
+)
+def test_active_hermes_rejects_a_base_url_without_a_usable_http_authority(monkeypatch, base_url):
+    """A prefix-shaped but hostless persisted route fails closed instead of reaching the provider."""
+    import importlib
+
+    from remnic_hermes.hermes_llm_bridge import BridgePolicy, RuntimeConfigurationError, invoke_completion
+
+    config_module = SimpleNamespace(
+        load_config_readonly=lambda: {
+            "model": {
+                "provider": "anthropic",
+                "default": "claude-sonnet-5",
+                "base_url": base_url,
+            }
+        }
+    )
+    original_import = importlib.import_module
+
+    def import_module(name, package=None):
+        if name == "hermes_cli.config":
+            return config_module
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+    calls: list[dict[str, object]] = []
+
+    with pytest.raises(RuntimeConfigurationError, match="base URL is invalid"):
+        invoke_completion(
+            {"messages": [{"role": "user", "content": "extract"}], "max_tokens": 8},
+            BridgePolicy(provider="active-hermes", model="hermes-active", timeout_seconds=90),
+            call_llm=lambda **kwargs: calls.append(kwargs) or SimpleNamespace(choices=[]),
+        )
+
+    assert calls == []

--- a/packages/plugin-hermes/tests/test_hermes_llm_bridge.py
+++ b/packages/plugin-hermes/tests/test_hermes_llm_bridge.py
@@ -489,6 +489,9 @@ def test_active_hermes_policy_rejects_an_unstable_public_alias():
         "https://:8080/v1",
         "ftp://example.invalid/v1",
         "example.invalid/v1",
+        "https://example.invalid:99999/v1",
+        "https://example.invalid:notaport/v1",
+        "https://example.invalid:0/v1",
     ],
 )
 def test_active_hermes_rejects_a_base_url_without_a_usable_http_authority(monkeypatch, base_url):

--- a/packages/plugin-hermes/tests/test_hermes_llm_bridge.py
+++ b/packages/plugin-hermes/tests/test_hermes_llm_bridge.py
@@ -318,3 +318,163 @@ def test_run_server_rejects_a_missing_hermes_runtime_before_opening_the_listener
                 run_server(_policy_path(tmp_path), request_token=BRIDGE_REQUEST_TOKEN)
 
     server.assert_not_called()
+
+
+def test_active_hermes_policy_routes_to_the_persisted_claude_runtime(monkeypatch):
+    """The stable public alias follows Hermes config, never a client model selector."""
+    import importlib
+
+    from remnic_hermes.hermes_llm_bridge import BridgePolicy, invoke_completion
+
+    config_module = SimpleNamespace(
+        load_config_readonly=lambda: {
+            "model": {
+                "provider": "anthropic",
+                "default": "claude-sonnet-5",
+                "base_url": "https://example.invalid/v1/",
+            }
+        }
+    )
+    original_import = importlib.import_module
+
+    def import_module(name, package=None):
+        if name == "hermes_cli.config":
+            return config_module
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+    calls: list[dict[str, object]] = []
+
+    result = invoke_completion(
+        {"model": "attacker-selected-model", "messages": [{"role": "user", "content": "extract"}], "max_tokens": 8},
+        BridgePolicy(provider="active-hermes", model="hermes-active", timeout_seconds=90),
+        call_llm=lambda **kwargs: calls.append(kwargs)
+        or SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="dynamic response"))]),
+    )
+
+    assert calls[0]["provider"] == "anthropic"
+    assert calls[0]["model"] == "claude-sonnet-5"
+    assert calls[0]["base_url"] == "https://example.invalid/v1"
+    assert result["model"] == "hermes-active"
+
+
+def test_active_hermes_endpoint_advertises_a_stable_alias_across_runtime_changes(tmp_path, monkeypatch):
+    """Remnic sees one model while each completion re-reads the persisted Hermes route."""
+    import importlib
+
+    from remnic_hermes.hermes_llm_bridge import make_handler
+
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {"provider": "active-hermes", "model": "hermes-active", "timeout_seconds": 90}
+        ),
+        encoding="utf-8",
+    )
+    runtime = {"model": {"provider": "anthropic", "default": "claude-sonnet-5"}}
+    original_import = importlib.import_module
+    monkeypatch.setattr(
+        importlib,
+        "import_module",
+        lambda name, package=None: SimpleNamespace(load_config_readonly=lambda: runtime)
+        if name == "hermes_cli.config"
+        else original_import(name, package),
+    )
+    calls: list[dict[str, object]] = []
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        make_handler(
+            policy_path,
+            call_llm=lambda **kwargs: calls.append(kwargs)
+            or SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="dynamic response"))]),
+            request_token=BRIDGE_REQUEST_TOKEN,
+        ),
+    )
+    worker = Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    try:
+        assert _request(server, "/v1/models")["data"] == [
+            {"id": "hermes-active", "object": "model", "owned_by": "hermes"}
+        ]
+        first = _request(
+            server,
+            "/v1/chat/completions",
+            body={"model": "client-selected", "messages": [{"role": "user", "content": "extract"}]},
+        )
+        runtime["model"] = {"provider": "openai-codex", "default": "gpt-5.6-terra-900k"}
+        second = _request(
+            server,
+            "/v1/chat/completions",
+            body={"model": "another-client-selection", "messages": [{"role": "user", "content": "extract"}]},
+        )
+        assert first["model"] == second["model"] == "hermes-active"
+        assert [(call["provider"], call["model"]) for call in calls] == [
+            ("anthropic", "claude-sonnet-5"),
+            ("openai-codex", "gpt-5.6-terra-900k"),
+        ]
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join(timeout=2)
+
+
+def test_active_hermes_runtime_misconfiguration_is_a_retryable_service_error(tmp_path, monkeypatch):
+    """A bad persisted Hermes route is server state, not a caller-owned 400."""
+    import importlib
+
+    from remnic_hermes.hermes_llm_bridge import make_handler
+
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {"provider": "active-hermes", "model": "hermes-active", "timeout_seconds": 90}
+        ),
+        encoding="utf-8",
+    )
+    original_import = importlib.import_module
+    monkeypatch.setattr(
+        importlib,
+        "import_module",
+        lambda name, package=None: SimpleNamespace(load_config_readonly=lambda: {})
+        if name == "hermes_cli.config"
+        else original_import(name, package),
+    )
+    calls: list[dict[str, object]] = []
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        make_handler(
+            policy_path,
+            call_llm=lambda **kwargs: calls.append(kwargs),
+            request_token=BRIDGE_REQUEST_TOKEN,
+        ),
+    )
+    worker = Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    try:
+        with pytest.raises(HTTPError) as error:
+            _request(
+                server,
+                "/v1/chat/completions",
+                body={"messages": [{"role": "user", "content": "extract"}]},
+            )
+        assert error.value.code == 503
+        assert json.loads(error.value.read())["error"]["message"] == "active Hermes model configuration is unavailable"
+        assert calls == []
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join(timeout=2)
+
+
+def test_active_hermes_policy_rejects_an_unstable_public_alias():
+    """Dynamic routing has one explicit, stable OpenAI-compatible public model ID."""
+    from remnic_hermes.hermes_llm_bridge import BridgePolicy, PolicyError
+
+    with pytest.raises(PolicyError, match="hermes-active"):
+        BridgePolicy.from_mapping(
+            {
+                "provider": "active-hermes",
+                "model": "claude-sonnet-5",
+                "timeout_seconds": 90,
+            }
+        )


### PR DESCRIPTION
## Summary
- Add an `active-hermes` policy sentinel that resolves only Hermes' persisted provider, model, and optional base URL for each completion.
- Keep a required, stable public `hermes-active` alias for `/v1/models` and completion responses; client request routing selectors remain ignored.
- Return retryable `503` without a provider call when the persisted Hermes route is unavailable or invalid.

## Validation
- `packages/plugin-hermes/tests`: 278 passed
- Ruff, docs parity, diff check, and repository cheap pre-push gates passed.
- Fresh wheel install and live Hermes runtime probe passed.
- Independent review approved.

## Known upstream baseline
`preflight:quick` remains red because `tests/pr-preflight-paths.test.mjs` fails identically on clean `origin/main` (an existing fixture/package-scope mismatch); this PR does not modify that preflight code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for routing requests through Hermes’ persisted provider, model, and optional base URL.
  * Introduced the stable `hermes-active` model alias while preventing client-selected alternate routes.
  * Continued support for fixed provider and model policies.

* **Bug Fixes**
  * Invalid or unavailable configurations now return retryable service errors.
  * Invalid base URLs, including unusable ports and unsupported schemes, are rejected before requests are sent.

* **Documentation**
  * Updated setup and policy guidance for active Hermes routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->