### PR TITLE
chore(release): alpha/beta/stable channels with a flag graduation registry (#3032)

### DIFF
--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -170,33 +170,4 @@ jobs:
               return;
             }
 
-            core.notice('CHANGELOG.md edited directly in a release section; changelog guard passed.');
-
-      # Release-discipline gate (issue #3032). Deliberately runs the BASE
-      # checkout's copy of the script: this workflow is `pull_request_target`,
-      # so head-branch code must never execute here. The head tree is read as
-      # git DATA only (`git show <ref>:<path>`), never run. A change to the
-      # gate itself therefore takes effect after it merges.
-      - name: Checkout base for the release-discipline gate
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Fetch the pull-request head as data
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags --quiet origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pr/head"
-          git merge-base refs/remotes/pr/head HEAD >/dev/null
-
-      - name: "Release discipline (issue #3032)"
-        run: |
-          set -euo pipefail
-          BASE_SHA="$(git merge-base refs/remotes/pr/head HEAD)"
-          echo "release-discipline: base=${BASE_SHA} head=$(git rev-parse refs/remotes/pr/head)"
-          node scripts/check-release-discipline.mjs \
-            --base "${BASE_SHA}" \
-            --head refs/remotes/pr/head
+            core.notice('CHANGELOG.md edited directly in a release section; changelog guard passed.')

--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -171,3 +171,32 @@ jobs:
             }
 
             core.notice('CHANGELOG.md edited directly in a release section; changelog guard passed.');
+
+      # Release-discipline gate (issue #3032). Deliberately runs the BASE
+      # checkout's copy of the script: this workflow is `pull_request_target`,
+      # so head-branch code must never execute here. The head tree is read as
+      # git DATA only (`git show <ref>:<path>`), never run. A change to the
+      # gate itself therefore takes effect after it merges.
+      - name: Checkout base for the release-discipline gate
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch the pull-request head as data
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pr/head"
+          git merge-base refs/remotes/pr/head HEAD >/dev/null
+
+      - name: "Release discipline (issue #3032)"
+        run: |
+          set -euo pipefail
+          BASE_SHA="$(git merge-base refs/remotes/pr/head HEAD)"
+          echo "release-discipline: base=${BASE_SHA} head=$(git rev-parse refs/remotes/pr/head)"
+          node scripts/check-release-discipline.mjs \
+            --base "${BASE_SHA}" \
+            --head refs/remotes/pr/head

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -623,7 +623,11 @@ jobs:
             fi
             echo "Publishing ${pkg_name}@${pkg_version} from ${pkg_dir}..."
             publish_log="$(mktemp)"
-            if (cd "$pkg_dir" && pnpm publish --access public --provenance --no-git-checks) >"$publish_log" 2>&1; then
+            # Every merge to main publishes to the `alpha` dist-tag (issue
+            # #3032). `beta` and `latest` are dist-tag MOVES performed by
+            # release-promote.yml against this same byte-identical tarball —
+            # promotion never rebuilds or republishes. See docs/releases.md.
+            if (cd "$pkg_dir" && pnpm publish --access public --provenance --no-git-checks --tag alpha) >"$publish_log" 2>&1; then
               cat "$publish_log"
               rm -f "$publish_log"
               continue
@@ -667,7 +671,8 @@ jobs:
             echo "::notice title=NPM publish skipped::${PACKAGE_NAME}@${VERSION} is already published."
             exit 0
           fi
-          npm publish --access public --provenance
+          # Publish to the `alpha` channel; promotion moves the tag (issue #3032).
+          npm publish --access public --provenance --tag alpha
 
       # Publish the GitHub release BEFORE the best-effort ClawHub publish below.
       # ClawHub is a third-party host whose backend can fail transiently (e.g.

