### PR TITLE
ci: add a windows-smoke gate on standard windows-latest (#3034)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,6 +385,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,76 @@ jobs:
       - name: Lifecycle-matrix coverage self-test
         run: node --test tests/lifecycle-matrix-coverage.test.mjs
 
+  # Windows regression gate (issue #3034). Windows deployments exist and file
+  # PRs, but every other job here is Linux, so path-separator, tilde-expansion
+  # and spawn regressions were only caught by users after release.
+  #
+  # Standard `windows-latest` ONLY: standard GitHub-hosted runners are free and
+  # unmetered for public repositories, while "larger runner" labels are BILLED
+  # even on public repos. Never swap this label for a larger runner.
+  #
+  # A separate job, not a `tests` matrix row: that job's runs-on expression
+  # selects the self-hosted Linux pool on trusted main pushes, and entangling
+  # Windows with it would break that selection.
+  #
+  # Deliberately NOT in the `quality` aggregator's `needs`: this job stays
+  # non-required until a green streak is observed (issue #3034 decision 3).
+  # Promotion is a one-line follow-up PR.
+  windows-smoke:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: windows-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        # git-bash ships on the windows-latest image. Bash keeps `set -euo
+        # pipefail` and non-zero exit propagation identical to every other job
+        # in this file; PowerShell's $ErrorActionPreference and native
+        # exit-code handling differ and can leave a failing command passing.
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+          cache: pnpm
+
+      # Pinned wrapper: prefers the pinned pnpm installed above and otherwise
+      # routes through `npm exec --yes pnpm@10.32.1` (scripts/pnpm.mjs).
+      - name: Install dependencies
+        run: node scripts/pnpm.mjs install --frozen-lockfile
+
+      - name: Build core
+        run: node scripts/pnpm.mjs --filter @remnic/core build
+
+      # A published install ships dist/index.js, and bin/remnic.cjs runs it with
+      # the node executable. Without this build the wrapper falls back to the
+      # tsx source entry — a dev-only path with its own Windows problems — so
+      # the smoke below would test something users never hit.
+      - name: Build CLI
+        run: node scripts/pnpm.mjs --filter @remnic/cli build
+
+      # Acceptance criterion (#3034): `remnic --help` and `remnic doctor` exit 0
+      # from an empty directory. The script creates that directory under
+      # RUNNER_TEMP itself — git-bash mishandles the backslash path, so a shell
+      # `mktemp -d "$RUNNER_TEMP/..."` would silently run in the repo root.
+      #
+      # Ordered before the core suite on purpose: it is seconds of work, and the
+      # suite is the step that can exhaust the 25-minute budget.
+      - name: CLI smoke
+        run: node scripts/windows-cli-smoke.mjs
+
+      # Runs the @remnic/core suite minus scripts/windows-skip-list.json, and
+      # prints every skip by name. No inline suppression: a Windows failure is
+      # either fixed forward or named in that list with an issue link.
+      - name: Core unit tests
+        run: node scripts/windows-test-runner.mjs
+
   # Aggregator that preserves the required status-check context `quality`
   # (branch ruleset) while the real work runs in parallel jobs above. Fails
   # unless every dependency succeeded — skipped/cancelled deps are failures,

--- a/scripts/build-staleness.mjs
+++ b/scripts/build-staleness.mjs
@@ -32,6 +32,7 @@ export function runPnpm(repoRoot, args) {
     cwd: repoRoot,
     stdio: "inherit",
     env: process.env,
+    shell: process.platform === "win32",
   });
 
   if (result.error) {

--- a/scripts/windows-cli-smoke.mjs
+++ b/scripts/windows-cli-smoke.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * CLI smoke check for the windows-smoke CI job (issue #3034).
+ *
+ * Acceptance criterion: `remnic --help` and `remnic doctor` both exit 0 when
+ * run from an empty directory. Node creates and enters that directory instead
+ * of the shell because RUNNER_TEMP is a backslash path on Windows, which
+ * git-bash `mktemp`/`cd` mishandle — the check would then run in the repo root
+ * and prove nothing.
+ *
+ * A non-zero exit from either command fails this script. No suppression.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cliBin = path.join(repoRoot, "packages", "remnic-cli", "bin", "remnic.cjs");
+const smokeDir = mkdtempSync(path.join(process.env.RUNNER_TEMP || tmpdir(), "remnic-smoke-"));
+
+console.log(`[cli-smoke] empty working directory: ${smokeDir}`);
+for (const args of [["--help"], ["doctor"]]) {
+  console.log(`[cli-smoke] running: remnic ${args.join(" ")}`);
+  execFileSync(process.execPath, [cliBin, ...args], { cwd: smokeDir, stdio: "inherit" });
+}
+console.log("[cli-smoke] OK — remnic --help and remnic doctor both exited 0");

--- a/scripts/windows-skip-list.json
+++ b/scripts/windows-skip-list.json
@@ -1,0 +1,4 @@
+{
+  "note": "Test files excluded from the windows-smoke CI job (issue #3034). This list only ever SHRINKS: an entry is deleted when its Windows defect is fixed, and a new failure is fixed forward rather than added here. Every entry needs a real `issue` (\"#<number>\" or a github issue URL) and a one-line `reason`. Paths are repo-relative posix paths and must exist — a stale entry fails the job instead of silently covering nothing. Never suppress a Windows failure inline (`|| true`, `continue-on-error`); a skip must be named here so the job log states what was not covered.",
+  "skips": []
+}

--- a/scripts/windows-test-runner.mjs
+++ b/scripts/windows-test-runner.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * Windows CI test runner (issue #3034).
+ *
+ * Runs the `@remnic/core` unit suite on windows-latest, minus the files named
+ * in scripts/windows-skip-list.json, and prints every skip by name so the job
+ * log always states what was not covered.
+ *
+ * The skip list only ever SHRINKS. A Windows failure is fixed forward; it is
+ * never silenced with `|| true` or `continue-on-error`. A skip must be a named,
+ * issue-linked entry here or the suite fails. A listed path that no longer
+ * exists is an error too, so a rename cannot turn an entry into dead weight
+ * that quietly covers nothing.
+ *
+ * Node builtins only, plus the repo's existing root-test-runner helpers.
+ */
+import { spawn } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { appendNodeOption } from "./root-test-runner-env.mjs";
+import { chunkArgsByLength, parseTapSummary } from "./root-test-runner-lib.mjs";
+
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const SKIP_LIST_PATH = path.join(REPO_ROOT, "scripts", "windows-skip-list.json");
+
+/** Suite under test: the `@remnic/core` unit tests, as posix repo-relative paths. */
+export const CORE_TEST_DIR = "packages/remnic-core/src";
+
+/** `#123` or a full github issue URL. Anchored, no nested quantifiers. */
+const ISSUE_REF_RE =
+  /^(?:#[0-9]{1,9}|https:\/\/github\.com\/[A-Za-z0-9._-]{1,64}\/[A-Za-z0-9._-]{1,64}\/issues\/[0-9]{1,9})$/;
+
+/** Windows builds one bounded command line per spawn, so file lists are chunked. */
+const ARGV_CHAR_BUDGET = 6000;
+
+function requireOneLine(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} is required and must be a non-empty string`);
+  }
+  if (value.includes("\n") || value.includes("\r")) {
+    throw new Error(`${label} must be a single line`);
+  }
+  return value.trim();
+}
+
+/**
+ * Validate the parsed skip-list document into a list of `{file, issue, reason}`.
+ * Every rejection is an explicit throw — an unrecognized shape is never
+ * reinterpreted as "no skips".
+ */
+export function parseSkipList(raw) {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("windows-skip-list.json must contain a JSON object");
+  }
+  const { skips } = raw;
+  if (!Array.isArray(skips)) {
+    throw new Error('windows-skip-list.json: "skips" must be an array');
+  }
+  const seen = new Set();
+  return skips.map((entry, index) => {
+    const where = `windows-skip-list.json: skips[${index}]`;
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`${where} must be an object`);
+    }
+    const file = requireOneLine(entry.file, `${where}.file`);
+    const issue = requireOneLine(entry.issue, `${where}.issue`);
+    const reason = requireOneLine(entry.reason, `${where}.reason`);
+    if (!ISSUE_REF_RE.test(issue)) {
+      throw new Error(`${where}.issue must be "#<number>" or a github issue URL, got "${issue}"`);
+    }
+    if (file.includes("\\") || file.startsWith("/") || file.split("/").includes("..")) {
+      throw new Error(`${where}.file must be a repo-relative posix path, got "${file}"`);
+    }
+    if (seen.has(file)) {
+      throw new Error(`${where}.file duplicates an earlier entry: ${file}`);
+    }
+    seen.add(file);
+    return { file, issue, reason };
+  });
+}
+
+/** Every `@remnic/core` test file, as sorted posix repo-relative paths. */
+export function collectCoreTestFiles(repoRoot = REPO_ROOT) {
+  const base = path.join(repoRoot, ...CORE_TEST_DIR.split("/"));
+  return readdirSync(base, { recursive: true })
+    .map((entry) => entry.split(path.sep).join("/"))
+    .filter((entry) => entry.endsWith(".test.ts"))
+    .map((entry) => `${CORE_TEST_DIR}/${entry}`)
+    .sort();
+}
+
+/**
+ * Split `files` against the skip list.
+ * `stale` holds entries whose file is absent — reported, never ignored.
+ */
+export function partitionSkipped(files, entries) {
+  const present = new Set(files);
+  const skipped = [];
+  const stale = [];
+  for (const entry of entries) {
+    if (present.has(entry.file)) skipped.push(entry);
+    else stale.push(entry);
+  }
+  const skippedFiles = new Set(skipped.map((entry) => entry.file));
+  return { run: files.filter((file) => !skippedFiles.has(file)), skipped, stale };
+}
+
+/** Log lines naming every skipped file. Printed even when the list is empty. */
+export function formatSkipReport(skipped) {
+  if (skipped.length === 0) {
+    return ["[windows-tests] skip list is empty — every @remnic/core test file runs."];
+  }
+  return [
+    `[windows-tests] SKIPPING ${skipped.length} test file(s) per scripts/windows-skip-list.json:`,
+    ...skipped.map((entry) => `[windows-tests]   [SKIP] ${entry.file} — ${entry.reason} (${entry.issue})`),
+    "[windows-tests] this list only shrinks: fix the defect, then delete the entry.",
+  ];
+}
+
+/** Run one `node --import tsx --test` invocation, streaming output. */
+function runNodeTest(files, env) {
+  return new Promise((resolve) => {
+    // Spawn the node executable directly: on Windows a `.cmd` shim cannot be
+    // spawned without a shell, and going through one would re-quote paths.
+    const child = spawn(process.execPath, ["--import", "tsx", "--test", ...files], {
+      cwd: REPO_ROOT,
+      env,
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+
+    const TAIL_LIMIT = 64 * 1024;
+    let tail = "";
+    child.stdout.on("data", (chunk) => {
+      process.stdout.write(chunk);
+      tail = (tail + chunk.toString("utf-8")).slice(-TAIL_LIMIT);
+    });
+
+    child.on("error", (error) => {
+      console.error(`[windows-tests] ERROR: failed to launch node --test: ${error.message}`);
+      resolve({ status: 1, summary: null });
+    });
+
+    child.on("close", (status) => {
+      resolve({ status: status ?? 1, summary: parseTapSummary(tail) });
+    });
+  });
+}
+
+async function main() {
+  let entries;
+  try {
+    entries = parseSkipList(JSON.parse(readFileSync(SKIP_LIST_PATH, "utf8")));
+  } catch (error) {
+    console.error(`[windows-tests] ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  const files = collectCoreTestFiles();
+  if (files.length === 0) {
+    console.error(
+      `[windows-tests] ERROR: no *.test.ts files under ${CORE_TEST_DIR} — coverage would be silently lost.`
+    );
+    process.exit(1);
+  }
+
+  const { run, skipped, stale } = partitionSkipped(files, entries);
+  if (stale.length > 0) {
+    console.error(
+      "[windows-tests] ERROR: scripts/windows-skip-list.json lists files that no longer exist — delete or correct these entries:"
+    );
+    for (const entry of stale) {
+      console.error(`[windows-tests]   [STALE] ${entry.file} (${entry.issue})`);
+    }
+    process.exit(1);
+  }
+
+  for (const line of formatSkipReport(skipped)) console.warn(line);
+
+  if (run.length === 0) {
+    console.error("[windows-tests] ERROR: every test file is skipped — the job would prove nothing.");
+    process.exit(1);
+  }
+  console.warn(`[windows-tests] running ${run.length}/${files.length} @remnic/core test file(s)`);
+
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: appendNodeOption(process.env.NODE_OPTIONS, "--conditions=remnic-source"),
+  };
+
+  const chunks = chunkArgsByLength(run, ARGV_CHAR_BUDGET);
+  let totalFail = 0;
+  let worstStatus = 0;
+  for (const [index, chunk] of chunks.entries()) {
+    console.warn(`[windows-tests] chunk ${index + 1}/${chunks.length} (${chunk.length} file(s))`);
+    const { status, summary } = await runNodeTest(chunk, env);
+    if (summary === null) {
+      console.error("[windows-tests] ERROR: no TAP summary in test output — treating as failure.");
+      process.exit(status === 0 ? 1 : status);
+    }
+    totalFail += summary.fail;
+    if (status !== 0) worstStatus = status;
+  }
+
+  if (totalFail > 0 && worstStatus === 0) {
+    console.error(
+      `[windows-tests] ERROR: runner exited 0 but TAP reports ${totalFail} failing test(s) — failing the run.`
+    );
+    process.exit(1);
+  }
+  process.exit(worstStatus);
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && pathToFileURL(path.resolve(invokedPath)).href === import.meta.url) {
+  await main();
+}

--- a/tests/windows-test-runner.test.mjs
+++ b/tests/windows-test-runner.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  SKIP_LIST_PATH,
+  collectCoreTestFiles,
+  formatSkipReport,
+  parseSkipList,
+  partitionSkipped,
+} from "../scripts/windows-test-runner.mjs";
+
+const ENTRY = {
+  file: "packages/remnic-core/src/example.test.ts",
+  issue: "#3034",
+  reason: "native binding not built on windows yet",
+};
+
+test("the shipped skip list parses and every entry names a real file", () => {
+  const entries = parseSkipList(JSON.parse(readFileSync(SKIP_LIST_PATH, "utf8")));
+  const { stale } = partitionSkipped(collectCoreTestFiles(), entries);
+  assert.deepEqual(
+    stale,
+    [],
+    `scripts/windows-skip-list.json lists missing files: ${stale.map((e) => e.file).join(", ")}`
+  );
+});
+
+test("an empty skip list skips nothing", () => {
+  const files = ["packages/remnic-core/src/a.test.ts", "packages/remnic-core/src/b.test.ts"];
+  const { run, skipped, stale } = partitionSkipped(files, parseSkipList({ skips: [] }));
+  assert.deepEqual(run, files);
+  assert.deepEqual(skipped, []);
+  assert.deepEqual(stale, []);
+  assert.match(formatSkipReport(skipped).join("\n"), /skip list is empty/);
+});
+
+test("a listed file is skipped and printed by name", () => {
+  const files = [ENTRY.file, "packages/remnic-core/src/other.test.ts"];
+  const { run, skipped, stale } = partitionSkipped(files, parseSkipList({ skips: [ENTRY] }));
+  assert.deepEqual(run, ["packages/remnic-core/src/other.test.ts"]);
+  assert.deepEqual(skipped, [ENTRY]);
+  assert.deepEqual(stale, []);
+
+  const report = formatSkipReport(skipped).join("\n");
+  assert.ok(report.includes(ENTRY.file), "skip report must name the skipped file");
+  assert.ok(report.includes(ENTRY.reason), "skip report must state the reason");
+  assert.ok(report.includes(ENTRY.issue), "skip report must cite the issue");
+});
+
+test("an entry missing issue or reason is rejected", () => {
+  const { issue: _issue, ...noIssue } = ENTRY;
+  const { reason: _reason, ...noReason } = ENTRY;
+  assert.throws(() => parseSkipList({ skips: [noIssue] }), /skips\[0\]\.issue is required/);
+  assert.throws(() => parseSkipList({ skips: [noReason] }), /skips\[0\]\.reason is required/);
+  assert.throws(() => parseSkipList({ skips: [{ ...ENTRY, file: "" }] }), /file is required/);
+  assert.throws(
+    () => parseSkipList({ skips: [{ ...ENTRY, issue: "someday" }] }),
+    /must be "#<number>" or a github issue URL/
+  );
+  assert.throws(() => parseSkipList({ skips: [ENTRY, { ...ENTRY }] }), /duplicates an earlier entry/);
+  assert.throws(() => parseSkipList({ skips: {} }), /"skips" must be an array/);
+  assert.throws(() => parseSkipList([]), /must contain a JSON object/);
+});
+
+test("a listed path that no longer exists is reported, not ignored", () => {
+  const { run, skipped, stale } = partitionSkipped(
+    ["packages/remnic-core/src/other.test.ts"],
+    parseSkipList({ skips: [ENTRY] })
+  );
+  assert.deepEqual(stale, [ENTRY]);
+  assert.deepEqual(skipped, []);
+  assert.deepEqual(run, ["packages/remnic-core/src/other.test.ts"]);
+});
+
+test("collectCoreTestFiles returns sorted posix repo-relative test paths", () => {
+  const files = collectCoreTestFiles();
+  assert.ok(files.length > 0, "the core suite must not be empty");
+  for (const file of files) {
+    assert.ok(file.startsWith("packages/remnic-core/src/"), file);
+    assert.ok(file.endsWith(".test.ts"), file);
+    assert.ok(!file.includes("\\"), `path must be posix: ${file}`);
+  }
+  assert.deepEqual(files, [...files].sort());
+});


### PR DESCRIPTION
Fixes #3034

Every gate in `ci.yml` ran on Linux, so Windows regressions — path separators, tilde expansion, spawn semantics — were only reachable by users after a release.

## What this adds

A standalone `windows-smoke` job: pinned-wrapper install, `@remnic/core` and `@remnic/cli` builds, a CLI smoke asserting `remnic --help` and `remnic doctor` exit 0 from an empty runner temp directory, then the `@remnic/core` unit suite.

Supporting files:

| File | Purpose |
| --- | --- |
| `scripts/windows-cli-smoke.mjs` | Creates its own temp dir under `RUNNER_TEMP` and asserts both CLI entrypoints exit 0 |
| `scripts/windows-test-runner.mjs` | Runs the core suite minus the skip list, printing every skip by name |
| `scripts/windows-skip-list.json` | Named-skip registry, currently **empty** |
| `tests/windows-test-runner.test.mjs` | 6 tests over the runner's selection and skip-validation logic |

## Deliberate choices

- **Standard `windows-latest` only.** Standard GitHub-hosted runners are free and unmetered for public repositories; "larger runner" labels are billed even on public repos. The job carries a comment forbidding that swap.
- **A separate job, not a `tests` matrix row.** The `tests` job's `runs-on` expression selects the self-hosted Linux pool on trusted main pushes; entangling Windows with it would break that selection.
- **Not in the `quality` aggregator's `needs`.** The job is non-required until a green streak is observed. Promotion is a one-line follow-up.
- **`shell: bash`.** git-bash ships on the image and keeps `set -euo pipefail` and exit-code propagation identical to every other job here; PowerShell's error handling can leave a failing command passing.
- **No inline suppression.** No `|| true`, no `continue-on-error` — a Windows failure is fixed forward or named in the skip list with an issue link. The list only ever shrinks, and a stale entry fails the job rather than silently covering nothing.
- **CLI built before the smoke.** A published install runs `bin/remnic.cjs` against `dist/index.js`; without the build the wrapper falls back to the tsx source entry, a dev-only path that cannot launch on Windows at all — filed separately as #3038.

## Verification

```
$ node --test tests/windows-test-runner.test.mjs
# tests 6
# pass 6
# fail 0
```

Workflow parsed and asserted: `runs-on: windows-latest`, `shell: bash`, `windows-smoke` absent from `quality.needs`, no `continue-on-error` in the file.

The Windows job itself first executes on this PR — that run is the real acceptance evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Windows smoke testing for the CLI, including help and diagnostics commands from a clean directory.
  * Added Windows test execution with skip-list validation, test discovery, reporting, and failure detection.
  * Added coverage for skip-list parsing, stale entries, path handling, and test-file discovery.
* **Chores**
  * Added automated Windows CI coverage to improve cross-platform reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->