### PR TITLE
docs: add tooling and automation guidance from multi-issue batch run (#3032-#3037)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,6 +467,20 @@ kin — also semantic, not stream-rule-able):
 - deadline is shared across retries (elapsed time subtracted, not reset)
 - `session_end` drains the same way as `before_reset`
 
+
+## Tooling & Automation Guidance (Fleet Learnings)
+
+Established from multi-issue batch runs. Each row documents a repeatable friction with the preferred resolution.
+
+| Friction | Resolution |
+|---|---|
+| `omp` hangs at startup blocking on stdin | Route input from `/dev/null` — `omp --mode text < /dev/null`. The CLI's `readPipedInput` blocks on piped stdin indefinitely |
+| `task` subagents fail with `403 Access denied` for the model | The default subagent model may not have quota; override via explicit model selection in the spawner |
+| Background omp processes killed by shell job control | Use `setsid` + `disown` (or `nohup setsid`) to detach from the shell process group. Bare `&` does not survive the bash tool's job-reaping |
+| GraphQL rate limit exhausted by `gh issue edit` / `gh issue view --json` / `gh pr view --json` | Prefer REST: `gh api repos/.../issues/<n>`, `gh api repos/.../pulls/<n>/reviews`, `gh api repos/.../pulls/<n>/comments`. REST has a separate 5000-requests/hour budget |
+| `scripts/dev-worktree.sh` is a shell script | Invoke as `bash scripts/dev-worktree.sh`, never `node scripts/dev-worktree.sh` |
+
+
 ## Mechanical Stream Rules (`.omp/rules/`)
 
 The most-recurring, textually-detectable mistakes from AI review feedback are


### PR DESCRIPTION
Captures 5 repeatable frictions from the #3032-#3037 batch:

1. **omp stdin hang**: route input from `/dev/null` — `omp --mode text < /dev/null`
2. **task subagent 403**: default model may not be purchased; explicit model selection needed
3. **Background omp reaping**: use `setsid` + `disown` to survive shell job control
4. **GraphQL budget exhaustion**: prefer REST for GitHub API calls (separate 5000/hr budget)
5. **dev-worktree.sh invocation**: shell script, not node script — use `bash scripts/dev-worktree.sh`