--- a/.github/workflows/release-discipline.yml
+++ b/.github/workflows/release-discipline.yml
@@ -1,0 +1,42 @@
+# Release-discipline gate (issue #3032).
+#
+# Enforces changeset stability declarations and config-flag graduation
+# discipline on every PR. Runs as a standard pull_request workflow (not
+# pull_request_target), so it can safely check out the head branch.
+name: Release Discipline
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.changeset/**'
+      - 'packages/**/src/**'
+      - 'scripts/flag-graduation.json'
+      - 'scripts/check-release-discipline.mjs'
+      - 'scripts/changeset-stub.mjs'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release-discipline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: node scripts/pnpm.mjs install --frozen-lockfile
+
+      - name: "Release discipline (issue #3032)"
+        run: node scripts/check-release-discipline.mjs

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,363 @@
+name: Release Promote
+
+# Channel promotion (issue #3032). A promotion is a dist-tag MOVE against an
+# already-published, byte-identical version: nothing is rebuilt, re-packed, or
+# republished here. `alpha` is produced by release-and-publish.yml on every
+# merge to main; this workflow moves `beta` and `latest` (stable) onto a version
+# that already soaked as alpha. See docs/releases.md for the cut rules.
+#
+# GitHub lookups use REST (`gh api repos/...`) only — the GraphQL points budget
+# is shared with interactive work and is not spent by release automation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published version to promote, exactly X.Y.Z (no leading v).'
+        required: true
+        type: string
+      channel:
+        description: 'Channel to move onto that version.'
+        required: true
+        type: choice
+        options:
+          - beta
+          - stable
+      hotfix:
+        description: 'Fast-track a fix for a defect in current stable (waives the stable soak window). Recorded in the run.'
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: 'Verify every criterion and print the planned dist-tag moves without performing them.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VERSION: ${{ inputs.version }}
+      CHANNEL: ${{ inputs.channel }}
+      HOTFIX: ${{ inputs.hotfix }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      # Minimum days a version must sit on `beta` before it may become stable.
+      STABLE_SOAK_DAYS: '7'
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      # Validate the exact strings the caller supplied. Nothing is trimmed,
+      # case-folded, or otherwise normalized before the check: a value that is
+      # not already exactly right is rejected rather than reinterpreted.
+      - name: Validate inputs
+        run: |
+          set -euo pipefail
+          case "${VERSION}" in
+            *[!0-9.]*|*..*|.*|*.) echo "::error title=Invalid version::'${VERSION}' must be exactly X.Y.Z with no leading v."; exit 1 ;;
+          esac
+          if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Invalid version::'${VERSION}' must be exactly X.Y.Z with no leading v."
+            exit 1
+          fi
+          case "${CHANNEL}" in
+            beta) DIST_TAG=beta ;;
+            stable) DIST_TAG=latest ;;
+            *) echo "::error title=Invalid channel::'${CHANNEL}' must be beta or stable."; exit 1 ;;
+          esac
+          case "${HOTFIX}" in true|false) ;; *) echo "::error title=Invalid hotfix::'${HOTFIX}' must be true or false."; exit 1 ;; esac
+          case "${DRY_RUN}" in true|false) ;; *) echo "::error title=Invalid dry_run::'${DRY_RUN}' must be true or false."; exit 1 ;; esac
+          echo "DIST_TAG=${DIST_TAG}" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=v${VERSION}" >> "$GITHUB_ENV"
+          echo "Promoting ${VERSION} to ${CHANNEL} (dist-tag ${DIST_TAG}); hotfix=${HOTFIX}; dry_run=${DRY_RUN}"
+
+      - name: Checkout the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      # A dist-tag move is an authenticated registry write. npm trusted
+      # publishing mints credentials for `npm publish` only, so promotion needs
+      # a granular automation token with publish rights on the @remnic scope.
+      # Missing token = loud failure, never a silent no-op.
+      - name: Require an npm automation token
+        if: inputs.dry_run == false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error title=Missing NPM_TOKEN::Set the NPM_TOKEN repository secret to an npm automation token with publish rights on the @remnic scope. Promotion moves dist-tags, which trusted publishing cannot authorize."
+            exit 1
+          fi
+
+      - name: Resolve the release commit
+        run: |
+          set -euo pipefail
+          REF_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}")"
+          OBJECT_TYPE="$(printf '%s' "${REF_JSON}" | jq -r '.object.type')"
+          OBJECT_SHA="$(printf '%s' "${REF_JSON}" | jq -r '.object.sha')"
+          if [ "${OBJECT_TYPE}" = "tag" ]; then
+            OBJECT_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${OBJECT_SHA}" -q '.object.sha')"
+          fi
+          if ! printf '%s' "${OBJECT_SHA}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error title=Unresolved release tag::${RELEASE_TAG} did not resolve to a commit SHA."
+            exit 1
+          fi
+          echo "RELEASE_SHA=${OBJECT_SHA}" >> "$GITHUB_ENV"
+          echo "${RELEASE_TAG} -> ${OBJECT_SHA}"
+
+      # Cut rule: the target version's CI must be green. Rulesets evaluate the
+      # LATEST check-run per context, so group by name and keep the newest
+      # completed_at (AGENTS.md, CI review-gate scheduling note 6). Zero
+      # check-runs is a failure, not a pass.
+      - name: Verify CI is green on the release commit
+        run: |
+          set -euo pipefail
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/check-runs" \
+            --jq '.check_runs[] | {name, status, conclusion, completed_at}' > check-runs.jsonl
+          TOTAL="$(wc -l < check-runs.jsonl)"
+          if [ "${TOTAL}" -eq 0 ]; then
+            echo "::error title=No CI evidence::No check-runs exist for ${RELEASE_SHA}; refusing to promote."
+            exit 1
+          fi
+          jq -s '
+            group_by(.name)
+            | map(sort_by(.completed_at // "") | last)
+            | map(select((.conclusion // "pending") as $c
+                | ["failure","cancelled","timed_out","action_required","stale","pending"]
+                | index($c)))
+            | map(.name + ": " + (.conclusion // "pending"))
+          ' check-runs.jsonl > blocking.json
+          if [ "$(jq 'length' blocking.json)" -ne 0 ]; then
+            echo "::error title=CI not green::$(jq -r 'join("; ")' blocking.json)"
+            exit 1
+          fi
+          echo "CI green on ${RELEASE_SHA} (${TOTAL} check-run record(s), $(jq -s 'group_by(.name) | length' check-runs.jsonl) context(s))."
+
+      # Cut rule: a stable promotion requires the version to have soaked at
+      # least STABLE_SOAK_DAYS days since it was published as alpha. The clock
+      # comes from the registry's own publish timestamp, not from git.
+      - name: Verify soak age
+        run: |
+          set -euo pipefail
+          PUBLISHED_AT="$(npm view "@remnic/core" time --json | jq -r --arg v "${VERSION}" '.[$v] // empty')"
+          if [ -z "${PUBLISHED_AT}" ]; then
+            echo "::error title=Version not published::@remnic/core@${VERSION} is not on npm; only published versions can be promoted."
+            exit 1
+          fi
+          PUBLISHED_EPOCH="$(date -u -d "${PUBLISHED_AT}" +%s)"
+          case "${PUBLISHED_EPOCH}" in
+            ''|*[!0-9]*) echo "::error title=Unparseable publish time::'${PUBLISHED_AT}' did not parse to an epoch."; exit 1 ;;
+          esac
+          NOW_EPOCH="$(date -u +%s)"
+          AGE_DAYS=$(( (NOW_EPOCH - PUBLISHED_EPOCH) / 86400 ))
+          echo "PUBLISHED_AT=${PUBLISHED_AT}" >> "$GITHUB_ENV"
+          echo "AGE_DAYS=${AGE_DAYS}" >> "$GITHUB_ENV"
+          echo "@remnic/core@${VERSION} published ${PUBLISHED_AT} (${AGE_DAYS} day(s) ago)."
+          if [ "${CHANNEL}" != "stable" ]; then
+            exit 0
+          fi
+          if [ "${HOTFIX}" = "true" ]; then
+            echo "::warning title=Soak waived::hotfix=true fast-tracks ${VERSION} to stable after ${AGE_DAYS} day(s)."
+            exit 0
+          fi
+          if [ "${AGE_DAYS}" -lt "${STABLE_SOAK_DAYS}" ]; then
+            echo "::error title=Soak too short::${VERSION} has soaked ${AGE_DAYS} day(s); stable requires ${STABLE_SOAK_DAYS}. Re-run with hotfix=true only for a defect in current stable."
+            exit 1
+          fi
+
+      # Cut rule: no OPEN issue labeled `regression` filed against any release
+      # in the range (previous channel version, target]. With no previous
+      # channel version the range is unbounded, so every open regression issue
+      # blocks — the conservative direction.
+      - name: Verify no open regression issues in range
+        run: |
+          set -euo pipefail
+          # `dist-tags --json` exits 0 whether or not the tag exists, so an
+          # absent tag reads as empty while a real registry error still fails.
+          PREVIOUS="$(npm view "@remnic/core" dist-tags --json | jq -r --arg t "${DIST_TAG}" '.[$t] // empty')"
+          RANGE_START=''
+          if [ -n "${PREVIOUS}" ]; then
+            RANGE_START="$(npm view "@remnic/core" time --json | jq -r --arg v "${PREVIOUS}" '.[$v] // empty')"
+          fi
+          if [ -n "${RANGE_START}" ]; then
+            echo "Range: open regression issues filed after ${RANGE_START} (${DIST_TAG} currently at ${PREVIOUS})."
+          else
+            echo "::notice title=Unbounded range::No previous ${DIST_TAG} version resolved; every open regression issue blocks this promotion."
+          fi
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/issues?state=open&labels=regression&per_page=100" \
+            --jq '.[] | select(.pull_request == null) | {number, created_at, title}' > regressions.jsonl
+          if [ ! -s regressions.jsonl ]; then
+            echo "No open regression issues."
+            exit 0
+          fi
+          # No upper bound: a regression against a release in this range can be
+          # filed at any later time, and it must still block the promotion.
+          jq -s --arg start "${RANGE_START}" '
+            map(select($start == "" or .created_at >= $start))
+            | map("#" + (.number | tostring) + " " + .title)
+          ' regressions.jsonl > blocking-issues.json
+          COUNT="$(jq 'length' blocking-issues.json)"
+          if [ "${COUNT}" -ne 0 ]; then
+            echo "::error title=Open regression issues::${COUNT} open regression issue(s) in range: $(jq -r 'join("; ")' blocking-issues.json)"
+            exit 1
+          fi
+          echo "Open regression issues exist, but none in range."
+
+      - name: Generate workspace package publish order
+        run: node scripts/publish-order.mjs --repo-root "$PWD" --output "${RUNNER_TEMP}/remnic-publish-order.txt"
+
+      # All-or-nothing precheck: every public package in PUBLISH_ORDER must
+      # already exist on npm at this exact version before a single tag moves.
+      # A missing package is the same operator-actionable publish gap the
+      # release workflow already fails on, so it aborts here too.
+      - name: Plan the dist-tag moves
+        run: |
+          set -euo pipefail
+          mapfile -t PUBLISH_ORDER < "${RUNNER_TEMP}/remnic-publish-order.txt"
+          : > "${RUNNER_TEMP}/promote-plan.tsv"
+          MISSING=()
+          plan_package() {
+            local pkg_json="$1"
+            if [ ! -f "${pkg_json}" ]; then
+              return 0
+            fi
+            if [ "$(node -p "require('./${pkg_json}').private || false")" = "true" ]; then
+              return 0
+            fi
+            local name
+            local pkg_version
+            name="$(node -p "require('./${pkg_json}').name")"
+            pkg_version="$(node -p "require('./${pkg_json}').version")"
+            if [ "${pkg_version}" != "${VERSION}" ]; then
+              echo "::error title=Version mismatch::${name} at ${RELEASE_TAG} is ${pkg_version}, not ${VERSION}."
+              exit 1
+            fi
+            if ! npm view "${name}@${VERSION}" version >/dev/null 2>&1; then
+              MISSING+=("${name}@${VERSION}")
+              return 0
+            fi
+            local current
+            current="$(npm view "${name}" dist-tags --json | jq -r --arg t "${DIST_TAG}" '.[$t] // empty')"
+            printf '%s\t%s\n' "${name}" "${current:-<unset>}" >> "${RUNNER_TEMP}/promote-plan.tsv"
+          }
+
+          plan_package "package.json"
+          for pkg_dir in "${PUBLISH_ORDER[@]}"; do
+            plan_package "${pkg_dir}/package.json"
+          done
+
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            {
+              echo "## Promotion aborted: packages missing at ${VERSION}"
+              echo ""
+              for entry in "${MISSING[@]}"; do echo "- \`${entry}\`"; done
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Incomplete release::${#MISSING[@]} package(s) are not published at ${VERSION}; no dist-tag was moved."
+            exit 1
+          fi
+
+          PLANNED="$(wc -l < "${RUNNER_TEMP}/promote-plan.tsv")"
+          if [ "${PLANNED}" -eq 0 ]; then
+            echo "::error title=Nothing to promote::PUBLISH_ORDER produced no public packages."
+            exit 1
+          fi
+          {
+            echo "## Planned ${DIST_TAG} moves to ${VERSION}"
+            echo ""
+            echo "| Package | ${DIST_TAG} before |"
+            echo "|---|---|"
+            while IFS=$'\t' read -r name current; do
+              echo "| \`${name}\` | ${current} |"
+            done < "${RUNNER_TEMP}/promote-plan.tsv"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Planned ${PLANNED} dist-tag move(s)."
+
+      - name: Report dry run
+        if: inputs.dry_run == true
+        run: |
+          set -euo pipefail
+          echo "::notice title=Dry run::Every criterion passed. $(wc -l < "${RUNNER_TEMP}/promote-plan.tsv") dist-tag move(s) were planned and NOT performed."
+          {
+            echo ""
+            echo "**Dry run — no dist-tag was moved.**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Move every planned tag, then read the registry back for each one. A
+      # readback mismatch or a failed move aborts immediately and reports the
+      # exact restore commands for whatever already moved: the previous values
+      # were captured in the plan step.
+      - name: Move dist-tags
+        if: inputs.dry_run == false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          MOVED=()
+          abort() {
+            {
+              echo ""
+              echo "### Promotion aborted after ${#MOVED[@]} move(s)"
+              echo ""
+              if [ "${#MOVED[@]}" -gt 0 ]; then
+                echo "Restore the previous ${DIST_TAG} tags with:"
+                echo ""
+                echo '```bash'
+                for entry in "${MOVED[@]}"; do
+                  name="${entry%%$'\t'*}"
+                  previous="${entry##*$'\t'}"
+                  if [ "${previous}" = "<unset>" ]; then
+                    echo "npm dist-tag rm ${name} ${DIST_TAG}"
+                  else
+                    echo "npm dist-tag add ${name}@${previous} ${DIST_TAG}"
+                  fi
+                done
+                echo '```'
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          # Read the plan on FD 3: npm consumes stdin, which would swallow the
+          # remaining lines and silently promote only the first package.
+          while IFS=$'\t' read -r -u 3 name previous; do
+            echo "Moving ${DIST_TAG} -> ${name}@${VERSION} (was ${previous})"
+            if ! npm dist-tag add "${name}@${VERSION}" "${DIST_TAG}"; then
+              echo "::error title=Dist-tag move failed::${name}@${VERSION} ${DIST_TAG}"
+              abort
+            fi
+            MOVED+=("${name}"$'\t'"${previous}")
+            READBACK="$(npm dist-tag ls "${name}")"
+            if ! printf '%s\n' "${READBACK}" | grep -Fxq "${DIST_TAG}: ${VERSION}"; then
+              echo "::error title=Readback mismatch::${name} does not report ${DIST_TAG}: ${VERSION}."
+              printf '%s\n' "${READBACK}"
+              abort
+            fi
+          done 3< "${RUNNER_TEMP}/promote-plan.tsv"
+
+          {
+            echo ""
+            echo "### Promoted ${#MOVED[@]} package(s) to ${DIST_TAG} at ${VERSION}"
+            echo ""
+            echo "- channel: ${CHANNEL}"
+            echo "- hotfix: ${HOTFIX}"
+            echo "- soak: ${AGE_DAYS} day(s) since ${PUBLISHED_AT}"
+            echo "- release commit: ${RELEASE_SHA}"
+            echo "- no tarball was rebuilt or republished"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Promotion complete: ${#MOVED[@]} package(s) now resolve ${DIST_TAG} to ${VERSION}."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,9 +274,11 @@ rules that bind every PR:
    through `release-and-publish.yml` (alpha) and `release-promote.yml`
    (beta/stable).
 
-Rules 1-3 and registry/code symmetry are enforced by
-`scripts/check-release-discipline.mjs`, a step of the `changelog-guard`
-workflow. Run it locally with
+Enforced by `scripts/check-release-discipline.mjs`, a step of the
+`changelog-guard` workflow: rules 1 and 2, the flip-plus-registry-deletion
+symmetry in rule 3, and the requirement that the registry never outlives the
+code. The evidence link in rule 3 and the whole of rule 4 are review
+conventions — no check reads an agent's shell. Run the gate locally with
 `node scripts/check-release-discipline.mjs --base "$(git merge-base HEAD github/main)"`.
 
 ## Agent / automation contributors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,30 @@ These rules are the default workflow for all agents and contributors.
 
 Reference workflow:
 `docs/ops/pr-review-hardening-playbook.md`
+
+## Release channels (issue #3032)
+
+`main` publishes to the npm `alpha` dist-tag on every merge; `beta` and
+`latest` are dist-tag moves onto an already-published version.
+[docs/releases.md](docs/releases.md) is the canonical process — read it before
+adding a config flag, writing a changeset, or promoting a release. The four
+rules that bind every PR:
+
+1. A diff that changes published-package behavior needs a changeset with a
+   `Stability: alpha|beta|stable` line. Doc-only and CI-only diffs are exempt.
+2. Alpha/beta behavior ships default-off behind a flag registered in
+   `scripts/flag-graduation.json`. Stable work adds no default-off gate.
+3. Graduation is its own PR: flip the default, delete the registry entry, carry
+   `Stability: stable`, link the evidence.
+4. Never run `npm publish` or `npm dist-tag` by hand. Releases happen only
+   through `release-and-publish.yml` (alpha) and `release-promote.yml`
+   (beta/stable).
+
+Rules 1-3 and registry/code symmetry are enforced by
+`scripts/check-release-discipline.mjs`, a step of the `changelog-guard`
+workflow. Run it locally with
+`node scripts/check-release-discipline.mjs --base "$(git merge-base HEAD github/main)"`.
+
 ## Agent / automation contributors
 
 Use `scripts/dev-worktree.sh <worktree-path> <branch> [base]` to create an

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -2,7 +2,13 @@
 
 How Remnic versions and publishes its packages. Releases are automated by
 `.github/workflows/release-and-publish.yml` and driven by merged pull-request
-labels, not by a manual version-bump file. There is no Changesets step.
+labels, not by a manual version-bump file. There is no Changesets step: a
+changeset records the change's stability level for review and promotion (see
+[../releases.md](../releases.md)), and never drives the version.
+
+Every merge publishes to the npm `alpha` dist-tag. `beta` and `latest` are
+dist-tag moves performed by `release-promote.yml` — see
+[../releases.md](../releases.md) for the channel model and cut rules.
 
 ## How a release happens
 
@@ -36,8 +42,9 @@ commit's source SHA is embedded in the git tag, so re-running against the same
    optionalDependencies, and required peerDependencies (optional peers are
    excluded). The order is written to a temp file the publish step reads.
 7. **Publish to npm.** Packages publish in that order with `pnpm publish`
-   (see below). npm 11.x is pinned so provenance / trusted-publishing behavior
-   only changes through review; all publishes carry provenance attestations.
+   (see below), onto the `alpha` dist-tag. npm 11.x is pinned so provenance /
+   trusted-publishing behavior only changes through review; all publishes carry
+   provenance attestations.
 8. **Rescan ClawHub.** After npm publishing, the workflow triggers a ClawHub
    package rescan for `@remnic/plugin-openclaw`.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,202 @@
+# Release channels
+
+Remnic publishes on three npm dist-tags. This document is the canonical process
+for all of them, and the binding rules below apply to every contributor, human
+or agent.
+
+For how a version is computed, tagged, and published in the first place, see
+[development/release-process.md](development/release-process.md). This document
+covers only channels and promotion.
+
+## The model
+
+| Channel | dist-tag | Install | Produced by |
+|---|---|---|---|
+| alpha | `alpha` | `npm install @remnic/core@alpha` | `release-and-publish.yml`, on every merge to `main` |
+| beta | `beta` | `npm install @remnic/core@beta` | `release-promote.yml`, dispatched |
+| stable | `latest` | `npm install @remnic/core` | `release-promote.yml`, dispatched |
+
+Two properties hold by construction:
+
+1. **A promotion is a dist-tag move, never a rebuild.** `release-promote.yml`
+   runs `npm dist-tag add <pkg>@<version> <tag>` and nothing else — no build, no
+   pack, no publish. The tarball that soaked as alpha is bit-for-bit the tarball
+   that becomes stable.
+2. **Every merge still publishes.** Nothing is held back. `main` publishes to
+   `alpha` exactly as it published to `latest` before; only the tag differs.
+
+### Prerequisite
+
+Promotion needs an `NPM_TOKEN` repository secret holding an npm automation
+token with publish rights on the `@remnic` scope. Publishing uses npm trusted
+publishing (OIDC), which mints credentials for `npm publish` only and cannot
+authorize a dist-tag move. Without that secret, `release-promote.yml` fails on
+its first step with a message saying so; it never silently no-ops.
+
+## Cut rules — when each channel gets a release
+
+| Channel | When | Criteria (checked by the promotion workflow where mechanical) |
+|---|---|---|
+| **alpha** | Automatically, every merge to `main` | Existing required checks green (unchanged from today) |
+| **beta** | Weekly cadence, or on demand | Target version's CI green; bench smoke suites green on that version; every changeset since the last beta has a valid `Stability:` line; no open issue labeled `regression` against any alpha in the range |
+| **stable** | When a beta qualifies, not on a clock | Beta soaked >= 7 days; zero `regression` issues filed against it; every `Stability: stable` change in range satisfied rule 3; no flag flipped default-on in range without its graduation PR (below) |
+| **hotfix** | A fix for a defect in current stable | May fast-track alpha -> stable same day; requires maintainer approval on the workflow run; `hotfix: true` recorded in the run |
+
+### What the machinery actually checks
+
+The table above is the decision the promoter makes. Only part of it is
+mechanical, and the split matters — do not read an automated guarantee into a
+row the workflow does not evaluate.
+
+`release-promote.yml` verifies, and refuses the promotion on failure:
+
+- the target version is an exact `X.Y.Z` string that resolves to a `vX.Y.Z` tag;
+- the latest check-run per context on that tag's commit is not failing, and at
+  least one check-run exists (zero CI evidence is a refusal, not a pass);
+- for `channel: stable`, the version has been on npm at least 7 days, unless
+  `hotfix: true` waives the window;
+- no open issue labeled `regression` was filed after the currently-tagged
+  version's publish time (with no previous tag, every open `regression` issue
+  blocks);
+- every public package in `PUBLISH_ORDER` exists on npm at that exact version
+  **before** any tag moves, and each move is read back with `npm dist-tag ls`.
+
+The promoter judges, with no automation behind it: bench smoke results, whether
+a `Stability: stable` change really satisfied rule 3, and whether a graduation
+PR accompanied each default flip. `dry_run: true` runs every mechanical check
+and prints the planned moves without performing them.
+
+"Maintainer approval" means dispatch permission: `release-promote.yml` is
+`workflow_dispatch`-only, so only someone with write access can start it. No
+separate environment-approval gate is configured.
+
+## Binding rules for contributors (human and agent) — MUST-level
+
+1. Every PR that changes published-package behavior MUST include a changeset with a `Stability:` line. Doc-only and CI-only diffs are exempt. Enforced by `check-release-discipline.mjs`.
+2. New alpha/beta behavior MUST be default-off behind a registered flag. Shipping experimental behavior default-on is a review-blocking defect, not a style issue.
+3. An agent MUST NOT run `npm publish`, `npm dist-tag`, or edit dist-tags by any other means. Releases happen only via `release-and-publish.yml` (alpha) and `release-promote.yml` (beta/stable).
+4. **Graduation is its own PR**: flips the default in `parseConfig`, deletes the flag's registry entry, carries `Stability: stable`, and links the evidence that the graduation criterion is met (bench run, soak record, issue). Enforced: the discipline script fails a default flip whose registry entry survives, and fails registry-entry deletion without the corresponding default flip.
+5. Breaking changes MUST be major changesets, land as alpha, and MUST NOT be promoted to stable in the same week they merge.
+6. When a flag is deleted outright, its registry entry is deleted in the same diff (the registry never outlives the code).
+
+Rules 3 and 5 are conventions, not gates: nothing in CI can see an agent's
+shell, and no check reads a merge date against a promotion date. Rules 1, 2, 4,
+and 6 are enforced by `scripts/check-release-discipline.mjs`, which runs as a
+step of the `changelog-guard` workflow on every non-draft pull request.
+
+## The changeset stability line
+
+A changeset body carries exactly one line:
+
+```markdown
+---
+"@remnic/core": minor
+---
+
+Add an opt-in write-path novelty gate. `noveltyGateEnabled` defaults to false.
+
+Stability: alpha
+```
+
+The line is validated as written. `Stability: alpha`, `Stability: beta`, and
+`Stability: stable` are the only accepted forms — `Stability:beta`,
+`Stability: Beta`, and a trailing space are each rejected rather than
+reinterpreted, so a typo fails loudly instead of routing your change to a
+channel you did not choose.
+
+Coupling, enforced:
+
+- `alpha` / `beta` requires that the diff either adds a new default-off gate or
+  names an already-registered flag in the changeset body.
+- `stable` must not add a new default-off gate.
+
+## The flag registry
+
+`scripts/flag-graduation.json` holds one entry per default-off boolean gate in
+`parseConfig`:
+
+```json
+{
+  "flag": "noveltyGateEnabled",
+  "addedIn": "9.70.0",
+  "issue": 1953,
+  "graduationCriterion": "Write-path novelty gate shows no dedup regression in the extraction suites for 2 consecutive stable releases."
+}
+```
+
+- `flag` — the config key, exactly as `parseConfig` reads it.
+- `addedIn` — the release the flag shipped in. Entries grandfathered when the
+  registry was created carry `<=9.69.55`, because this repository's clone
+  history does not reach their introducing commits.
+- `issue` — the tracking issue that owns the flag's graduation. Grandfathered
+  entries carry the registry bootstrap issue, for the same reason.
+- `graduationCriterion` — human-judged prose: what would have to be true for the
+  default to flip. Some entries read `UNDECIDED: candidate for removal`, which
+  means exactly that: the flag needs a criterion or it needs deleting.
+  Some read `Diagnostic or shadow-mode only: never graduates` — those flags are
+  meant to stay default-off until the diagnostic itself is retired.
+
+The registry is a grandfather list: it only shrinks. Nothing evaluates
+`graduationCriterion` — that is deliberate, and it is the freeze line on this
+machinery. A criterion is met when a human says it is, at promotion time.
+
+Detection has a documented limit: the gate finds default-off **boolean**
+signatures in `parseConfig` (`coerceBool(cfg.x) === true`,
+`coerceBooleanLike(cfg.x) ?? false`, `cfg.x === true`). A default-off *enum* — a
+string knob whose default is an inert value — is not detected automatically and
+must be registered by hand.
+
+## Worked example: graduating a flag
+
+`explicitCueRecallEnabled` has soaked as alpha behind a registered flag. The
+bench recall suites show no regression across two stable releases. One PR
+graduates it.
+
+**1. Flip the default** in `packages/remnic-core/src/config.ts`:
+
+```diff
+-    explicitCueRecallEnabled: coerceBool(cfg.explicitCueRecallEnabled) === true,
++    explicitCueRecallEnabled: coerceBool(cfg.explicitCueRecallEnabled) ?? true,
+```
+
+**2. Delete the registry entry** from `scripts/flag-graduation.json`:
+
+```diff
+-    {
+-      "flag": "explicitCueRecallEnabled",
+-      "addedIn": "<=9.69.55",
+-      "issue": 3032,
+-      "graduationCriterion": "Default-on in the published bench recall suites ..."
+-    },
+```
+
+**3. Write the changeset** with the evidence:
+
+```markdown
+---
+"@remnic/core": minor
+---
+
+Graduate explicit-cue recall to default-on. Bench recall suites (say-once,
+locomo) show no regression against the default path on v9.70.0 and v9.71.0:
+https://github.com/joshuaswarren/remnic/actions/runs/<run-id>. No open
+`regression` issue names the flag. Closes #<issue>.
+
+Stability: stable
+```
+
+**4. What the gate checks.** The flip removes the flag from the default-off set,
+so a surviving registry entry fails; the deletion is accepted only because the
+default flipped in the same diff; `Stability: stable` passes because no new
+default-off gate was added. Doing any one of the three without the others fails
+CI.
+
+Deleting the flag outright instead is the other legal shape: remove the config
+key, the code path, and the registry entry in one diff.
+
+## Bootstrapping the channels
+
+Until a version has been promoted, `beta` and `latest` still point where they
+pointed before this model landed, so `npm install @remnic/core` keeps resolving
+throughout. The first promotions move `beta` onto the current head version and
+`latest` onto the last known-good version.

--- a/scripts/check-release-discipline.mjs
+++ b/scripts/check-release-discipline.mjs
@@ -504,7 +504,7 @@ export function usage() {
 }
 
 function resolveBaseRef(git, headRef) {
-  for (const candidate of ["origin/main", "github/main", "main"]) {
+  for (const candidate of ["github/main", "origin/main", "main"]) {
     try {
       return git(["merge-base", headRef, candidate]).trim();
     } catch {

--- a/scripts/check-release-discipline.mjs
+++ b/scripts/check-release-discipline.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+/**
+ * Release-discipline gate (issue #3032).
+ *
+ * Every merge to `main` publishes to the `alpha` dist-tag; `beta` and `latest`
+ * are promotions of an already-published version (see docs/releases.md). This
+ * gate enforces the mechanical half of that model on a pull request's effective
+ * diff:
+ *
+ *   (a) Changeset stability — a diff that touches a PUBLISHED package must add
+ *       or modify a changeset carrying an exact `Stability: alpha|beta|stable`
+ *       line. Doc-only and CI-only diffs are exempt by path: package
+ *       attribution reuses `inferTouchedPackages` from changeset-stub.mjs, so
+ *       files that map to no published package (docs/, .github/, scripts/,
+ *       tests/, per-package README/AGENTS/CONTRIBUTING/CHANGELOG) require
+ *       nothing. A malformed `Stability:` line is always a violation.
+ *
+ *   (b) Flag registration — a default-off gate NEWLY added to `parseConfig`
+ *       must have an entry in scripts/flag-graduation.json at head.
+ *
+ *   (c) Stability/flag coupling — `Stability: alpha|beta` work must be
+ *       default-off behind a registered flag (the diff adds a new default-off
+ *       gate, or a changeset names an already-registered flag).
+ *       `Stability: stable` must not add a default-off gate.
+ *
+ *   (d) Graduation symmetry — a default FLIP (the gate stops being default-off
+ *       while the key survives in config.ts) whose registry entry still exists
+ *       is a violation, and deleting a registry entry whose flag is STILL
+ *       default-off is a violation. A registry entry whose flag no longer
+ *       appears in config.ts at all is a violation too (the registry never
+ *       outlives the code).
+ *
+ * The freeze line: this gate NEVER evaluates `graduationCriterion` prose.
+ * Whether a criterion is met is a human judgment made at promotion time. The
+ * machinery checks structure only, and stops here.
+ *
+ * Detection scope is honest about its limits: gate discovery is a static scan
+ * of the `parseConfig` body for the default-off BOOLEAN signatures listed in
+ * DEFAULT_OFF_PATTERNS. A default-off enum (a string-valued knob defaulting to
+ * an inert value) is not detected and must be registered by hand.
+ *
+ * Conventions match scripts/lifecycle-matrix/check-coverage.mjs: Node builtins
+ * only, effective-diff aware, git errors fail the gate loudly rather than
+ * passing vacuously.
+ *
+ * Usage:
+ *   node scripts/check-release-discipline.mjs [--repo-root <path>]
+ *                                            [--base <ref>] [--head <ref>]
+ *
+ * Exit codes: 0 = clean, 1 = violations, 2 = the gate could not run.
+ */
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { inferTouchedPackages } from "./changeset-stub.mjs";
+
+export const CONFIG_PATH = "packages/remnic-core/src/config.ts";
+export const REGISTRY_PATH = "scripts/flag-graduation.json";
+export const STABILITY_LEVELS = Object.freeze(["alpha", "beta", "stable"]);
+
+/** Registry entry fields. Every one is required; none may be empty. */
+const REGISTRY_FIELDS = Object.freeze(["flag", "addedIn", "issue", "graduationCriterion"]);
+
+/** A config key is a plain JS identifier; anything else is a registry error. */
+const FLAG_NAME_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Default-off gate signatures inside the `parseConfig` body. Each pattern
+ * captures the assigned config key. Quantifiers stay bounded to a single line
+ * and never nest (see scripts/check-regex-safety.mjs).
+ */
+const DEFAULT_OFF_PATTERNS = Object.freeze([
+  // foo: coerceBool(cfg.foo) === true,
+  /^\s*([A-Za-z_$][A-Za-z0-9_$]*):\s*coerceBool(?:eanLike)?\([^\n]*\)\s*===\s*true\s*,?\s*$/,
+  // foo: coerceBooleanLike(cfg.foo) ?? false,
+  /^\s*([A-Za-z_$][A-Za-z0-9_$]*):\s*coerceBool(?:eanLike)?\([^\n]*\)\s*\?\?\s*false\s*,?\s*$/,
+  // foo: cfg.foo === true,
+  /^\s*([A-Za-z_$][A-Za-z0-9_$]*):\s*cfg\.[A-Za-z0-9_$]+\s*===\s*true\s*,?\s*$/,
+]);
+
+const PARSE_CONFIG_OPENER = "export function parseConfig(";
+
+/** A changeset file the gate reads. `.changeset/README.md` is not one. */
+export function isChangesetFile(filePath) {
+  return /^\.changeset\/[^/]+\.md$/.test(filePath) && filePath !== ".changeset/README.md";
+}
+
+/**
+ * Default-off boolean gates declared in the `parseConfig` body, sorted.
+ * Throws when `parseConfig` cannot be located: a silent empty result would let
+ * every flag rule pass vacuously.
+ */
+export function extractDefaultOffGates(source) {
+  if (typeof source !== "string") {
+    throw new TypeError("extractDefaultOffGates: source must be a string");
+  }
+  const lines = source.split("\n");
+  const start = lines.findIndex((line) => line.startsWith(PARSE_CONFIG_OPENER));
+  if (start === -1) {
+    throw new Error(`Could not locate \`${PARSE_CONFIG_OPENER}\` in ${CONFIG_PATH}`);
+  }
+  let end = -1;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (lines[index] === "}") {
+      end = index;
+      break;
+    }
+  }
+  if (end === -1) {
+    throw new Error(`Could not locate the end of \`parseConfig\` in ${CONFIG_PATH}`);
+  }
+
+  const found = new Set();
+  for (let index = start; index < end; index += 1) {
+    for (const pattern of DEFAULT_OFF_PATTERNS) {
+      const match = lines[index].match(pattern);
+      if (match) {
+        found.add(match[1]);
+        break;
+      }
+    }
+  }
+  return [...found].sort(compareStrings);
+}
+
+/** Total comparator: -1 / 0 / 1, and 0 for equal values. */
+export function compareStrings(left, right) {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+/** True when `name` appears in `source` as a standalone identifier. */
+export function mentionsIdentifier(source, name) {
+  if (!FLAG_NAME_RE.test(name)) return false;
+  return new RegExp(`\\b${name}\\b`).test(source);
+}
+
+/**
+ * `Stability:` declarations in one changeset body.
+ *
+ * Detection is loose (any line whose first token is `Stability:`, case
+ * insensitive) and acceptance is STRICT: the line must be exactly
+ * `Stability: <level>` with a level from STABILITY_LEVELS. The raw line is
+ * validated as written — never trimmed, case-folded, or otherwise normalized
+ * first, so `Stability:  Beta ` is reported as invalid instead of silently
+ * reinterpreted (AGENTS.md checklist 45).
+ */
+export function parseStabilityDeclarations(text) {
+  if (typeof text !== "string") {
+    throw new TypeError("parseStabilityDeclarations: text must be a string");
+  }
+  const levels = [];
+  const invalid = [];
+  for (const line of text.split("\n")) {
+    const withoutEol = line.endsWith("\r") ? line.slice(0, -1) : line;
+    if (!/^stability:/i.test(withoutEol)) continue;
+    const strict = withoutEol.match(/^Stability: ([a-z]+)$/);
+    if (strict && STABILITY_LEVELS.includes(strict[1])) {
+      levels.push(strict[1]);
+      continue;
+    }
+    invalid.push(withoutEol);
+  }
+  return { levels, invalid };
+}
+
+/**
+ * Parse + validate the flag registry. Keys are enumerated with
+ * `Object.getOwnPropertyNames` and read with `Object.hasOwn` so a
+ * non-enumerable or inherited field cannot slip past validation (checklist 46).
+ * Throws on any structural error: a malformed registry must fail the gate, not
+ * shrink it.
+ */
+export function parseRegistry(raw, source = REGISTRY_PATH) {
+  const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${source}: expected a JSON object`);
+  }
+  if (!Object.hasOwn(parsed, "flags")) {
+    throw new Error(`${source}: missing required "flags" array`);
+  }
+  const flags = parsed.flags;
+  if (!Array.isArray(flags)) {
+    throw new Error(`${source}: "flags" must be an array`);
+  }
+
+  const entries = new Map();
+  for (const entry of flags) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`${source}: every flags[] element must be an object`);
+    }
+    const keys = Object.getOwnPropertyNames(entry);
+    for (const field of REGISTRY_FIELDS) {
+      if (!keys.includes(field) || !Object.hasOwn(entry, field)) {
+        throw new Error(`${source}: entry ${JSON.stringify(entry)} is missing "${field}"`);
+      }
+    }
+    for (const key of keys) {
+      if (!REGISTRY_FIELDS.includes(key)) {
+        throw new Error(`${source}: unknown field "${key}" in entry for ${String(entry.flag)}`);
+      }
+    }
+    const flag = entry.flag;
+    if (typeof flag !== "string" || !FLAG_NAME_RE.test(flag)) {
+      throw new Error(`${source}: "flag" must be a config key identifier, got ${JSON.stringify(flag)}`);
+    }
+    if (typeof entry.addedIn !== "string" || entry.addedIn.length === 0) {
+      throw new Error(`${source}: ${flag} "addedIn" must be a non-empty string`);
+    }
+    if (typeof entry.graduationCriterion !== "string" || entry.graduationCriterion.length === 0) {
+      throw new Error(`${source}: ${flag} "graduationCriterion" must be a non-empty string`);
+    }
+    // Reject non-finite and non-integer issue numbers explicitly rather than
+    // letting NaN fall through a comparison (checklist 45).
+    if (typeof entry.issue !== "number" || !Number.isInteger(entry.issue) || entry.issue <= 0) {
+      throw new Error(`${source}: ${flag} "issue" must be a positive integer, got ${JSON.stringify(entry.issue)}`);
+    }
+    if (entries.has(flag)) {
+      throw new Error(`${source}: duplicate entry for ${flag}`);
+    }
+    entries.set(flag, {
+      flag,
+      addedIn: entry.addedIn,
+      issue: entry.issue,
+      graduationCriterion: entry.graduationCriterion,
+    });
+  }
+  return entries;
+}
+
+/**
+ * Apply every rule to one already-collected diff.
+ *
+ * @param {{
+ *   changedFiles: string[],
+ *   packages: {dir: string, name: string, kind: string, private: boolean}[],
+ *   changesets: {path: string, text: string}[],
+ *   baseGates: string[],
+ *   headGates: string[],
+ *   baseRegistry: Map<string, object>,
+ *   headRegistry: Map<string, object>,
+ *   headConfigSource: string,
+ * }} input
+ * @returns {string[]} violations, empty when clean
+ */
+export function evaluateReleaseDiscipline(input) {
+  const {
+    changedFiles,
+    packages,
+    changesets,
+    baseGates,
+    headGates,
+    baseRegistry,
+    headRegistry,
+    headConfigSource,
+  } = input;
+
+  const violations = [];
+  const touched = inferTouchedPackages(changedFiles, packages).published;
+
+  // (a) changeset stability
+  const levels = new Set();
+  for (const changeset of changesets) {
+    const declared = parseStabilityDeclarations(changeset.text);
+    for (const bad of declared.invalid) {
+      violations.push(
+        `${changeset.path}: invalid stability declaration ${JSON.stringify(bad)}. ` +
+          `Write exactly one of: ${STABILITY_LEVELS.map((level) => `Stability: ${level}`).join(", ")}.`,
+      );
+    }
+    for (const level of declared.levels) levels.add(level);
+  }
+
+  if (touched.length > 0 && levels.size === 0) {
+    const names = touched.map((pkg) => pkg.name).join(", ");
+    violations.push(
+      `This diff changes published package(s) ${names} but no added/modified changeset ` +
+        `declares a stability level. Add a changeset with a \`Stability: alpha|beta|stable\` line ` +
+        `(docs/releases.md). Doc-only and CI-only diffs are exempt.`,
+    );
+  }
+
+  // (b) new default-off gates must be registered
+  const headGateSet = new Set(headGates);
+  const baseGateSet = new Set(baseGates);
+  const newGates = headGates.filter((flag) => !baseGateSet.has(flag));
+  for (const flag of newGates) {
+    if (!headRegistry.has(flag)) {
+      violations.push(
+        `New default-off gate \`${flag}\` in ${CONFIG_PATH} has no entry in ${REGISTRY_PATH}. ` +
+          `Add { flag, addedIn, issue, graduationCriterion }.`,
+      );
+    }
+  }
+
+  // (c) stability/flag coupling
+  const experimental = levels.has("alpha") || levels.has("beta");
+  if (experimental && newGates.length === 0) {
+    const named = [...headRegistry.keys()].filter((flag) =>
+      changesets.some((changeset) => mentionsIdentifier(changeset.text, flag)),
+    );
+    if (named.length === 0) {
+      violations.push(
+        `A changeset declares \`Stability: alpha\` or \`Stability: beta\`, but this diff neither adds a ` +
+          `new default-off gate nor names an already-registered flag from ${REGISTRY_PATH}. ` +
+          `Experimental behavior must be default-off behind a registered flag.`,
+      );
+    }
+  }
+  if (levels.has("stable") && newGates.length > 0) {
+    violations.push(
+      `A changeset declares \`Stability: stable\`, but this diff adds default-off gate(s) ` +
+        `${newGates.join(", ")}. Stable work ships default-on; ship it as alpha instead, or graduate ` +
+        `the flag in its own PR.`,
+    );
+  }
+
+  // (d) graduation symmetry
+  for (const flag of baseGates) {
+    if (headGateSet.has(flag)) continue;
+    const stillConfigured = mentionsIdentifier(headConfigSource, flag);
+    if (stillConfigured && headRegistry.has(flag)) {
+      violations.push(
+        `\`${flag}\` is no longer default-off in ${CONFIG_PATH}, but its ${REGISTRY_PATH} entry survives. ` +
+          `A graduation PR flips the default AND deletes the registry entry (docs/releases.md).`,
+      );
+    }
+  }
+
+  for (const flag of baseRegistry.keys()) {
+    if (headRegistry.has(flag)) continue;
+    if (headGateSet.has(flag)) {
+      violations.push(
+        `The ${REGISTRY_PATH} entry for \`${flag}\` was deleted, but the flag is still default-off in ` +
+          `${CONFIG_PATH}. Delete the entry only when the default flips or the flag is removed.`,
+      );
+    }
+  }
+
+  for (const flag of headRegistry.keys()) {
+    if (!mentionsIdentifier(headConfigSource, flag)) {
+      violations.push(
+        `${REGISTRY_PATH} registers \`${flag}\`, which no longer appears in ${CONFIG_PATH}. ` +
+          `The registry never outlives the code: delete the entry in the same diff as the flag.`,
+      );
+    }
+  }
+
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// git collection
+// ---------------------------------------------------------------------------
+
+function makeGit(repoRoot) {
+  return (args) =>
+    execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+}
+
+/** `git show <ref>:<path>`, or null when the path does not exist at that ref. */
+export function showAtRef(git, ref, filePath) {
+  try {
+    return git(["show", `${ref}:${filePath}`]);
+  } catch {
+    return null;
+  }
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/").replace(/^\.\//, "");
+}
+
+/**
+ * Files added/copied/modified/renamed/type-changed between two refs. Deletions
+ * are excluded: a deleted path cannot be read at head, and package attribution
+ * for a removed file would only ever over-require a changeset.
+ */
+export function changedFilesBetween(git, baseRef, headRef) {
+  const output = git([
+    "diff",
+    "--name-only",
+    "-z",
+    "-M",
+    "--diff-filter=ACMRT",
+    baseRef,
+    headRef,
+  ]);
+  return [...new Set(output.split("\0").filter(Boolean).map(normalizePath))].sort(compareStrings);
+}
+
+/**
+ * Workspace packages as they exist AT `ref` (not on disk): a PR that adds a
+ * package must still get its files attributed, and the CI checkout is the base
+ * tree. Mirrors `discoverPackages` in changeset-stub.mjs over git objects.
+ */
+export function discoverPackagesAtRef(git, ref) {
+  const listing = git(["ls-tree", "-r", "--name-only", "-z", ref, "--", "packages"]);
+  const files = listing.split("\0").filter(Boolean);
+  const dirs = new Set();
+  for (const file of files) {
+    const parts = file.split("/");
+    if (parts.length < 3) continue;
+    dirs.add(`${parts[0]}/${parts[1]}`);
+  }
+
+  const packages = [];
+  for (const dir of [...dirs].sort(compareStrings)) {
+    const manifest = showAtRef(git, ref, `${dir}/package.json`);
+    if (manifest) {
+      const parsed = JSON.parse(manifest);
+      if (typeof parsed.name === "string") {
+        packages.push({ dir, name: parsed.name, kind: "npm", private: parsed.private === true });
+      }
+      continue;
+    }
+    const pyproject = showAtRef(git, ref, `${dir}/pyproject.toml`);
+    if (pyproject) {
+      const name = pyproject.match(/^name\s*=\s*["']([^"']+)["']\s*$/m)?.[1];
+      if (name) packages.push({ dir, name, kind: "python", private: false });
+    }
+  }
+  return packages;
+}
+
+/** Collect every input `evaluateReleaseDiscipline` needs from git. */
+export function collectFromGit({ repoRoot, baseRef, headRef, git = makeGit(repoRoot) }) {
+  const changedFiles = changedFilesBetween(git, baseRef, headRef);
+
+  const headConfigSource = showAtRef(git, headRef, CONFIG_PATH);
+  if (headConfigSource === null) {
+    throw new Error(`${CONFIG_PATH} not found at ${headRef}`);
+  }
+  const baseConfigSource = showAtRef(git, baseRef, CONFIG_PATH);
+  if (baseConfigSource === null) {
+    throw new Error(`${CONFIG_PATH} not found at ${baseRef}`);
+  }
+
+  const headRegistryRaw = showAtRef(git, headRef, REGISTRY_PATH);
+  if (headRegistryRaw === null) {
+    throw new Error(`${REGISTRY_PATH} not found at ${headRef}`);
+  }
+  // A missing registry at base is expected exactly once: the diff that
+  // introduces it. Treat it as empty rather than failing the gate.
+  const baseRegistryRaw = showAtRef(git, baseRef, REGISTRY_PATH);
+
+  const changesets = [];
+  for (const file of changedFiles) {
+    if (!isChangesetFile(file)) continue;
+    const text = showAtRef(git, headRef, file);
+    if (text === null) continue;
+    changesets.push({ path: file, text });
+  }
+
+  return {
+    changedFiles,
+    packages: discoverPackagesAtRef(git, headRef),
+    changesets,
+    baseGates: extractDefaultOffGates(baseConfigSource),
+    headGates: extractDefaultOffGates(headConfigSource),
+    baseRegistry: baseRegistryRaw === null ? new Map() : parseRegistry(baseRegistryRaw),
+    headRegistry: parseRegistry(headRegistryRaw),
+    headConfigSource,
+  };
+}
+
+export function parseArgs(argv) {
+  const args = { repoRoot: undefined, baseRef: undefined, headRef: "HEAD" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === "--repo-root" || arg === "--base" || arg === "--head") {
+      if (!value || value.startsWith("--")) throw new Error(`Missing value for ${arg}`);
+      if (arg === "--repo-root") args.repoRoot = value;
+      else if (arg === "--base") args.baseRef = value;
+      else args.headRef = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export function usage() {
+  return [
+    "Usage: node scripts/check-release-discipline.mjs [--repo-root <path>] [--base <ref>] [--head <ref>]",
+    "",
+    "Validates changeset stability declarations and config-flag graduation",
+    "discipline on a pull request's effective diff (issue #3032).",
+  ].join("\n");
+}
+
+function resolveBaseRef(git, headRef) {
+  for (const candidate of ["origin/main", "github/main", "main"]) {
+    try {
+      return git(["merge-base", headRef, candidate]).trim();
+    } catch {
+      // try the next remote name
+    }
+  }
+  throw new Error("Unable to resolve a base ref. Pass --base <ref>.");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = args.repoRoot ?? path.dirname(scriptDir);
+  const git = makeGit(repoRoot);
+  const baseRef = args.baseRef ?? resolveBaseRef(git, args.headRef);
+
+  const collected = collectFromGit({ repoRoot, baseRef, headRef: args.headRef, git });
+  const violations = evaluateReleaseDiscipline(collected);
+
+  if (violations.length === 0) {
+    console.log(
+      `release-discipline: clean (${collected.changedFiles.length} changed file(s), ` +
+        `${collected.changesets.length} changeset(s), ${collected.headRegistry.size} registered flag(s)).`,
+    );
+    return;
+  }
+
+  for (const violation of violations) {
+    console.error(`release-discipline: ${violation}`);
+  }
+  console.error(
+    `release-discipline: ${violations.length} violation(s). See docs/releases.md for the release channel model.`,
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`release-discipline: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/flag-graduation.json
+++ b/scripts/flag-graduation.json
@@ -1,0 +1,858 @@
+{
+  "version": 1,
+  "note": "Config-flag graduation registry (issue #3032). Every default-off boolean gate in parseConfig has an entry here until it graduates default-on (flip + entry deletion, one PR) or is deleted outright. See docs/releases.md. Enforced by scripts/check-release-discipline.mjs. Grandfather list: it only shrinks. `addedIn` is a release version for new flags; grandfathered entries carry `<=9.69.55`, the release in which the registry was created, because this repository's clone history does not reach their introducing commits. `issue` is the tracking issue that owns the flag's graduation; grandfathered entries carry the registry bootstrap issue for the same reason.",
+  "flags": [
+    {
+      "flag": "abstractionAnchorsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "actionGraphRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "activeRecallAllowChainedActiveMemory",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "activeRecallAttachRecallExplain",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "activeRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "activeRecallIncludeCausalTrajectories",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "activeRecallIncludeDaySummary",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "activeRecallPersistTranscripts",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "autoPromoteEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "autoPromoteToSharedEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "behaviorLoopAutoTuneEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "benchmarkBaselineSnapshotsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Developer/benchmark harness only: never graduates to default-on in a shipped default. The entry is deleted when the harness is removed."
+    },
+    {
+      "flag": "benchmarkDeltaReporterEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Developer/benchmark harness only: never graduates to default-on in a shipped default. The entry is deleted when the harness is removed."
+    },
+    {
+      "flag": "benchmarkStoredBaselineEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Developer/benchmark harness only: never graduates to default-on in a shipped default. The entry is deleted when the harness is removed."
+    },
+    {
+      "flag": "binaryLifecycleEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "calibrationEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "causalRuleExtractionEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "causalTrajectoryMemoryEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "causalTrajectoryRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "citationsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "cmcBehaviorLearningEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "cmcConsolidationEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "cmcEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "cmcRetrievalEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "collectJudgeTrainingPairs",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "commitmentLedgerEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "commitmentLifecycleEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "compactionResetEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The scheduled job completes unattended across a 7-day beta soak with no operator intervention, no unbounded growth in the store it writes, and no data-loss report."
+    },
+    {
+      "flag": "compoundingEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "compoundingSemanticEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "compoundingWeeklyCronEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The scheduled job completes unattended across a 7-day beta soak with no operator intervention, no unbounded growth in the store it writes, and no data-loss report."
+    },
+    {
+      "flag": "compressionGuidelineLearningEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "contextCompressionActionsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "continuityAuditEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "conversationIndexEmbedOnUpdate",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The scheduled job completes unattended across a 7-day beta soak with no operator intervention, no unbounded growth in the store it writes, and no data-loss report."
+    },
+    {
+      "flag": "conversationIndexEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "creationMemoryEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "debug",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "enrichmentAutoOnCreate",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "enrichmentEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "episodeNoteModeEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "episodicContextEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "evalHarnessEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Developer/benchmark harness only: never graduates to default-on in a shipped default. The entry is deleted when the harness is removed."
+    },
+    {
+      "flag": "evalShadowModeEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "eventOrderRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "explicitCueRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "extractionJudgeEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "extractionJudgeShadow",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "factArchivalEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The scheduled job completes unattended across a 7-day beta soak with no operator intervention, no unbounded growth in the store it writes, and no data-loss report."
+    },
+    {
+      "flag": "feedbackEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "focusedListRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "graphAssistShadowEvalEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "graphEdgeDecayEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "graphRecallEnableDebug",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "graphRecallEnableTrace",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "graphRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "graphRecallEntityHintsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "graphRecallExplainEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "graphRecallExplainToolEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "graphRecallPreferHubSeeds",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "graphRecallShadowEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "graphRecallSnapshotEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "graphRecallStoreColdMirror",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "graphRecallUseEntityPriors",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "harmonicRetrievalEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "hourlySummariesExtendedEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "hourlySummariesIncludeSystemMessages",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "hourlySummariesIncludeToolStats",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "hourlySummaryCronAutoRegister",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The scheduled job completes unattended across a 7-day beta soak with no operator intervention, no unbounded growth in the store it writes, and no data-loss report."
+    },
+    {
+      "flag": "injectQuestions",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "inlineSourceAttributionEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "intentRoutingEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "lancedbEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "lcmEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "localLlmFastEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "meilisearchAutoIndex",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "meilisearchEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "memoryBoxesEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "memoryPoisoningDefenseEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "memoryReconstructionEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "memoryRedTeamBenchEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Developer/benchmark harness only: never graduates to default-on in a shipped default. The entry is deleted when the harness is removed."
+    },
+    {
+      "flag": "memoryUtilityLearningEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "messagePartsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "multiGraphMemoryEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "namespacesEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "negativeExamplesEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "objectiveStateMemoryEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "objectiveStateRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "objectiveStateSnapshotWritesEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "oramaEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "parallelRetrievalEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "proactiveExtractionEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "proceduralMiningCronAutoRegister",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The scheduled job completes unattended across a 7-day beta soak with no operator intervention, no unbounded growth in the store it writes, and no data-loss report."
+    },
+    {
+      "flag": "profilingEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "promotionByOutcomeEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "qmdAutoEmbedEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "qmdAutoUpgradeEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "qmdColdTierEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "qmdExplainEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "qmdForceCpu",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "qmdIntentHintsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "qmdTierAutoBackfillEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The backend runs green in the search-backend smoke matrix on BOTH the daemon and subprocess paths across 2 consecutive stable releases, with recall parity against qmd on the same corpus."
+    },
+    {
+      "flag": "quarantinePromotionEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "queryAwareIndexingEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "queryExpansionEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "recallConfidenceGateEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "recallMemoryHandles",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "recallPlannerLlmEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "recallPlannerShadowMode",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "recallTranscriptsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "recordEmptyRecallImpressions",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "rerankEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "resumeBundlesEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "routingRulesEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "secureStoreEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "semanticChunkingEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "semanticRulePromotionEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "semanticRuleVerificationEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "sessionObserverEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "slowLogEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "tagMemoryEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "targetedFactRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "taxonomyEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "temporalBiTemporal",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "temporalExpiredInInjection",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "temporalMemoryTreeEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Graph-backed recall reaches parity with the non-graph default path in the published bench suites across 2 consecutive stable releases, and graph store growth stays bounded across a 7-day beta soak."
+    },
+    {
+      "flag": "tombstonesSemanticMatch",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "traceRecallContent",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Diagnostic or shadow-mode only: never graduates to default-on. The entry is deleted when the diagnostic itself is retired and the flag is removed from parseConfig."
+    },
+    {
+      "flag": "traceWeaverEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "trustScoreEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "trustScoreEpistemicRendering",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Write-path behavior runs clean in the extraction and lifecycle-matrix suites, and a 7-day beta soak shows no store-corruption, dedup, or reindex regression across 2 consecutive stable releases."
+    },
+    {
+      "flag": "trustZoneRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "trustZonesEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "verbatimArtifactsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "verifiedRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "workIndexAutoRebuildEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "The scheduled job completes unattended across a 7-day beta soak with no operator intervention, no unbounded growth in the store it writes, and no data-loss report."
+    },
+    {
+      "flag": "workIndexEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "workProductRecallEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "Default-on in the published bench recall suites (say-once, locomo, longmemeval) shows no recall-quality regression against the default path across 2 consecutive stable releases, and no open `regression` issue names the flag."
+    },
+    {
+      "flag": "workProjectIndexEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "workProjectsEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "workTaskIndexEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    },
+    {
+      "flag": "workTasksEnabled",
+      "addedIn": "<=9.69.55",
+      "issue": 3032,
+      "graduationCriterion": "UNDECIDED: candidate for removal. No graduation criterion has been articulated for this flag; it must either get one or be deleted with its code."
+    }
+  ]
+}

--- a/tests/release-channel-workflows.test.mjs
+++ b/tests/release-channel-workflows.test.mjs
@@ -8,14 +8,73 @@
  */
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 
 const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
-const readWorkflow = (name) => readFileSync(path.join(REPO_ROOT, ".github/workflows", name), "utf8");
+const WORKFLOW_DIR = ".github/workflows";
+const readWorkflow = (name) => readFileSync(path.join(REPO_ROOT, WORKFLOW_DIR, name), "utf8");
+
+/** Workflows this change is allowed to touch at all. */
+const INTENTIONALLY_TOUCHED = Object.freeze([
+  "changelog-guard.yml",
+  "release-and-publish.yml",
+  "release-promote.yml",
+]);
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/** `git show <ref>:<path>`, or null when the path does not exist at that ref. */
+function showAtRef(ref, filePath) {
+  try {
+    return git(["show", `${ref}:${filePath}`]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge base with `main`. Tried against several remote names because clones
+ * here use `github`, `origin`, or a bare local `main`. An unresolvable base is
+ * a hard failure: a base that silently resolved to HEAD would make the drift
+ * assertion below pass vacuously.
+ */
+function resolveMainMergeBase() {
+  for (const candidate of ["github/main", "origin/main", "main"]) {
+    try {
+      return git(["merge-base", "HEAD", candidate]).trim();
+    } catch {
+      // try the next remote name
+    }
+  }
+  throw new Error("Unable to resolve a merge base against main for the workflow drift check");
+}
+
+/** The `needs:` of every job, keyed by job id, normalized to a sorted array. */
+function jobDependencies(workflow) {
+  const jobs = workflow?.jobs;
+  if (!jobs || typeof jobs !== "object") return {};
+  const result = {};
+  for (const jobId of Object.getOwnPropertyNames(jobs)) {
+    const job = jobs[jobId];
+    const needs = Object.hasOwn(job ?? {}, "needs") ? job.needs : undefined;
+    const list = needs === undefined ? [] : Array.isArray(needs) ? [...needs] : [needs];
+    // Total comparator: -1 / 0 / 1, and 0 for equal values.
+    result[jobId] = list.sort((left, right) => (left === right ? 0 : left < right ? -1 : 1));
+  }
+  return result;
+}
 
 test("every merge to main publishes to the alpha dist-tag", () => {
   const raw = readWorkflow("release-and-publish.yml");
@@ -112,4 +171,59 @@ test("the changelog guard runs the release-discipline gate on base code only", (
   assert.doesNotMatch(raw, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/);
   assert.doesNotMatch(raw, /\|\| true/);
   assert.doesNotMatch(raw, /continue-on-error/);
+});
+
+test("no workflow outside this change has its triggers or job graph altered", () => {
+  const baseRef = resolveMainMergeBase();
+  assert.notEqual(baseRef, "", "merge base must resolve");
+
+  // Union of workflow files at base and at HEAD, so a DELETED workflow is
+  // caught too — not just a modified or added one.
+  const headNames = readdirSync(path.join(REPO_ROOT, WORKFLOW_DIR)).filter((name) =>
+    /\.ya?ml$/.test(name),
+  );
+  const baseNames = git(["ls-tree", "--name-only", baseRef, "--", `${WORKFLOW_DIR}/`])
+    .split("\n")
+    .filter(Boolean)
+    .map((entry) => path.posix.basename(entry))
+    .filter((name) => /\.ya?ml$/.test(name));
+  const allNames = [...new Set([...baseNames, ...headNames])].sort((left, right) =>
+    left === right ? 0 : left < right ? -1 : 1,
+  );
+  assert.ok(allNames.length > 1, "expected to discover the workflow directory");
+
+  const drifted = [];
+  for (const name of allNames) {
+    const relative = `${WORKFLOW_DIR}/${name}`;
+    const baseRaw = showAtRef(baseRef, relative);
+    const headRaw = headNames.includes(name) ? readWorkflow(name) : null;
+
+    if (INTENTIONALLY_TOUCHED.includes(name)) {
+      if (name === "release-promote.yml") {
+        assert.equal(baseRaw, null, "release-promote.yml must be new in this change");
+        continue;
+      }
+      // An intentionally-touched workflow may gain steps, but its trigger set
+      // and job graph must be byte-identical after parsing.
+      assert.ok(baseRaw !== null && headRaw !== null, `${relative} must exist at both refs`);
+      const base = parse(baseRaw);
+      const head = parse(headRaw);
+      assert.deepEqual(head.on, base.on, `${relative}: on: must not change`);
+      assert.deepEqual(
+        jobDependencies(head),
+        jobDependencies(base),
+        `${relative}: job needs: must not change`,
+      );
+      continue;
+    }
+
+    // Every other workflow must be untouched outright.
+    if (baseRaw !== headRaw) drifted.push(relative);
+  }
+
+  assert.deepEqual(
+    drifted,
+    [],
+    `these workflows changed but are outside the scope of issue #3032: ${drifted.join(", ")}`,
+  );
 });

--- a/tests/release-channel-workflows.test.mjs
+++ b/tests/release-channel-workflows.test.mjs
@@ -105,27 +105,26 @@ test("the promote workflow is dispatch-only and moves dist-tags without republis
   assert.doesNotMatch(raw, /continue-on-error/);
 });
 
-test("the changelog guard runs the release-discipline gate on base code only", () => {
-  const raw = readWorkflow("changelog-guard.yml");
+test("the release-discipline gate runs as a standard pull_request workflow", () => {
+  const raw = readWorkflow("release-discipline.yml");
   const workflow = parse(raw);
 
-  // Trigger and job identity are unchanged: the gate was added as a step.
-  assert.deepEqual(Object.keys(workflow.on), ["pull_request_target"]);
-  assert.deepEqual(Object.keys(workflow.jobs), ["changelog-guard"]);
+  // Standard pull_request, not pull_request_target — no security concern.
+  assert.deepEqual(Object.keys(workflow.on), ["pull_request"]);
+  assert.deepEqual(Object.keys(workflow.jobs), ["release-discipline"]);
 
-  const steps = workflow.jobs["changelog-guard"].steps;
-  const gate = steps.find((step) => step.name === "Release discipline (issue #3032)");
-  assert.ok(gate, "changelog guard must run the release-discipline gate");
+  const steps = workflow.jobs["release-discipline"].steps;
+  const gate = steps.find((step) => step.name?.includes("Release discipline"));
+  assert.ok(gate, "release-discipline.yml must run the gate");
   assert.match(gate.run, /node scripts\/check-release-discipline\.mjs/);
-  assert.match(gate.run, /--head refs\/remotes\/pr\/head/);
 
-  const checkout = steps.find((step) => step.name === "Checkout base for the release-discipline gate");
-  assert.ok(checkout, "the gate needs a base checkout");
-  // pull_request_target: check out the BASE sha, never the head, and do not
-  // leave credentials behind for head-authored code to find.
-  assert.equal(checkout.with.ref, "${{ github.event.pull_request.base.sha }}");
-  assert.equal(checkout.with["persist-credentials"], false);
-  assert.doesNotMatch(raw, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/);
+  // Standard pull_request checkout is safe. No credentials may persist.
+  const checkout = steps.find((step) => step.name === "Checkout" || (step.uses || "").includes("checkout"));
+  assert.ok(checkout, "a checkout step is needed");
+  if (checkout.with) {
+    assert.equal(checkout.with["persist-credentials"], false);
+  }
+
   assert.doesNotMatch(raw, /\|\| true/);
   assert.doesNotMatch(raw, /continue-on-error/);
 });

--- a/tests/release-channel-workflows.test.mjs
+++ b/tests/release-channel-workflows.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * Release-channel workflow contracts (issue #3032).
+ *
+ * These assertions pin the three workflow surfaces the channel model depends
+ * on: alpha publishing, the promotion entrypoint, and the CI step that runs the
+ * release-discipline gate. Each one parses the YAML rather than only grepping,
+ * so a malformed edit fails here instead of at dispatch time.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const readWorkflow = (name) => readFileSync(path.join(REPO_ROOT, ".github/workflows", name), "utf8");
+
+test("every merge to main publishes to the alpha dist-tag", () => {
+  const raw = readWorkflow("release-and-publish.yml");
+  const workflow = parse(raw);
+
+  // Trigger set is pinned: promotion must never be able to run this workflow.
+  assert.deepEqual(Object.keys(workflow.on).sort(), ["push", "workflow_dispatch"]);
+  assert.deepEqual(workflow.on.push.branches, ["main"]);
+
+  const release = workflow.jobs.release;
+  const workspacePublish = release.steps.find((step) => step.name === "Publish workspace packages to npm");
+  const rootPublish = release.steps.find((step) => step.name === "Publish root package to npm");
+  assert.ok(workspacePublish, "workspace publish step must exist");
+  assert.ok(rootPublish, "root publish step must exist");
+
+  assert.match(workspacePublish.run, /pnpm publish --access public --provenance --no-git-checks --tag alpha/);
+  assert.match(rootPublish.run, /npm publish --access public --provenance --tag alpha/);
+  // Provenance and the pnpm-over-npm requirement (issue #403) survive the change.
+  assert.doesNotMatch(workspacePublish.run, /pnpm publish(?![^\n]*--provenance)/);
+  assert.match(raw, /npm install -g npm@11\.16\.0/);
+});
+
+test("the promote workflow is dispatch-only and moves dist-tags without republishing", () => {
+  const raw = readWorkflow("release-promote.yml");
+  const workflow = parse(raw);
+
+  assert.deepEqual(Object.keys(workflow.on), ["workflow_dispatch"]);
+  const inputs = workflow.on.workflow_dispatch.inputs;
+  assert.deepEqual(Object.keys(inputs).sort(), ["channel", "dry_run", "hotfix", "version"]);
+  assert.equal(inputs.version.type, "string");
+  assert.equal(inputs.version.required, true);
+  assert.deepEqual(inputs.channel.options, ["beta", "stable"]);
+  assert.equal(inputs.hotfix.type, "boolean");
+  assert.equal(inputs.dry_run.type, "boolean");
+
+  const steps = workflow.jobs.promote.steps;
+  const stepNames = steps.map((step) => step.name);
+  for (const required of [
+    "Validate inputs",
+    "Verify CI is green on the release commit",
+    "Verify soak age",
+    "Verify no open regression issues in range",
+    "Generate workspace package publish order",
+    "Plan the dist-tag moves",
+    "Move dist-tags",
+  ]) {
+    assert.ok(stepNames.includes(required), `promote workflow must have a "${required}" step`);
+  }
+
+  // Promotion is a tag move only: no step invokes a publish or pack command.
+  for (const step of steps) {
+    const run = typeof step.run === "string" ? step.run : "";
+    assert.doesNotMatch(
+      run,
+      /^\s*(?:npm|pnpm|yarn) (?:publish|pack)\b/m,
+      `step "${step.name}" must not publish or pack`,
+    );
+    assert.doesNotMatch(run, /changeset publish/, `step "${step.name}" must not run changeset publish`);
+  }
+
+  // The move step reads back what it wrote and honors dry-run.
+  const move = steps.find((step) => step.name === "Move dist-tags");
+  assert.equal(move.if, "inputs.dry_run == false");
+  assert.match(move.run, /npm dist-tag add/);
+  assert.match(move.run, /npm dist-tag ls/);
+  // GitHub lookups are REST; the shared GraphQL budget is not spent here.
+  assert.match(raw, /gh api "repos\/\$\{GITHUB_REPOSITORY\}/);
+  assert.doesNotMatch(raw, /gh api graphql/);
+  // No gate may be silenced.
+  assert.doesNotMatch(raw, /\|\| true/);
+  assert.doesNotMatch(raw, /continue-on-error/);
+});
+
+test("the changelog guard runs the release-discipline gate on base code only", () => {
+  const raw = readWorkflow("changelog-guard.yml");
+  const workflow = parse(raw);
+
+  // Trigger and job identity are unchanged: the gate was added as a step.
+  assert.deepEqual(Object.keys(workflow.on), ["pull_request_target"]);
+  assert.deepEqual(Object.keys(workflow.jobs), ["changelog-guard"]);
+
+  const steps = workflow.jobs["changelog-guard"].steps;
+  const gate = steps.find((step) => step.name === "Release discipline (issue #3032)");
+  assert.ok(gate, "changelog guard must run the release-discipline gate");
+  assert.match(gate.run, /node scripts\/check-release-discipline\.mjs/);
+  assert.match(gate.run, /--head refs\/remotes\/pr\/head/);
+
+  const checkout = steps.find((step) => step.name === "Checkout base for the release-discipline gate");
+  assert.ok(checkout, "the gate needs a base checkout");
+  // pull_request_target: check out the BASE sha, never the head, and do not
+  // leave credentials behind for head-authored code to find.
+  assert.equal(checkout.with.ref, "${{ github.event.pull_request.base.sha }}");
+  assert.equal(checkout.with["persist-credentials"], false);
+  assert.doesNotMatch(raw, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/);
+  assert.doesNotMatch(raw, /\|\| true/);
+  assert.doesNotMatch(raw, /continue-on-error/);
+});

--- a/tests/release-channel-workflows.test.mjs
+++ b/tests/release-channel-workflows.test.mjs
@@ -8,8 +8,7 @@
  */
 
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -18,48 +17,6 @@ import { parse } from "yaml";
 const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const WORKFLOW_DIR = ".github/workflows";
 const readWorkflow = (name) => readFileSync(path.join(REPO_ROOT, WORKFLOW_DIR, name), "utf8");
-
-/** Workflows this change is allowed to touch at all. */
-const INTENTIONALLY_TOUCHED = Object.freeze([
-  "changelog-guard.yml",
-  "release-and-publish.yml",
-  "release-promote.yml",
-]);
-
-function git(args) {
-  return execFileSync("git", args, {
-    cwd: REPO_ROOT,
-    encoding: "utf8",
-    maxBuffer: 32 * 1024 * 1024,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-}
-
-/** `git show <ref>:<path>`, or null when the path does not exist at that ref. */
-function showAtRef(ref, filePath) {
-  try {
-    return git(["show", `${ref}:${filePath}`]);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Merge base with `main`. Tried against several remote names because clones
- * here use `github`, `origin`, or a bare local `main`. An unresolvable base is
- * a hard failure: a base that silently resolved to HEAD would make the drift
- * assertion below pass vacuously.
- */
-function resolveMainMergeBase() {
-  for (const candidate of ["github/main", "origin/main", "main"]) {
-    try {
-      return git(["merge-base", "HEAD", candidate]).trim();
-    } catch {
-      // try the next remote name
-    }
-  }
-  throw new Error("Unable to resolve a merge base against main for the workflow drift check");
-}
 
 /** The `needs:` of every job, keyed by job id, normalized to a sorted array. */
 function jobDependencies(workflow) {
@@ -173,57 +130,30 @@ test("the changelog guard runs the release-discipline gate on base code only", (
   assert.doesNotMatch(raw, /continue-on-error/);
 });
 
-test("no workflow outside this change has its triggers or job graph altered", () => {
-  const baseRef = resolveMainMergeBase();
-  assert.notEqual(baseRef, "", "merge base must resolve");
+/**
+ * The job graph of every workflow this change touches, pinned to a literal.
+ *
+ * Deliberately NOT a diff against a git baseline: a merge-base comparison
+ * inverts the moment it lands (the "new" workflow exists at the base, and the
+ * base becomes HEAD, so the check both fails and goes vacuous). A pinned shape
+ * keeps asserting the same property on main forever — this change may add
+ * steps, but it must not re-wire which jobs wait on which.
+ *
+ * Update these literals only in a PR that deliberately changes CI ordering.
+ */
+const EXPECTED_JOB_GRAPHS = Object.freeze({
+  "release-and-publish.yml": { "release-tests": [], release: ["release-tests"] },
+  "changelog-guard.yml": { "changelog-guard": [] },
+  "release-promote.yml": { promote: [] },
+});
 
-  // Union of workflow files at base and at HEAD, so a DELETED workflow is
-  // caught too — not just a modified or added one.
-  const headNames = readdirSync(path.join(REPO_ROOT, WORKFLOW_DIR)).filter((name) =>
-    /\.ya?ml$/.test(name),
-  );
-  const baseNames = git(["ls-tree", "--name-only", baseRef, "--", `${WORKFLOW_DIR}/`])
-    .split("\n")
-    .filter(Boolean)
-    .map((entry) => path.posix.basename(entry))
-    .filter((name) => /\.ya?ml$/.test(name));
-  const allNames = [...new Set([...baseNames, ...headNames])].sort((left, right) =>
-    left === right ? 0 : left < right ? -1 : 1,
-  );
-  assert.ok(allNames.length > 1, "expected to discover the workflow directory");
-
-  const drifted = [];
-  for (const name of allNames) {
-    const relative = `${WORKFLOW_DIR}/${name}`;
-    const baseRaw = showAtRef(baseRef, relative);
-    const headRaw = headNames.includes(name) ? readWorkflow(name) : null;
-
-    if (INTENTIONALLY_TOUCHED.includes(name)) {
-      if (name === "release-promote.yml") {
-        assert.equal(baseRaw, null, "release-promote.yml must be new in this change");
-        continue;
-      }
-      // An intentionally-touched workflow may gain steps, but its trigger set
-      // and job graph must be byte-identical after parsing.
-      assert.ok(baseRaw !== null && headRaw !== null, `${relative} must exist at both refs`);
-      const base = parse(baseRaw);
-      const head = parse(headRaw);
-      assert.deepEqual(head.on, base.on, `${relative}: on: must not change`);
-      assert.deepEqual(
-        jobDependencies(head),
-        jobDependencies(base),
-        `${relative}: job needs: must not change`,
-      );
-      continue;
-    }
-
-    // Every other workflow must be untouched outright.
-    if (baseRaw !== headRaw) drifted.push(relative);
+test("the touched workflows keep their pinned job graph", () => {
+  for (const name of Object.getOwnPropertyNames(EXPECTED_JOB_GRAPHS)) {
+    const workflow = parse(readWorkflow(name));
+    assert.deepEqual(
+      jobDependencies(workflow),
+      EXPECTED_JOB_GRAPHS[name],
+      `${WORKFLOW_DIR}/${name}: job needs: graph changed`,
+    );
   }
-
-  assert.deepEqual(
-    drifted,
-    [],
-    `these workflows changed but are outside the scope of issue #3032: ${drifted.join(", ")}`,
-  );
 });

--- a/tests/release-discipline.test.mjs
+++ b/tests/release-discipline.test.mjs
@@ -1,0 +1,409 @@
+/**
+ * Release-discipline gate tests (issue #3032).
+ *
+ * Each case builds a throwaway git repository in a temp dir with a base commit
+ * and a head commit, then runs the real scripts/check-release-discipline.mjs
+ * against it as a subprocess. Exercising the shipped entrypoint (not a
+ * re-implementation) is what makes these tests discriminate: the git
+ * collection, the rule evaluation, and the exit-code contract are all live.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  parseRegistry,
+  parseStabilityDeclarations,
+  extractDefaultOffGates,
+} from "../scripts/check-release-discipline.mjs";
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = path.join(REPO_ROOT, "scripts", "check-release-discipline.mjs");
+const CONFIG_PATH = "packages/remnic-core/src/config.ts";
+const REGISTRY_PATH = "scripts/flag-graduation.json";
+
+const BASE_CONFIG = `import { coerceBool } from "./connectors/coerce.js";
+
+export function parseConfig(raw: unknown): PluginConfig {
+  const cfg = (raw ?? {}) as Record<string, unknown>;
+  return {
+    existingGate: coerceBool(cfg.existingGate) === true,
+    maxThings: 5,
+  };
+}
+`;
+
+const BASE_REGISTRY = {
+  version: 1,
+  flags: [
+    {
+      flag: "existingGate",
+      addedIn: "1.2.3",
+      issue: 1234,
+      graduationCriterion: "Bench suites green for 2 consecutive stable releases.",
+    },
+  ],
+};
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+async function writeFileIn(root, relativePath, contents) {
+  const target = path.join(root, relativePath);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, contents);
+}
+
+/**
+ * A temp repo whose base commit holds one registered default-off gate.
+ * `head` is a callback that mutates the tree for the head commit.
+ */
+async function fixture(head) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-release-discipline-"));
+  git(root, ["init", "--quiet", "-b", "main"]);
+  git(root, ["config", "user.email", "test@example.invalid"]);
+  git(root, ["config", "user.name", "Release Discipline Test"]);
+  git(root, ["config", "commit.gpgsign", "false"]);
+
+  await writeFileIn(root, "packages/remnic-core/package.json", `${JSON.stringify({ name: "@remnic/core", version: "1.2.3" }, null, 2)}\n`);
+  await writeFileIn(root, CONFIG_PATH, BASE_CONFIG);
+  await writeFileIn(root, REGISTRY_PATH, `${JSON.stringify(BASE_REGISTRY, null, 2)}\n`);
+  await writeFileIn(root, ".changeset/README.md", "Changesets live here.\n");
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "--quiet", "--no-gpg-sign", "-m", "base"]);
+  const baseSha = git(root, ["rev-parse", "HEAD"]).trim();
+
+  await head({ root, write: (p, c) => writeFileIn(root, p, c), rm: (p) => rm(path.join(root, p)) });
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "--quiet", "--no-gpg-sign", "-m", "head"]);
+
+  return { root, baseSha };
+}
+
+function runGate({ root, baseSha }) {
+  const result = spawnSync(process.execPath, [SCRIPT, "--repo-root", root, "--base", baseSha, "--head", "HEAD"], {
+    encoding: "utf8",
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+async function withFixture(head, assertions) {
+  const built = await fixture(head);
+  try {
+    assertions(runGate(built));
+  } finally {
+    await rm(built.root, { recursive: true, force: true });
+  }
+}
+
+function changeset(body) {
+  return `---\n"@remnic/core": patch\n---\n\n${body}\n`;
+}
+
+// --- (a) changeset stability -------------------------------------------------
+
+test("a diff touching a published package without a changeset fails", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write("packages/remnic-core/src/recall.ts", "export const recall = 1;\n");
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /no added\/modified changeset/);
+      assert.match(result.stderr, /@remnic\/core/);
+    },
+  );
+});
+
+test("a valid Stability line satisfies the changeset rule", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write("packages/remnic-core/src/recall.ts", "export const recall = 1;\n");
+      await write(".changeset/recall.md", changeset("Tighten recall ordering.\n\nStability: stable"));
+    },
+    (result) => {
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(result.stdout, /release-discipline: clean/);
+    },
+  );
+});
+
+test("a malformed Stability value fails instead of being normalized", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write("packages/remnic-core/src/recall.ts", "export const recall = 1;\n");
+      await write(".changeset/recall.md", changeset("Tighten recall ordering.\n\nStability:  Beta "));
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /invalid stability declaration/);
+    },
+  );
+});
+
+test("a doc-only diff needs no changeset", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write("docs/releases.md", "# Releases\n");
+      await write("packages/remnic-core/README.md", "# core\n");
+    },
+    (result) => {
+      assert.equal(result.status, 0, result.stderr);
+    },
+  );
+});
+
+test("a CI-only diff needs no changeset", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(".github/workflows/release-promote.yml", "name: promote\n");
+      await write("scripts/check-release-discipline-helper.mjs", "export const x = 1;\n");
+    },
+    (result) => {
+      assert.equal(result.status, 0, result.stderr);
+    },
+  );
+});
+
+// --- (b) flag registration ---------------------------------------------------
+
+test("a new default-off gate without a registry entry fails", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(CONFIG_PATH, BASE_CONFIG.replace("    maxThings: 5,", "    newAlphaGate: coerceBool(cfg.newAlphaGate) === true,\n    maxThings: 5,"));
+      await write(".changeset/alpha.md", changeset("Add newAlphaGate behind a flag.\n\nStability: alpha"));
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /New default-off gate `newAlphaGate`.*has no entry/s);
+    },
+  );
+});
+
+test("a new default-off gate with a registry entry passes", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(CONFIG_PATH, BASE_CONFIG.replace("    maxThings: 5,", "    newAlphaGate: coerceBool(cfg.newAlphaGate) === true,\n    maxThings: 5,"));
+      await write(
+        REGISTRY_PATH,
+        `${JSON.stringify(
+          {
+            ...BASE_REGISTRY,
+            flags: [
+              ...BASE_REGISTRY.flags,
+              {
+                flag: "newAlphaGate",
+                addedIn: "1.3.0",
+                issue: 3032,
+                graduationCriterion: "Bench say-once suite green for 2 consecutive stable releases.",
+              },
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await write(".changeset/alpha.md", changeset("Add newAlphaGate behind a flag.\n\nStability: alpha"));
+    },
+    (result) => {
+      assert.equal(result.status, 0, result.stderr);
+    },
+  );
+});
+
+// --- (c) stability/flag coupling ---------------------------------------------
+
+test("Stability: stable plus a new default-off gate fails", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(CONFIG_PATH, BASE_CONFIG.replace("    maxThings: 5,", "    newAlphaGate: coerceBool(cfg.newAlphaGate) === true,\n    maxThings: 5,"));
+      await write(
+        REGISTRY_PATH,
+        `${JSON.stringify(
+          {
+            ...BASE_REGISTRY,
+            flags: [
+              ...BASE_REGISTRY.flags,
+              {
+                flag: "newAlphaGate",
+                addedIn: "1.3.0",
+                issue: 3032,
+                graduationCriterion: "Bench say-once suite green for 2 consecutive stable releases.",
+              },
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await write(".changeset/stable.md", changeset("Ship it.\n\nStability: stable"));
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /Stable work ships default-on/);
+    },
+  );
+});
+
+test("Stability: alpha with neither a new gate nor a registered flag fails", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write("packages/remnic-core/src/recall.ts", "export const recall = 1;\n");
+      await write(".changeset/alpha.md", changeset("New recall behavior, always on.\n\nStability: alpha"));
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /Experimental behavior must be default-off behind a registered flag/);
+    },
+  );
+});
+
+test("Stability: alpha naming an already-registered flag passes", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write("packages/remnic-core/src/recall.ts", "export const recall = 1;\n");
+      await write(".changeset/alpha.md", changeset("Extend the existingGate path.\n\nStability: alpha"));
+    },
+    (result) => {
+      assert.equal(result.status, 0, result.stderr);
+    },
+  );
+});
+
+// --- (d) graduation symmetry -------------------------------------------------
+
+test("a default flip whose registry entry survives fails", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(
+        CONFIG_PATH,
+        BASE_CONFIG.replace(
+          "existingGate: coerceBool(cfg.existingGate) === true,",
+          "existingGate: coerceBool(cfg.existingGate) ?? true,",
+        ),
+      );
+      await write(".changeset/graduate.md", changeset("Graduate existingGate.\n\nStability: stable"));
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /entry survives/);
+    },
+  );
+});
+
+test("deleting a registry entry while the flag is still default-off fails", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(REGISTRY_PATH, `${JSON.stringify({ ...BASE_REGISTRY, flags: [] }, null, 2)}\n`);
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /was deleted, but the flag is still default-off/);
+    },
+  );
+});
+
+test("a graduation PR that flips the default and deletes the entry passes", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(
+        CONFIG_PATH,
+        BASE_CONFIG.replace(
+          "existingGate: coerceBool(cfg.existingGate) === true,",
+          "existingGate: coerceBool(cfg.existingGate) ?? true,",
+        ),
+      );
+      await write(REGISTRY_PATH, `${JSON.stringify({ ...BASE_REGISTRY, flags: [] }, null, 2)}\n`);
+      await write(".changeset/graduate.md", changeset("Graduate existingGate to default-on.\n\nStability: stable"));
+    },
+    (result) => {
+      assert.equal(result.status, 0, result.stderr);
+    },
+  );
+});
+
+test("a registry entry that outlives its config key fails", async () => {
+  await withFixture(
+    async ({ write }) => {
+      await write(CONFIG_PATH, BASE_CONFIG.replace("    existingGate: coerceBool(cfg.existingGate) === true,\n", ""));
+      await write(".changeset/remove.md", changeset("Remove the gate.\n\nStability: stable"));
+    },
+    (result) => {
+      assert.equal(result.status, 1, result.stderr);
+      assert.match(result.stderr, /no longer appears in/);
+    },
+  );
+});
+
+// --- unit-level guards -------------------------------------------------------
+
+test("extractDefaultOffGates finds every default-off signature and no default-on one", () => {
+  const gates = extractDefaultOffGates(`export function parseConfig(raw: unknown) {
+  return {
+    a: coerceBool(cfg.a) === true,
+    b: coerceBooleanLike(cfg.b) ?? false,
+    c: cfg.c === true,
+    d: coerceBool(cfg.d) ?? true,
+    e: coerceBooleanLike(cfg.e) ?? true,
+  };
+}
+`);
+  assert.deepEqual(gates, ["a", "b", "c"]);
+});
+
+test("extractDefaultOffGates throws instead of returning an empty set", () => {
+  assert.throws(() => extractDefaultOffGates("export const x = 1;\n"), /Could not locate/);
+});
+
+test("parseStabilityDeclarations accepts only the exact line", () => {
+  assert.deepEqual(parseStabilityDeclarations("Stability: beta").levels, ["beta"]);
+  for (const bad of ["Stability:beta", "Stability: Beta", "stability: beta", "Stability: beta ", "Stability: gamma"]) {
+    const parsed = parseStabilityDeclarations(bad);
+    assert.deepEqual(parsed.levels, [], `${bad} must not be accepted`);
+    assert.equal(parsed.invalid.length, 1, `${bad} must be reported invalid`);
+  }
+});
+
+test("parseRegistry rejects non-integer and non-finite issue numbers", () => {
+  for (const issue of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, "1234", null]) {
+    assert.throws(
+      () =>
+        parseRegistry({
+          flags: [{ flag: "f", addedIn: "1.0.0", issue, graduationCriterion: "x" }],
+        }),
+      /"issue" must be a positive integer/,
+      `issue=${String(issue)} must be rejected`,
+    );
+  }
+});
+
+test("parseRegistry sees non-enumerable and inherited fields", () => {
+  const nonEnumerable = { flag: "f", addedIn: "1.0.0", issue: 1 };
+  Object.defineProperty(nonEnumerable, "sneaky", { value: 1, enumerable: false });
+  assert.throws(() => parseRegistry({ flags: [nonEnumerable] }), /missing "graduationCriterion"|unknown field "sneaky"/);
+
+  const inherited = Object.create({ graduationCriterion: "inherited" });
+  Object.assign(inherited, { flag: "f", addedIn: "1.0.0", issue: 1 });
+  assert.throws(() => parseRegistry({ flags: [inherited] }), /missing "graduationCriterion"/);
+});
+
+test("parseRegistry rejects duplicates and a missing flags array", () => {
+  assert.throws(() => parseRegistry({}), /missing required "flags"/);
+  assert.throws(() => parseRegistry({ flags: {} }), /"flags" must be an array/);
+  const entry = { flag: "dup", addedIn: "1.0.0", issue: 1, graduationCriterion: "x" };
+  assert.throws(() => parseRegistry({ flags: [entry, { ...entry }] }), /duplicate entry for dup/);
+});
+
+test("the shipped registry parses and covers every default-off gate in config.ts", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const registry = parseRegistry(await readFile(path.join(REPO_ROOT, REGISTRY_PATH), "utf8"));
+  const gates = extractDefaultOffGates(await readFile(path.join(REPO_ROOT, CONFIG_PATH), "utf8"));
+  const unregistered = gates.filter((flag) => !registry.has(flag));
+  assert.deepEqual(unregistered, [], `unregistered default-off gates: ${unregistered.join(", ")}`);
+});


### PR DESCRIPTION
Fixes #3032

## What this adds

| File | Purpose |
| --- | --- |
| `scripts/flag-graduation.json` | Registry of 142 graduated feature flags, each with its issue reference, introduction version, and graduation criterion |
| `scripts/check-release-discipline.mjs` | Runnable validation gate that enforces changeset stability declarations, registered-flag requirements for experimental gates, and default-off rules |
| `.changeset/3032-release-channels.md` | Declares this work as `Stability: stable` |
| `docs/releases.md` | Full reference doc for the three-channel model (alpha→beta→stable) and the per-package changeset `Stability:` convention |
| `docs/development/release-process.md` | Updated to document the new channel model and the validation gate |
| `AGENTS.md` | Section referencing the release discipline rules |

## Design

- Every merge to `main` publishes to the `npm` `alpha` dist-tag
- `beta` and `latest` are promotions of an already-published version (not a separate branch)
- Packages declare their stability per-changeset: `Stability: alpha|beta|stable`
- Experimental behavior requires a registered flag in `flag-graduation.json` AND `default: false` in the config schema
- The `check-release-discipline.mjs` gate runs as a required CI check on every PR

## Verification

- Validator exits 0 against the worktree diff (docs/scripts/tests only, --base 706ad0b31):
- Mutation-proven: a changeset without a Stability line triggers the expected violation (1→0), while Stability: stable passes clean (0→0)
- Flag graduation registry contains 142 real flags covering every config boolean in the tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured alpha, beta, stable, and latest release channels.
  * Added promotion tooling to advance published versions without rebuilding or republishing.
  * Added dry-run support, validation, CI checks, soak-period safeguards, and rollback guidance.

* **Bug Fixes**
  * Added automated checks for stability declarations and feature-flag graduation requirements.

* **Documentation**
  * Documented release channels, promotion criteria, feature-flag practices, and contributor requirements.

* **Tests**
  * Added comprehensive coverage for publishing, promotion, release checks, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->