### PR TITLE
fix: repair build breakage and address unaddressed reviewer feedback from the #3032-#3037 batch

### DIFF
--- a/.changeset/3042-restore-access-errors.md
+++ b/.changeset/3042-restore-access-errors.md
@@ -1,0 +1,13 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Stability: stable
+
+Restore the `EngramAccessForbiddenError`, `EngramAccessInputError`, and
+`NamespaceNotWritableError` exports that were inadvertently deleted from
+`@remnic/core`'s `access-errors` module, and repair a syntax error in the
+`@remnic/cli` entrypoint. Wire the teaching-rejection builders into the MCP
+unknown-tool path, scoped to caller-visible tools. Sanitize the optional
+benchmark scorecard in `remnic report` through an allow-list.

--- a/packages/bench/src/benchmarks/remnic/say-once/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/say-once/runner.test.ts
@@ -23,13 +23,13 @@ test("say-once: replay mode produces identical scorecards across two runs", asyn
     seed: 0,
     onTaskComplete: () => {},
   };
-  const result1 = await runSayOnceBenchmark(options, { replay: true });
-  const result2 = await runSayOnceBenchmark(options, { replay: true });
+  const result1 = await runSayOnceBenchmark(options);
+  const result2 = await runSayOnceBenchmark(options);
 
-  assert.equal(result1.tasks.length, result2.tasks.length);
-  for (let i = 0; i < result1.tasks.length; i++) {
-    assert.equal(result1.tasks[i].scores.recall, result2.tasks[i].scores.recall);
-    assert.equal(result1.tasks[i].taskId, result2.tasks[i].taskId);
+  assert.equal(result1.results.tasks.length, result2.results.tasks.length);
+  for (let i = 0; i < result1.results.tasks.length; i++) {
+    assert.equal(result1.results.tasks[i].scores.recall, result2.results.tasks[i].scores.recall);
+    assert.equal(result1.results.tasks[i].taskId, result2.results.tasks[i].taskId);
   }
 });
 
@@ -46,7 +46,7 @@ test("say-once: no writes outside the temp directory", async () => {
     seed: 0,
     onTaskComplete: () => {},
   };
-  await runSayOnceBenchmark(options, { replay: true });
+  await runSayOnceBenchmark(options);
 
   const after = new Set(readdirSync(tmpDir));
   // Only the temp memory dir should have been created inside tmpDir.
@@ -69,8 +69,8 @@ test("say-once: empty fixture produces zero tasks", async () => {
     seed: 0,
     onTaskComplete: () => {},
   };
-  const result = await runSayOnceBenchmark(options, { replay: true });
-  assert.equal(result.tasks.length, 0);
+  const result = await runSayOnceBenchmark(options);
+  assert.equal(result.results.tasks.length, 0);
 });
 
 // ─── Per-tier rates from known fixture ────────────────────────────────────
@@ -82,10 +82,10 @@ test("say-once: per-tier rates are computed correctly from synthetic fixture", a
     seed: 0,
     onTaskComplete: () => {},
   };
-  const result = await runSayOnceBenchmark(options, { replay: true });
+  const result = await runSayOnceBenchmark(options);
 
   // Replay mode writes the preference directly, so recall should be 1.0
-  for (const task of result.tasks) {
+  for (const task of result.results.tasks) {
     assert.equal(task.scores.recall, 1, `task ${task.taskId} should have perfect recall in replay mode`);
   }
 });
@@ -100,8 +100,8 @@ test("say-once: exit code 0 for a valid run (even with low scores)", async () =>
     onTaskComplete: () => {},
   };
   // This should not throw — scores are data, not pass/fail.
-  const result = await runSayOnceBenchmark(options, { replay: true });
-  assert.ok(result.tasks.length > 0, "should have produced tasks");
+  const result = await runSayOnceBenchmark(options);
+  assert.ok(result.results.tasks.length > 0, "should have produced tasks");
 });
 
 // ─── Fixture verification ────────────────────────────────────────────────

--- a/packages/bench/src/benchmarks/remnic/say-once/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/say-once/runner.test.ts
@@ -21,6 +21,7 @@ test("say-once: replay mode produces identical scorecards across two runs", asyn
     benchmark: sayOnceDefinition,
     mode: "quick" as const,
     seed: 0,
+    system: {} as never,
     onTaskComplete: () => {},
   };
   const result1 = await runSayOnceBenchmark(options);
@@ -44,6 +45,7 @@ test("say-once: no writes outside the temp directory", async () => {
     benchmark: sayOnceDefinition,
     mode: "quick" as const,
     seed: 0,
+    system: {} as never,
     onTaskComplete: () => {},
   };
   await runSayOnceBenchmark(options);
@@ -67,6 +69,7 @@ test("say-once: empty fixture produces zero tasks", async () => {
     mode: "full" as const,
     limit: 0, // zero budget = no tasks
     seed: 0,
+    system: {} as never,
     onTaskComplete: () => {},
   };
   const result = await runSayOnceBenchmark(options);
@@ -80,6 +83,7 @@ test("say-once: per-tier rates are computed correctly from synthetic fixture", a
     benchmark: sayOnceDefinition,
     mode: "full" as const,
     seed: 0,
+    system: {} as never,
     onTaskComplete: () => {},
   };
   const result = await runSayOnceBenchmark(options);
@@ -97,6 +101,7 @@ test("say-once: exit code 0 for a valid run (even with low scores)", async () =>
     benchmark: sayOnceDefinition,
     mode: "quick" as const,
     seed: 0,
+    system: {} as never,
     onTaskComplete: () => {},
   };
   // This should not throw — scores are data, not pass/fail.

--- a/packages/bench/src/benchmarks/remnic/say-once/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/say-once/runner.test.ts
@@ -10,6 +10,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import type { Message } from "../../../adapters/types.js";
 
 import { runSayOnceBenchmark, sayOnceDefinition } from "./runner.js";
 import { SAY_ONCE_CASES, SAY_ONCE_SMOKE_FIXTURE, type VaguenessTier } from "./fixture.js";
@@ -21,7 +22,7 @@ test("say-once: replay mode produces identical scorecards across two runs", asyn
     benchmark: sayOnceDefinition,
     mode: "quick" as const,
     seed: 0,
-    system: {} as never,
+    system: buildRecordingAdapter().system,
     onTaskComplete: () => {},
   };
   const result1 = await runSayOnceBenchmark(options);
@@ -45,7 +46,7 @@ test("say-once: no writes outside the temp directory", async () => {
     benchmark: sayOnceDefinition,
     mode: "quick" as const,
     seed: 0,
-    system: {} as never,
+    system: buildRecordingAdapter().system,
     onTaskComplete: () => {},
   };
   await runSayOnceBenchmark(options);
@@ -69,7 +70,7 @@ test("say-once: empty fixture produces zero tasks", async () => {
     mode: "full" as const,
     limit: 0, // zero budget = no tasks
     seed: 0,
-    system: {} as never,
+    system: buildRecordingAdapter().system,
     onTaskComplete: () => {},
   };
   const result = await runSayOnceBenchmark(options);
@@ -83,7 +84,7 @@ test("say-once: per-tier rates are computed correctly from synthetic fixture", a
     benchmark: sayOnceDefinition,
     mode: "full" as const,
     seed: 0,
-    system: {} as never,
+    system: buildRecordingAdapter().system,
     onTaskComplete: () => {},
   };
   const result = await runSayOnceBenchmark(options);
@@ -101,7 +102,7 @@ test("say-once: exit code 0 for a valid run (even with low scores)", async () =>
     benchmark: sayOnceDefinition,
     mode: "quick" as const,
     seed: 0,
-    system: {} as never,
+    system: buildRecordingAdapter().system,
     onTaskComplete: () => {},
   };
   // This should not throw — scores are data, not pass/fail.
@@ -136,4 +137,87 @@ test("say-once: benchmark definition is valid", () => {
   assert.equal(sayOnceDefinition.tier, "remnic");
   assert.equal(sayOnceDefinition.status, "ready");
   assert.equal(sayOnceDefinition.runnerAvailable, true);
+});
+// ─── Adapter-driven recall path (#3042 P1 finding) ──────────────────────────
+
+/**
+ * Minimal adapter that records every store/recall call and answers recall
+ * using the stored messages, so the runner can be tested without booting
+ * the real retrieval pipeline.
+ */
+function buildRecordingAdapter() {
+  const stored = new Map<string, Message[]>();
+  const storeCalls: { sessionId: string; messages: Message[] }[] = [];
+  const recallCalls: { sessionId: string; query: string }[] = [];
+  return {
+    stored,
+    storeCalls,
+    recallCalls,
+    system: {
+      async store(sessionId: string, messages: Message[]): Promise<void> {
+        storeCalls.push({ sessionId, messages });
+        const prev = stored.get(sessionId) ?? [];
+        stored.set(sessionId, prev.concat(messages));
+      },
+      async recall(sessionId: string, query: string): Promise<string> {
+        recallCalls.push({ sessionId, query });
+        const msgs = stored.get(sessionId) ?? [];
+        // Trivial recall: surface every stored message as context.
+        return msgs.map((m) => `${m.role}: ${m.content}`).join("\n");
+      },
+      async search(): Promise<never[]> { return []; },
+      async reset(): Promise<void> {},
+      async getStats(): Promise<{ totalMessages: number; totalSummaryNodes: number; maxDepth: number }> {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+      async destroy(): Promise<void> {},
+    },
+  };
+}
+
+test("say-once: routes every store+recall through the adapter, never the filesystem (#3042)", async () => {
+  const rec = buildRecordingAdapter();
+  const options = {
+    benchmark: sayOnceDefinition,
+    mode: "quick" as const,
+    seed: 0,
+    system: rec.system,
+    onTaskComplete: () => {},
+  };
+  const result = await runSayOnceBenchmark(options);
+  // At least one store + one recall per case.
+  assert.ok(rec.storeCalls.length >= result.results.tasks.length, "each case stores once");
+  assert.ok(rec.recallCalls.length >= result.results.tasks.length, "each case recalls at least once");
+  // Replay against this trivial adapter surfaces the seed message text,
+  // so all fixtures should report 1.0 recall.
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.recall, 1, `task ${task.taskId} should recall the preference`);
+  }
+});
+
+test("say-once: isolated session ids prevent cross-task recall bleed", async () => {
+  const rec = buildRecordingAdapter();
+  const options = {
+    benchmark: sayOnceDefinition,
+    mode: "full" as const,
+    seed: 0,
+    system: rec.system,
+    onTaskComplete: () => {},
+  };
+  await runSayOnceBenchmark(options);
+  const sessionIds = new Set(rec.storeCalls.map((c) => c.sessionId));
+  assert.equal(sessionIds.size, rec.storeCalls.length, "each store call uses a unique session");
+});
+
+test("say-once: refuses to run without a memory adapter (#3042 contract)", async () => {
+  const options = {
+    benchmark: sayOnceDefinition,
+    mode: "quick" as const,
+    seed: 0,
+    onTaskComplete: () => {},
+  } as unknown as Parameters<typeof runSayOnceBenchmark>[0];
+  await assert.rejects(
+    () => runSayOnceBenchmark(options),
+    /BenchMemoryAdapter is required/,
+  );
 });

--- a/packages/bench/src/benchmarks/remnic/say-once/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/say-once/runner.ts
@@ -7,9 +7,12 @@
  *
  * SCOPE: replay mode only.
  *
- * Replay writes each fixture's target preference into a fresh temp store
- * through the real sealed-envelope write path, then probes recall over that
- * store. It is deterministic, offline, and safe for CI.
+ * Each case runs through the bench adapter contract: the seed user/assistant
+ * turn is stored via `system.store`, then each probe's prompt is fed to
+ * `system.recall`. The harness never touches the filesystem directly; a
+ * benchmark that scores recall without going through recall is measuring
+ * disk, not retrieval, and ships misleading perfect-recall numbers (#3042
+ * review, P1).
  *
  * Live mode (drive the real LLM extraction pipeline, then probe) is NOT
  * implemented here. The Orchestrator exposes no programmatic turn-ingestion
@@ -17,16 +20,10 @@
  * harness needs a new seam in core rather than a call from this package.
  * Tracked separately; see the package README. Nothing here reports a live
  * result, because there is no live path: `runSayOnceBenchmark` has one code
- * path and it always writes to a fresh temp dir.
+ * path and it always goes through the adapter contract.
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
-import { readdirSync, readFileSync, statSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { StorageManager, parseConfig } from "@remnic/core";
-import { composeMemoryEnvelope } from "@remnic/core/write-envelope";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -96,13 +93,12 @@ export function resolveSayOnceLimit(raw: unknown): number {
 
 // Signature is deliberately the registry's one-arg `run` contract
 // (`registry.ts`: `run?: (options: ResolvedRunBenchmarkOptions) => ...`).
-// There is no mode parameter because there is only one mode: every case runs
-// against a fresh `mkdtemp` store, and this module imports nothing that could
-// reach the operator's live memory dir.
+// There is no mode parameter because there is only one mode: every case goes
+// through the adapter contract, and this module never reaches into a file
+// system that could carry operator memory content.
 export async function runSayOnceBenchmark(
   options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
-
   const source = options.mode === "quick" ? SAY_ONCE_SMOKE_FIXTURE : SAY_ONCE_CASES;
   if (source.length === 0) {
     throw new SayOnceHarnessError("say-once: fixture set is empty");
@@ -111,22 +107,36 @@ export async function runSayOnceBenchmark(
   const cases = takeWithinBudget(source, resolveSayOnceLimit(options.limit));
   const tasks: TaskResult[] = [];
 
+  const system = options.system;
+  // The benchmark contract REQUIRES a memory adapter -- without one there is
+  // no recall path to score against (checklist 39: missing required input
+  // rejects, not silently defaults).
+  if (!system) {
+    throw new SayOnceHarnessError(
+      "say-once: a BenchMemoryAdapter is required (pass --adapter or wire one through the bench runner)",
+    );
+  }
+
+  let caseIndex = 0;
   for (const sample of cases) {
+    caseIndex += 1;
     const startedAt = performance.now();
-    // Store safety: a fresh temp dir per case. The operator's live store is
-    // never opened — this harness has no path to it.
-    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-say-once-"));
+    // A fresh session id per case so each task has an isolated namespace and
+    // no cross-task recall bleed.
+    const sessionId = `say-once-${sample.id}-${randomUUID()}`;
     try {
-      const result = await runSingleCase(sample, dir);
+      const result = await runSingleCase(sample, sessionId, system);
       tasks.push({
         ...result,
         latencyMs: Math.round(performance.now() - startedAt),
         tokens: { input: 0, output: 0 },
       });
     } finally {
-      await rm(dir, { recursive: true, force: true });
+      // The adapter's reset/destroy handle the underlying storage; we don't
+      // fabricate a per-session API that the contract doesn't expose.
+      await system.reset(sessionId).catch(() => {});
     }
-    options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, cases.length);
+    options.onTaskComplete?.(tasks[tasks.length - 1]!, caseIndex, cases.length);
   }
 
   const remnicVersion = await getRemnicVersion();
@@ -171,29 +181,27 @@ export async function runSayOnceBenchmark(
   };
 }
 
-async function runSingleCase(sample: SayOnceCase, dir: string): Promise<Omit<TaskResult, "latencyMs" | "tokens">> {
-  // Real parsed config, memory dir forced to the temp dir.
-  parseConfig({ memoryDir: dir, workspaceDir: path.join(dir, "ws"), qmdEnabled: false });
-
-  const storage = new StorageManager(dir);
-  await storage.ensureDirectories();
-
-  // Replay: persist the target preference through the real sealed-envelope
-  // write path, standing in for what extraction would have produced.
-  await storage.writeSealedMemory(
-    composeMemoryEnvelope(
-      { content: sample.preference, category: "preference" },
-      { source: "bench" },
-    ),
-    {},
-  );
+async function runSingleCase(
+  sample: SayOnceCase,
+  sessionId: string,
+  system: ResolvedRunBenchmarkOptions["system"],
+): Promise<Omit<TaskResult, "latencyMs" | "tokens">> {
+  // Store through the real adapter ingest path -- same surface a live turn
+  // would take through extraction. We do NOT bypass into raw .md files; a
+  // benchmark that scores recall without going through recall is measuring
+  // disk, not retrieval, and ships misleading perfect-recall numbers.
+  const now = new Date().toISOString();
+  await system.store(sessionId, [
+    { role: "user", content: sample.seedUserMessage, timestamp: now },
+    { role: "assistant", content: sample.seedAssistantMessage, timestamp: now },
+  ]);
 
   let recalled = 0;
   const probeNotes: string[] = [];
-  const storeText = readStoreText(dir);
 
   for (const probe of sample.probes) {
-    const hit = storeText.includes(probe.expectInRecall);
+    const recalledContext = await system.recall(sessionId, probe.prompt, 2000);
+    const hit = recalledContext.toLowerCase().includes(probe.expectInRecall.toLowerCase());
     if (hit) recalled += 1;
     probeNotes.push(
       `${probe.prompt} -> ${hit ? "recalled" : "missed"} (expected "${probe.expectInRecall}")`,
@@ -210,30 +218,4 @@ async function runSingleCase(sample: SayOnceCase, dir: string): Promise<Omit<Tas
     scores: { recall: rate },
     details: { tier: sample.tier, probes: probeNotes },
   };
-}
-
-/** Concatenate every stored memory under `dir`. Confined to the temp store. */
-function readStoreText(dir: string): string {
-  const chunks: string[] = [];
-  const walk = (current: string): void => {
-    let entries: string[];
-    try {
-      entries = readdirSync(current);
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const full = path.join(current, entry);
-      let stat;
-      try {
-        stat = statSync(full);
-      } catch {
-        continue;
-      }
-      if (stat.isDirectory()) walk(full);
-      else if (entry.endsWith(".md")) chunks.push(readFileSync(full, "utf-8"));
-    }
-  };
-  walk(dir);
-  return chunks.join("\n");
 }

--- a/packages/bench/src/benchmarks/remnic/say-once/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/say-once/runner.ts
@@ -1,33 +1,45 @@
 /**
- * Say-Once benchmark: round-trip extraction -> recall reliability (issue #3036).
+ * Say-Once benchmark: extraction -> recall round-trip reliability (issue #3036).
  *
- * For each fixture case: seed a preference at a vagueness tier, process it
- * through the real extraction pipeline, then probe with related prompts and
- * check if the preference appears in the injected recall context.
+ * The product promise is that a preference mentioned ONCE — even vaguely — is
+ * stored and resurfaces in a later relevant context. This scores that promise
+ * per vagueness tier (explicit / casual / buried-mid-task).
  *
- * Two modes:
- *   - live: drives the real orchestrator (needs LLM keys for extraction)
- *   - replay: mocks extraction by writing the preference directly, checks
- *     recall deterministically. CI-safe.
+ * SCOPE: replay mode only.
+ *
+ * Replay writes each fixture's target preference into a fresh temp store
+ * through the real sealed-envelope write path, then probes recall over that
+ * store. It is deterministic, offline, and safe for CI.
+ *
+ * Live mode (drive the real LLM extraction pipeline, then probe) is NOT
+ * implemented here. The Orchestrator exposes no programmatic turn-ingestion
+ * seam — buffering happens through the host's `agent_end` hook — so a live
+ * harness needs a new seam in core rather than a call from this package.
+ * Tracked separately; see the package README. Nothing here reports a live
+ * result, because there is no live path: `runSayOnceBenchmark` has one code
+ * path and it always writes to a fresh temp dir.
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { parseConfig, StorageManager, Orchestrator } from "@remnic/core";
+import { StorageManager, parseConfig } from "@remnic/core";
 import { composeMemoryEnvelope } from "@remnic/core/write-envelope";
-import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../../types.js";
-import { aggregateTaskScores, exactMatch } from "../../../scorer.js";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import { SAY_ONCE_CASES, SAY_ONCE_SMOKE_FIXTURE } from "./fixture.js";
 import type { SayOnceCase } from "./fixture.js";
 
-export interface SayOnceRunOptions {
-  /** When true, avoid LLM calls by writing fixture preference directly. */
-  replay?: boolean;
-}
+/** Scorecard schema tag. Consumed by `remnic report --include-bench`. */
+export const SAY_ONCE_SCORECARD_VERSION = "1";
 
 export const sayOnceDefinition: BenchmarkDefinition = {
   id: "say-once",
@@ -39,157 +51,189 @@ export const sayOnceDefinition: BenchmarkDefinition = {
     name: "say-once",
     version: "1.0.0",
     description:
-      "Round-trip extraction -> recall reliability: seeds a preference, extracts it, then checks if it surfaces in later recall (issue #3036).",
+      "Scores whether a preference stated once at a given vagueness tier resurfaces in later recall (issue #3036). Replay mode only.",
     category: "retrieval",
     citation: "Remnic internal synthetic benchmark for issue #3036",
   },
 };
 
-function sliceWithBudget<T>(cases: T[], budget: number): { picked: T[]; remaining: number } {
-  if (!Number.isFinite(budget)) {
-    return { picked: cases, remaining: Number.POSITIVE_INFINITY };
+/** Thrown for harness faults. Scores are DATA; only harness errors are fatal. */
+export class SayOnceHarnessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SayOnceHarnessError";
   }
-  if (budget <= 0) {
-    return { picked: [], remaining: 0 };
-  }
-  const n = Math.min(cases.length, Math.floor(budget));
-  return { picked: cases.slice(0, n), remaining: budget - n };
 }
 
 /**
- * Run the say-once benchmark.
- *
- * @param options - Standard benchmark options.
- * @param runOptions.replay - When true, avoids LLM calls by writing
- *   fixture preference directly to the store. Deterministic and CI-safe.
+ * Take at most `budget` cases. A budget of exactly 0 means zero, never "all"
+ * (checklist 17: `slice(-0)` silently returns everything).
  */
+function takeWithinBudget<T>(cases: readonly T[], budget: number): T[] {
+  if (!Number.isFinite(budget)) return [...cases];
+  if (budget <= 0) return [];
+  return cases.slice(0, Math.floor(budget));
+}
+
+/**
+ * Resolve `--limit`, which arrives as a string from the CLI. Rejects a
+ * non-integer or non-finite value rather than silently defaulting
+ * (checklist 1 / 17 / 39).
+ */
+export function resolveSayOnceLimit(raw: unknown): number {
+  if (raw === undefined || raw === null) return Number.POSITIVE_INFINITY;
+  const value = typeof raw === "string" ? Number(raw) : raw;
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new SayOnceHarnessError(
+      `say-once: --limit must be a finite integer; got ${JSON.stringify(raw)}`,
+    );
+  }
+  if (value < 0) {
+    throw new SayOnceHarnessError(`say-once: --limit must not be negative; got ${value}`);
+  }
+  return value;
+}
+
+// Signature is deliberately the registry's one-arg `run` contract
+// (`registry.ts`: `run?: (options: ResolvedRunBenchmarkOptions) => ...`).
+// There is no mode parameter because there is only one mode: every case runs
+// against a fresh `mkdtemp` store, and this module imports nothing that could
+// reach the operator's live memory dir.
 export async function runSayOnceBenchmark(
   options: ResolvedRunBenchmarkOptions,
-  runOptions: SayOnceRunOptions = {},
 ): Promise<BenchmarkResult> {
-  const tasks: TaskResult[] = [];
-  const source = options.mode === "quick" ? SAY_ONCE_SMOKE_FIXTURE : SAY_ONCE_CASES;
 
-  const taskBudget =
-    typeof options.limit === "number" && options.limit >= 0 && Number.isFinite(options.limit)
-      ? Math.floor(options.limit)
-      : Number.POSITIVE_INFINITY;
-  const picked = sliceWithBudget(source, taskBudget);
-  const cases = picked.picked;
-  const totalTasks = cases.length;
+  const source = options.mode === "quick" ? SAY_ONCE_SMOKE_FIXTURE : SAY_ONCE_CASES;
+  if (source.length === 0) {
+    throw new SayOnceHarnessError("say-once: fixture set is empty");
+  }
+
+  const cases = takeWithinBudget(source, resolveSayOnceLimit(options.limit));
+  const tasks: TaskResult[] = [];
 
   for (const sample of cases) {
     const startedAt = performance.now();
+    // Store safety: a fresh temp dir per case. The operator's live store is
+    // never opened — this harness has no path to it.
     const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-say-once-"));
     try {
-      const result = await runSingleCase(sample, dir, runOptions.replay ?? false);
-      const latencyMs = Math.round(performance.now() - startedAt);
-      tasks.push({ ...result, latencyMs, tokens: { input: 0, output: 0 } });
+      const result = await runSingleCase(sample, dir);
+      tasks.push({
+        ...result,
+        latencyMs: Math.round(performance.now() - startedAt),
+        tokens: { input: 0, output: 0 },
+      });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
-    options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalTasks);
+    options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, cases.length);
   }
 
-  const scores = aggregateTaskScores(tasks, ["recall"]);
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
   return {
-    benchmark: sayOnceDefinition,
-    gitSha: getGitSha(),
-    remnicVersion: getRemnicVersion(),
-    config: options,
-    startedAt: new Date().toISOString(),
-    tasks,
-    scores,
-    aggregates: { scores },
-    meta: { invocation: options },
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
   };
 }
 
-async function runSingleCase(
-  sample: SayOnceCase,
-  dir: string,
-  replay: boolean,
-): Promise<TaskResult> {
-  const config = parseConfig({
-    memoryDir: dir,
-    workspaceDir: path.join(dir, "ws"),
-    openaiApiKey: replay ? "bench-replay-key" : undefined,
-    qmdEnabled: false,
-  });
+async function runSingleCase(sample: SayOnceCase, dir: string): Promise<Omit<TaskResult, "latencyMs" | "tokens">> {
+  // Real parsed config, memory dir forced to the temp dir.
+  parseConfig({ memoryDir: dir, workspaceDir: path.join(dir, "ws"), qmdEnabled: false });
 
   const storage = new StorageManager(dir);
   await storage.ensureDirectories();
 
-  if (replay) {
-    // Replay mode: write the preference directly as a fact, bypassing the
-    // LLM extraction pipeline. This is deterministic and CI-safe.
-    await storage.writeSealedMemory(
-      composeMemoryEnvelope(
-        {
-          content: sample.preference,
-          category: "preference",
-        },
-        { source: "bench" },
-      ),
-      {},
-    );
-  } else {
-    // Live mode: drive the real extraction pipeline.
-    // Boot the orchestrator, process the seed conversation, force flush.
-    const orchestrator = new Orchestrator({ config, storage });
-    await orchestrator.initialize();
-    await orchestrator.processTurn("user", sample.seedUserMessage, "seed-session");
-    await orchestrator.processTurn("assistant", sample.seedAssistantMessage, "seed-session");
-    await orchestrator.runExtraction(orchestrator.getBufferedTurns("seed-session"));
-  }
+  // Replay: persist the target preference through the real sealed-envelope
+  // write path, standing in for what extraction would have produced.
+  await storage.writeSealedMemory(
+    composeMemoryEnvelope(
+      { content: sample.preference, category: "preference" },
+      { source: "bench" },
+    ),
+    {},
+  );
 
-  // Probe: run the recall pipeline for each probe prompt.
-  let probesPassed = 0;
-  const probeDetails: string[] = [];
+  let recalled = 0;
+  const probeNotes: string[] = [];
+  const storeText = readStoreText(dir);
 
   for (const probe of sample.probes) {
-    const recallResult = await runProbeRecall(storage, probe.prompt, dir);
-    const found = recallResult.includes(probe.expectInRecall);
-    if (found) probesPassed++;
-    probeDetails.push(
-      `${probe.prompt}: ${found ? "recalled" : "missed"} (expected "${probe.expectInRecall}")`,
+    const hit = storeText.includes(probe.expectInRecall);
+    if (hit) recalled += 1;
+    probeNotes.push(
+      `${probe.prompt} -> ${hit ? "recalled" : "missed"} (expected "${probe.expectInRecall}")`,
     );
   }
 
-  const recallRate = sample.probes.length > 0 ? probesPassed / sample.probes.length : 0;
+  const rate = sample.probes.length > 0 ? recalled / sample.probes.length : 0;
 
   return {
     taskId: sample.id,
     question: sample.seedUserMessage,
-    expected: `recall rate 1.0 (${sample.probes.length} probe(s))`,
-    actual: `recall rate ${recallRate} (${probesPassed}/${sample.probes.length})`,
-    scores: { recall: recallRate },
-    details: { tier: sample.tier, probes: probeDetails },
+    expected: `all ${sample.probes.length} probe(s) recall the preference`,
+    actual: `${recalled}/${sample.probes.length} recalled`,
+    scores: { recall: rate },
+    details: { tier: sample.tier, probes: probeNotes },
   };
 }
 
-async function runProbeRecall(
-  storage: StorageManager,
-  prompt: string,
-  memoryDir: string,
-): Promise<string> {
-  // Read all stored facts. Uses static imports (rule: ts-no-dynamic-import).
-  const results: string[] = [];
-  const walk = (dir: string): void => {
+/** Concatenate every stored memory under `dir`. Confined to the temp store. */
+function readStoreText(dir: string): string {
+  const chunks: string[] = [];
+  const walk = (current: string): void => {
+    let entries: string[];
     try {
-      for (const entry of readdirSync(dir)) {
-        const full = path.join(dir, entry);
-        const st = statSync(full);
-        if (st.isDirectory()) walk(full);
-        else if (entry.endsWith(".md")) {
-          const content = readFileSync(full, "utf-8");
-          results.push(content);
-        }
-      }
+      entries = readdirSync(current);
     } catch {
-      // directory may not exist yet
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry);
+      let stat;
+      try {
+        stat = statSync(full);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) walk(full);
+      else if (entry.endsWith(".md")) chunks.push(readFileSync(full, "utf-8"));
     }
   };
-  walk(memoryDir);
-  return results.join("\n");
+  walk(dir);
+  return chunks.join("\n");
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -74,7 +74,6 @@ import {
   createSpace,
   deleteSpace,
   switchSpace,
-import { cmdReport } from "./report.js";
   pushToSpace,
   pullFromSpace,
   shareSpace,
@@ -301,6 +300,7 @@ import {
 } from "./openclaw-managed-upgrade-loader.js";
 import { expandTilde, resolveHomeDir } from "./path-utils.js";
 import { resolveConfigPath } from "./config-path.js";
+import { cmdReport } from "./report.js";
 export { resolveConfigPath };
 import {
   hostedOnlyDaemonRefusalMessage,

--- a/packages/remnic-cli/src/report.test.ts
+++ b/packages/remnic-cli/src/report.test.ts
@@ -181,21 +181,22 @@ test("non-enumerable and inherited config keys are excluded from the report", ()
 
 test("summarizeBenchScorecard drops every field outside the allow-list", () => {
   const sentinel = "SENTINEL_MEMORY_CONTENT_do_not_leak";
-  // Shaped like a real report card, which carries questions, answers, and
-  // recalled context alongside the aggregates.
+  // Canonical BenchmarkResult shape: meta.benchmark, results.tasks,
+  // results.aggregates (packages/bench/src/types.ts).
   const raw = {
-    benchmark: { id: "say-once", title: sentinel, citation: sentinel },
-    tasks: [
-      { taskId: "t1", question: sentinel, expected: sentinel, actual: sentinel },
-      { taskId: "t2", question: sentinel, details: { probes: [sentinel] } },
-    ],
-    scores: { recall: { mean: 0.5, median: 0.5 }, leaked: sentinel },
+    meta: { benchmark: "say-once", invocation: { note: sentinel } },
+    results: {
+      tasks: [
+        { taskId: "t1", question: sentinel, expected: sentinel, actual: sentinel },
+        { taskId: "t2", question: sentinel, details: { probes: [sentinel] } },
+      ],
+      aggregates: { recall: { mean: 0.5, median: 0.5 }, leaked: sentinel },
+    },
     config: { memoryDir: "/some/private/path", openaiApiKey: sentinel },
-    meta: { invocation: { note: sentinel } },
   };
 
   const summary = summarizeBenchScorecard(raw);
-  assert.ok(summary, "a scorecard with aggregates should summarize");
+  assert.ok(summary, "a canonical result should summarize");
   const rendered = JSON.stringify(summary);
 
   assert.doesNotMatch(rendered, new RegExp(sentinel), "no scorecard content may survive");
@@ -203,16 +204,31 @@ test("summarizeBenchScorecard drops every field outside the allow-list", () => {
   assert.equal(summary.benchmarkId, "say-once");
   assert.equal(summary.taskCount, 2);
   assert.equal(summary.scores?.recall, 0.5);
-  // A string-valued score is dropped, not stringified.
   assert.equal(Object.hasOwn(summary.scores ?? {}, "leaked"), false);
 });
 
-test("summarizeBenchScorecard rejects a non-identifier benchmark id", () => {
+test("summarizeBenchScorecard reads the canonical result shape, not a bare one", () => {
+  // Regression for the review finding that the extractor read top-level
+  // `tasks`/`scores` and therefore silently produced nothing for real
+  // @remnic/bench artifacts.
   const summary = summarizeBenchScorecard({
-    benchmark: { id: "Not An Id: with content and /paths/" },
-    tasks: [],
+    meta: { benchmark: "locomo" },
+    results: { tasks: [{ taskId: "a" }, { taskId: "b" }, { taskId: "c" }], aggregates: { f1: { mean: 0.42 } } },
   });
-  assert.equal(summary?.benchmarkId, undefined, "free-text id must be dropped");
+  assert.equal(summary?.taskCount, 3, "must read results.tasks");
+  assert.equal(summary?.scores?.f1, 0.42, "must read results.aggregates");
+  assert.equal(summary?.benchmarkId, "locomo", "must read meta.benchmark");
+});
+
+test("summarizeBenchScorecard maps a user-defined benchmark id to \"custom\"", () => {
+  // A custom benchmark can be named after a client, project, or person.
+  // Syntax restrictions do not anonymize it, so it must not be echoed.
+  const summary = summarizeBenchScorecard({
+    meta: { benchmark: "client-alpha-migration" },
+    results: { tasks: [{ taskId: "t" }], aggregates: { score: 1 } },
+  });
+  assert.equal(summary?.benchmarkId, "custom", "a non-built-in id must not be echoed");
+  assert.equal(summary?.taskCount, 1, "the count still conveys signal");
 });
 
 test("the rendered report never contains raw scorecard JSON", () => {
@@ -226,9 +242,8 @@ test("the rendered report never contains raw scorecard JSON", () => {
     configShape: {},
     storeScale: { totalMemories: 0, sizeBucket: "< 1 KB" },
     benchScorecard: summarizeBenchScorecard({
-      benchmark: { id: "say-once", title: sentinel },
-      tasks: [{ taskId: "t1", question: sentinel }],
-      scores: { recall: 1 },
+      meta: { benchmark: "say-once", note: sentinel },
+      results: { tasks: [{ taskId: "t1", question: sentinel }], aggregates: { recall: 1 } },
     }),
   };
   const md = renderReportMarkdown(report);

--- a/packages/remnic-cli/src/report.test.ts
+++ b/packages/remnic-cli/src/report.test.ts
@@ -251,3 +251,53 @@ test("the rendered report never contains raw scorecard JSON", () => {
   assert.doesNotMatch(md, new RegExp(sentinel));
   assert.doesNotMatch(json, new RegExp(sentinel));
 });
+// ─── Metric name allow-list (#3042 P1) ─────────────────────────────────────
+
+test("summarizeBenchScorecard rejects user-defined metric keys like client_alpha", () => {
+  const raw = {
+    meta: { benchmark: "say-once" },
+    results: {
+      aggregates: {
+        recall: { mean: 0.5 },
+        client_alpha: { mean: 1.0 },
+        "some user note": { mean: 0.9 },
+      },
+    },
+  };
+  const summary = summarizeBenchScorecard(raw);
+  assert.ok(summary);
+  assert.equal(summary?.scores?.recall, 0.5);
+  assert.equal(summary?.scores?.client_alpha, undefined, "non-public key must not leak");
+  assert.equal(summary?.scores?.["some user note"], undefined, "free text key must not leak");
+});
+
+// ─── Public benchmark id list is exhaustive (#3042 P2) ──────────────────────
+
+test("summarizeBenchScorecard recognizes every registered benchmark id", () => {
+  // The fixture list covers phase-1 plus remnic-native; any id not on
+  // PUBLIC_BENCHMARK_IDS collapses to "custom".
+  for (const id of [
+    "memory-arena",
+    "amemgym",
+    "taxonomy-accuracy",
+    "retrieval-personalization",
+    "retrieval-temporal",
+    "retrieval-graph",
+    "retrieval-reasoning-trace",
+    "ingestion-entity-recall",
+    "ingestion-schema-completeness",
+    "ingestion-backlink-f1",
+    "ingestion-setup-friction",
+    "ingestion-citation-accuracy",
+    "assistant-morning-brief",
+    "assistant-meeting-prep",
+    "assistant-next-best-action",
+    "assistant-synthesis",
+    "buffer-surprise-trigger",
+    "retention-aged-dataset",
+    "staged-memory-synthetic-v1",
+  ]) {
+    const summary = summarizeBenchScorecard({ meta: { benchmark: id } });
+    assert.equal(summary?.benchmarkId, id, `${id} should be recognized as public`);
+  }
+});

--- a/packages/remnic-cli/src/report.test.ts
+++ b/packages/remnic-cli/src/report.test.ts
@@ -13,7 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { REPORT_ALLOWED_CONFIG_FIELDS, buildReport, renderReportJson, renderReportMarkdown, sizeBucket } from "./report.js";
+import { REPORT_ALLOWED_CONFIG_FIELDS, buildReport, renderReportJson, renderReportMarkdown, sizeBucket, summarizeBenchScorecard } from "./report.js";
 
 // ─── Sentinel leak test ───────────────────────────────────────────────────
 
@@ -175,4 +175,64 @@ test("non-enumerable and inherited config keys are excluded from the report", ()
   // Allowed booleans should be present
   assert.equal(Object.hasOwn(result, "qmdEnabled"), true, "qmdEnabled should be present");
   assert.equal(Object.hasOwn(result, "debug"), true, "debug should be present");
+});
+
+// ─── Bench scorecard sanitization (#3037 review, P1) ──────────────────────
+
+test("summarizeBenchScorecard drops every field outside the allow-list", () => {
+  const sentinel = "SENTINEL_MEMORY_CONTENT_do_not_leak";
+  // Shaped like a real report card, which carries questions, answers, and
+  // recalled context alongside the aggregates.
+  const raw = {
+    benchmark: { id: "say-once", title: sentinel, citation: sentinel },
+    tasks: [
+      { taskId: "t1", question: sentinel, expected: sentinel, actual: sentinel },
+      { taskId: "t2", question: sentinel, details: { probes: [sentinel] } },
+    ],
+    scores: { recall: { mean: 0.5, median: 0.5 }, leaked: sentinel },
+    config: { memoryDir: "/some/private/path", openaiApiKey: sentinel },
+    meta: { invocation: { note: sentinel } },
+  };
+
+  const summary = summarizeBenchScorecard(raw);
+  assert.ok(summary, "a scorecard with aggregates should summarize");
+  const rendered = JSON.stringify(summary);
+
+  assert.doesNotMatch(rendered, new RegExp(sentinel), "no scorecard content may survive");
+  assert.doesNotMatch(rendered, /private\/path/, "no paths may survive");
+  assert.equal(summary.benchmarkId, "say-once");
+  assert.equal(summary.taskCount, 2);
+  assert.equal(summary.scores?.recall, 0.5);
+  // A string-valued score is dropped, not stringified.
+  assert.equal(Object.hasOwn(summary.scores ?? {}, "leaked"), false);
+});
+
+test("summarizeBenchScorecard rejects a non-identifier benchmark id", () => {
+  const summary = summarizeBenchScorecard({
+    benchmark: { id: "Not An Id: with content and /paths/" },
+    tasks: [],
+  });
+  assert.equal(summary?.benchmarkId, undefined, "free-text id must be dropped");
+});
+
+test("the rendered report never contains raw scorecard JSON", () => {
+  const sentinel = "SENTINEL_LEAK_CHECK";
+  const report = {
+    schemaVersion: "1" as const,
+    generatedAt: "2026-08-26T12:00:00.000Z",
+    platform: { os: "linux", arch: "x64", node: "v22.23.1" },
+    remnicVersion: "9.69.56",
+    doctor: [],
+    configShape: {},
+    storeScale: { totalMemories: 0, sizeBucket: "< 1 KB" },
+    benchScorecard: summarizeBenchScorecard({
+      benchmark: { id: "say-once", title: sentinel },
+      tasks: [{ taskId: "t1", question: sentinel }],
+      scores: { recall: 1 },
+    }),
+  };
+  const md = renderReportMarkdown(report);
+  const json = renderReportJson(report);
+  assert.doesNotMatch(md, new RegExp(sentinel));
+  assert.doesNotMatch(json, new RegExp(sentinel));
 });

--- a/packages/remnic-cli/src/report.ts
+++ b/packages/remnic-cli/src/report.ts
@@ -215,29 +215,84 @@ export interface BenchScorecardSummary {
  * Frozen `as const`; do NOT annotate as `readonly string[]` (checklist 47).
  */
 const PUBLIC_BENCHMARK_IDS = Object.freeze([
-  "say-once",
-  "procedural-recall",
-  "retrieval-direct-answer",
-  "coding-recall",
-  "contradiction-detection",
-  "entity-consolidation",
-  "page-versioning",
-  "bounded-memory-contracts",
-  "memcorrect-v1",
+  "ama-bench",
+  "memory-arena",
+  "amemgym",
   "longmemeval",
   "locomo",
+  "beam",
+  "personamem",
   "membench",
   "memoryagentbench",
-  "personamem",
-  "ama-bench",
-  "beam",
+  "taxonomy-accuracy",
+  "extraction-judge-calibration",
+  "extraction-span-mode",
+  "enrichment-fidelity",
+  "entity-consolidation",
+  "page-versioning",
+  "retrieval-personalization",
+  "retrieval-temporal",
+  "retrieval-direct-answer",
+  "retrieval-graph",
+  "retrieval-reasoning-trace",
+  "coding-recall",
+  "procedural-recall",
+  "say-once",
+  "ingestion-entity-recall",
+  "ingestion-schema-completeness",
+  "ingestion-backlink-f1",
+  "ingestion-setup-friction",
+  "ingestion-citation-accuracy",
+  "assistant-morning-brief",
+  "assistant-meeting-prep",
+  "assistant-next-best-action",
+  "assistant-synthesis",
+  "buffer-surprise-trigger",
+  "contradiction-detection",
+  "retention-aged-dataset",
+  "memcorrect-v1",
+  "bounded-memory-contracts",
+  "staged-memory-synthetic-v1",
 ] as const);
 // @ts-expect-error "bogus" is not a public benchmark id — fails if the union widens
 const _benchIdPin: (typeof PUBLIC_BENCHMARK_IDS)[number] = "bogus";
 void _benchIdPin;
+/**
+ * Public metric names that are safe to surface in a shared report.
+ *
+ * Anything outside this list is dropped during scorecard extraction, so a
+ * user-defined key like `client_alpha` (a project or person name) is never
+ * copied into a diagnostic report (#3037 review, P1). The fixed set is what
+ * benchmarks are allowed to publish; per-benchmark additions belong here
+ * as part of adding a metric, not at the read site.
+ */
+const PUBLIC_METRIC_KEYS = Object.freeze([
+  "recall",
+  "precision",
+  "f1",
+  "exact_match",
+  "category_match",
+  "keyword_overlap",
+  "high_confidence",
+  "latencyMs",
+  "tokens",
+  "cost",
+  "qrel_at_1",
+  "qrel_at_3",
+  "qrel_at_5",
+  "qrel_at_10",
+  "bleu",
+  "rouge",
+  "support",
+  "completeness",
+] as const);
+// @ts-expect-error "bogus" is not a public metric key — fails if the union widens
+const _metricKeyPin: (typeof PUBLIC_METRIC_KEYS)[number] = "bogus";
+void _metricKeyPin;
 
 /** Metric keys are identifier-shaped; a free-text key could carry content. */
 const METRIC_KEY_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
 
 /**
  * Extract only numeric aggregates and a public benchmark id from a canonical
@@ -279,14 +334,19 @@ function readOwn(source: object, key: string): unknown {
   return Object.hasOwn(source, key) ? (source as Record<string, unknown>)[key] : undefined;
 }
 
-function readNested(source: object, outer: string, inner: string): unknown {
-  const mid = readOwn(source, outer);
-  if (typeof mid !== "object" || mid === null) return undefined;
-  return readOwn(mid, inner);
+/** Walk a dotted path of own keys without following the prototype chain. */
+function readNested(source: unknown, ...path: string[]): unknown {
+  let current: unknown = source;
+  for (const key of path) {
+    if (typeof current !== "object" || current === null) return undefined;
+    if (!Object.hasOwn(current, key)) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
 }
 
+/** Locate the benchmark id at any of the three known locations. */
 function readBenchmarkId(raw: object): string | undefined {
-  // Canonical: meta.benchmark is the id string.
   const metaId = readNested(raw, "meta", "benchmark");
   if (typeof metaId === "string" && metaId.length > 0) return metaId;
   // Bare scorecard: benchmark.id.
@@ -299,14 +359,17 @@ function readBenchmarkId(raw: object): string | undefined {
 }
 
 /**
- * Keep finite numbers under identifier-shaped keys. A `MetricAggregate`
- * contributes its `mean`; a string value is dropped, never stringified.
+ * Keep finite numbers under public, identifier-shaped metric keys.
+ * The allow-list rejects user-defined keys like `client_alpha` even when
+ * they pass the syntax check (#3037 review, P1); the syntax check still
+ * rejects arbitrary string content on top of that.
  */
 function extractNumericScores(source: unknown): Record<string, number> | undefined {
   if (typeof source !== "object" || source === null) return undefined;
   const scores: Record<string, number> = {};
   for (const key of Object.getOwnPropertyNames(source)) {
     if (!Object.hasOwn(source, key)) continue;
+    if (!(PUBLIC_METRIC_KEYS as readonly string[]).includes(key)) continue;
     if (!METRIC_KEY_PATTERN.test(key)) continue;
     const value = readOwn(source, key);
     if (typeof value === "number" && Number.isFinite(value)) {

--- a/packages/remnic-cli/src/report.ts
+++ b/packages/remnic-cli/src/report.ts
@@ -197,59 +197,128 @@ function runDoctorChecks(): DoctorCheckSummary[] {
  * shape ever reaches the report.
  */
 export interface BenchScorecardSummary {
+  /** A built-in benchmark id, or `"custom"`. Never a user-defined name. */
   benchmarkId?: string;
   taskCount?: number;
   /** Per-metric mean, numbers only. */
   scores?: Record<string, number>;
 }
 
-/** Frozen `as const` — do NOT annotate as readonly string[] (checklist 47). */
-const BENCH_SCORECARD_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+/**
+ * Built-in benchmark ids that are safe to name in a public report.
+ *
+ * A user-defined id can be a client, project, or person name, and syntax
+ * restrictions do not anonymize it (#3037 review, P1). Anything not on this
+ * list is reported as `"custom"` — the count and scores still convey the
+ * signal without disclosing what was benchmarked.
+ *
+ * Frozen `as const`; do NOT annotate as `readonly string[]` (checklist 47).
+ */
+const PUBLIC_BENCHMARK_IDS = Object.freeze([
+  "say-once",
+  "procedural-recall",
+  "retrieval-direct-answer",
+  "coding-recall",
+  "contradiction-detection",
+  "entity-consolidation",
+  "page-versioning",
+  "bounded-memory-contracts",
+  "memcorrect-v1",
+  "longmemeval",
+  "locomo",
+  "membench",
+  "memoryagentbench",
+  "personamem",
+  "ama-bench",
+  "beam",
+] as const);
+// @ts-expect-error "bogus" is not a public benchmark id — fails if the union widens
+const _benchIdPin: (typeof PUBLIC_BENCHMARK_IDS)[number] = "bogus";
+void _benchIdPin;
+
+/** Metric keys are identifier-shaped; a free-text key could carry content. */
+const METRIC_KEY_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 
 /**
- * Extract only numeric aggregates and a syntactically-constrained benchmark
- * id from a scorecard. Every other field — including anything nested — is
+ * Extract only numeric aggregates and a public benchmark id from a canonical
+ * `BenchmarkResult`.
+ *
+ * Reads the real on-disk shape — `meta.benchmark`, `results.tasks`,
+ * `results.aggregates` (packages/bench/src/types.ts) — with top-level
+ * fallbacks for a bare scorecard. Everything outside the allow-list is
  * dropped by construction rather than redacted.
  */
 export function summarizeBenchScorecard(raw: unknown): BenchScorecardSummary | undefined {
   if (typeof raw !== "object" || raw === null) return undefined;
   const summary: BenchScorecardSummary = {};
 
-  // Benchmark id: an identifier, never free text that could carry content.
-  if ("benchmark" in raw && typeof raw.benchmark === "object" && raw.benchmark !== null) {
-    const bench = raw.benchmark;
-    if ("id" in bench && typeof bench.id === "string" && BENCH_SCORECARD_ID_PATTERN.test(bench.id)) {
-      summary.benchmarkId = bench.id;
-    }
+  // Benchmark id: canonical `meta.benchmark` is a string; a bare scorecard
+  // may carry `benchmark.id`. Either way it is mapped through the public
+  // allow-list, never copied verbatim.
+  const rawId = readBenchmarkId(raw);
+  if (rawId !== undefined) {
+    summary.benchmarkId = (PUBLIC_BENCHMARK_IDS as readonly string[]).includes(rawId)
+      ? rawId
+      : "custom";
   }
 
-  // Task count: a non-negative integer only.
-  if ("tasks" in raw && Array.isArray(raw.tasks)) {
-    summary.taskCount = raw.tasks.length;
-  }
+  // Task count from `results.tasks`, falling back to top-level `tasks`.
+  const tasks = readNested(raw, "results", "tasks") ?? readOwn(raw, "tasks");
+  if (Array.isArray(tasks)) summary.taskCount = tasks.length;
 
-  // Scores: finite numbers under identifier-shaped keys. Any non-numeric
-  // value is dropped — a string score could carry arbitrary text.
-  if ("scores" in raw && typeof raw.scores === "object" && raw.scores !== null) {
-    const scores: Record<string, number> = {};
-    const rawScores = raw.scores;
-    for (const key of Object.getOwnPropertyNames(rawScores)) {
-      if (!Object.hasOwn(rawScores, key)) continue;
-      if (!BENCH_SCORECARD_ID_PATTERN.test(key)) continue;
-      const value: unknown = (rawScores as Record<string, unknown>)[key];
-      if (typeof value === "number" && Number.isFinite(value)) {
-        scores[key] = value;
-      } else if (
-        typeof value === "object" && value !== null && "mean" in value
-        && typeof value.mean === "number" && Number.isFinite(value.mean)
-      ) {
-        scores[key] = value.mean;
-      }
-    }
-    if (Object.keys(scores).length > 0) summary.scores = scores;
-  }
+  // Scores from `results.aggregates`, falling back to top-level `scores`.
+  const aggregates = readNested(raw, "results", "aggregates") ?? readOwn(raw, "scores");
+  const scores = extractNumericScores(aggregates);
+  if (scores !== undefined) summary.scores = scores;
 
   return Object.keys(summary).length > 0 ? summary : undefined;
+}
+
+/** Own-property read that never follows the prototype chain (checklist 46). */
+function readOwn(source: object, key: string): unknown {
+  return Object.hasOwn(source, key) ? (source as Record<string, unknown>)[key] : undefined;
+}
+
+function readNested(source: object, outer: string, inner: string): unknown {
+  const mid = readOwn(source, outer);
+  if (typeof mid !== "object" || mid === null) return undefined;
+  return readOwn(mid, inner);
+}
+
+function readBenchmarkId(raw: object): string | undefined {
+  // Canonical: meta.benchmark is the id string.
+  const metaId = readNested(raw, "meta", "benchmark");
+  if (typeof metaId === "string" && metaId.length > 0) return metaId;
+  // Bare scorecard: benchmark.id.
+  const bench = readOwn(raw, "benchmark");
+  if (typeof bench === "object" && bench !== null) {
+    const id = readOwn(bench, "id");
+    if (typeof id === "string" && id.length > 0) return id;
+  }
+  return undefined;
+}
+
+/**
+ * Keep finite numbers under identifier-shaped keys. A `MetricAggregate`
+ * contributes its `mean`; a string value is dropped, never stringified.
+ */
+function extractNumericScores(source: unknown): Record<string, number> | undefined {
+  if (typeof source !== "object" || source === null) return undefined;
+  const scores: Record<string, number> = {};
+  for (const key of Object.getOwnPropertyNames(source)) {
+    if (!Object.hasOwn(source, key)) continue;
+    if (!METRIC_KEY_PATTERN.test(key)) continue;
+    const value = readOwn(source, key);
+    if (typeof value === "number" && Number.isFinite(value)) {
+      scores[key] = value;
+      continue;
+    }
+    if (typeof value === "object" && value !== null) {
+      const mean = readOwn(value, "mean");
+      if (typeof mean === "number" && Number.isFinite(mean)) scores[key] = mean;
+    }
+  }
+  return Object.keys(scores).length > 0 ? scores : undefined;
 }
 
 export async function buildReport(options: { includeBench?: boolean } = {}): Promise<ReportContent> {

--- a/packages/remnic-cli/src/report.ts
+++ b/packages/remnic-cli/src/report.ts
@@ -59,7 +59,7 @@ export interface ReportContent {
     totalMemories: number;
     sizeBucket: string;
   };
-  benchScorecard?: unknown;
+  benchScorecard?: BenchScorecardSummary;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -191,6 +191,67 @@ function runDoctorChecks(): DoctorCheckSummary[] {
 
 // ─── Report builders ──────────────────────────────────────────────────────
 
+/**
+ * Allow-listed scorecard fields. A raw benchmark report card can carry
+ * questions, answers, and recalled memory content, so nothing outside this
+ * shape ever reaches the report.
+ */
+export interface BenchScorecardSummary {
+  benchmarkId?: string;
+  taskCount?: number;
+  /** Per-metric mean, numbers only. */
+  scores?: Record<string, number>;
+}
+
+/** Frozen `as const` — do NOT annotate as readonly string[] (checklist 47). */
+const BENCH_SCORECARD_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+/**
+ * Extract only numeric aggregates and a syntactically-constrained benchmark
+ * id from a scorecard. Every other field — including anything nested — is
+ * dropped by construction rather than redacted.
+ */
+export function summarizeBenchScorecard(raw: unknown): BenchScorecardSummary | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const summary: BenchScorecardSummary = {};
+
+  // Benchmark id: an identifier, never free text that could carry content.
+  if ("benchmark" in raw && typeof raw.benchmark === "object" && raw.benchmark !== null) {
+    const bench = raw.benchmark;
+    if ("id" in bench && typeof bench.id === "string" && BENCH_SCORECARD_ID_PATTERN.test(bench.id)) {
+      summary.benchmarkId = bench.id;
+    }
+  }
+
+  // Task count: a non-negative integer only.
+  if ("tasks" in raw && Array.isArray(raw.tasks)) {
+    summary.taskCount = raw.tasks.length;
+  }
+
+  // Scores: finite numbers under identifier-shaped keys. Any non-numeric
+  // value is dropped — a string score could carry arbitrary text.
+  if ("scores" in raw && typeof raw.scores === "object" && raw.scores !== null) {
+    const scores: Record<string, number> = {};
+    const rawScores = raw.scores;
+    for (const key of Object.getOwnPropertyNames(rawScores)) {
+      if (!Object.hasOwn(rawScores, key)) continue;
+      if (!BENCH_SCORECARD_ID_PATTERN.test(key)) continue;
+      const value: unknown = (rawScores as Record<string, unknown>)[key];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        scores[key] = value;
+      } else if (
+        typeof value === "object" && value !== null && "mean" in value
+        && typeof value.mean === "number" && Number.isFinite(value.mean)
+      ) {
+        scores[key] = value.mean;
+      }
+    }
+    if (Object.keys(scores).length > 0) summary.scores = scores;
+  }
+
+  return Object.keys(summary).length > 0 ? summary : undefined;
+}
+
 export async function buildReport(options: { includeBench?: boolean } = {}): Promise<ReportContent> {
   const generatedAt = new Date().toISOString();
   const platform = { os: os.platform(), arch: os.arch(), node: process.version };
@@ -226,15 +287,18 @@ export async function buildReport(options: { includeBench?: boolean } = {}): Pro
   const storeBytes = sizeOfStore(memoryDir);
   const sizeBucketLabel = sizeBucket(storeBytes);
 
-  // Optional bench scorecard
-  let benchScorecard: unknown;
+  // Optional bench scorecard — NEVER copied verbatim. A benchmark report card
+  // can contain questions, answers, and recalled memory content
+  // (docs/benchmarks.md), so the same allow-list discipline as the config
+  // applies: only these numeric/enum aggregates are extracted (#3037 review).
+  let benchScorecard: BenchScorecardSummary | undefined;
   if (options.includeBench) {
     const scorecardPath = path.join(os.homedir(), ".remnic", "reports", "bench-scorecard.json");
     try {
-      const data = await readFile(scorecardPath, "utf-8");
-      benchScorecard = JSON.parse(data);
+      const raw: unknown = JSON.parse(await readFile(scorecardPath, "utf-8"));
+      benchScorecard = summarizeBenchScorecard(raw);
     } catch {
-      // Scorecard absent — section will be omitted
+      // Scorecard absent or unparseable — section omitted, exit stays 0.
     }
   }
 

--- a/packages/remnic-core/scripts/build-with-heap.mjs
+++ b/packages/remnic-core/scripts/build-with-heap.mjs
@@ -1,31 +1,52 @@
 #!/usr/bin/env node
-// Runs tsup with deterministic heap headroom for its DTS worker.
-// The DTS build sits near the default V8 heap cliff (see PR #1562):
-// unrelated lockfile refreshes flipped it to ERR_WORKER_OUT_OF_MEMORY.
-// A Node wrapper (not a NODE_OPTIONS= shell prefix) keeps the build
-// script portable to Windows' cmd.exe script shell.
+// Builds @remnic/core: JS bundle via tsup, declarations via tsc.
+//
+// History: tsup emitted declarations through rollup-plugin-dts, which runs ONE
+// type rollup per entry point. This package declares 438 entries over a
+// ~375k-line type graph, so that is 438 rollups sharing a program inside a
+// single worker thread. It sat on the V8 heap cliff from PR #1562 onward and
+// was kept alive by raising --max-old-space-size (4096 -> 8192 -> 12288);
+// unrelated lockfile refreshes were enough to flip it to
+// ERR_WORKER_OUT_OF_MEMORY, and it stopped completing at any heap size.
+//
+// `tsc --emitDeclarationOnly` builds the program once and writes one .d.ts per
+// source file. Measured on the same tree:
+//
+//   rollup-plugin-dts @ 8192 MB   -> OOM after ~170s
+//   rollup-plugin-dts @ 12288 MB  -> OOM / dts error
+//   tsc --emitDeclarationOnly     -> 0 errors, 1096 files, ~19s, DEFAULT heap
+//
+// Per-file output is also the shape this package's `exports` map already wants
+// (`./foo` -> `./dist/foo.js`), so the rollup was doing bundling work that no
+// consumer reads. No heap flag is needed for either step now.
+//
+// A Node wrapper (not a NODE_OPTIONS= shell prefix) keeps this portable to
+// Windows' cmd.exe script shell.
 import { spawnSync } from "node:child_process";
 import { cp, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const HEAP_DEFAULT = "--max-old-space-size=8192";
-const existing = process.env.NODE_OPTIONS?.trim();
-// Caller-supplied NODE_OPTIONS goes last so V8's last-wins parsing lets
-// callers override the default heap limit.
-const nodeOptions = existing ? `${HEAP_DEFAULT} ${existing}` : HEAP_DEFAULT;
+// .bin shims are .cmd files on Windows and need a shell to execute.
+const useShell = process.platform === "win32";
 
-const result = spawnSync("tsup", process.argv.slice(2), {
-  stdio: "inherit",
-  env: { ...process.env, NODE_OPTIONS: nodeOptions },
-  // .bin shims are .cmd files on Windows and need a shell to execute.
-  shell: process.platform === "win32",
-});
-
-if (result.error) {
-  console.error(`[build-with-heap] failed to launch tsup: ${result.error.message}`);
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit", shell: useShell });
+  if (result.error) {
+    console.error(`[build] failed to launch ${command}: ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.status !== 0) process.exit(result.status ?? 1);
 }
-if (result.status !== 0) process.exit(result.status ?? 1);
+
+// 1. JS bundle. tsup's own dts is off (see tsup.config.ts).
+run("tsup", process.argv.slice(2));
+
+// 2. Declarations. Skipped for the runtime-only container image, which ships
+//    no types — same condition tsup's dts flag used.
+if (process.env.REMNIC_DOCKER_RUNTIME_BUILD !== "1") {
+  run("tsc", ["-p", "tsconfig.dts.json"]);
+}
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const sourceDir = path.resolve(packageRoot, "../../admin-console/public/what-helps-me");

--- a/packages/remnic-core/src/access-errors.test.ts
+++ b/packages/remnic-core/src/access-errors.test.ts
@@ -140,6 +140,8 @@ test("invalidArgsError: an example that cannot round-trip is withheld, not shown
     safeParse: () => ({ success: false }),
   };
   const parse = MEMORY_GET_SCHEMA.safeParse({});
+  assert.equal(parse.success, false);
+  if (parse.success) return;
   const msg = invalidArgsError("engram.memory_get", parse.error, alwaysFails);
   assert.doesNotMatch(msg, /Example arguments/, "a non-parsing example must be withheld");
 });

--- a/packages/remnic-core/src/access-errors.test.ts
+++ b/packages/remnic-core/src/access-errors.test.ts
@@ -164,3 +164,19 @@ test("unknownToolError: no sentinel secret values appear in the message", () => 
   assert.doesNotMatch(msg, /\/Users\//);
   assert.doesNotMatch(msg, /api_key|token|secret|password/i);
 });
+// ─── Cap on requested tool name (#3042 P2) ──────────────────────────────────
+
+test("nearestSuggestions: refuses overlong requests without running Levenshtein", () => {
+  const huge = "x".repeat(10_000);
+  // Direct helper: defense-in-depth. The size of the registered set does
+  // not matter; an overlong request returns empty.
+  assert.deepEqual(nearestSuggestions(huge, ["alpha", "beta", "gamma"]), []);
+});
+
+test("unknownToolError: rejects overlong names with a teaching message", () => {
+  const huge = "x".repeat(200);
+  const msg = unknownToolError(huge, ["alpha", "beta"]);
+  assert.match(msg, /exceeds 64 characters/);
+  // Should NOT run a suggestion pass over a 200-char name.
+  assert.doesNotMatch(msg, /Did you mean/);
+});

--- a/packages/remnic-core/src/access-errors.test.ts
+++ b/packages/remnic-core/src/access-errors.test.ts
@@ -107,13 +107,41 @@ test("invalidArgsError: names the failing field path", () => {
   assert.match(msg, /required/i);
 });
 
-test("invalidArgsError: the generated example round-trips through the schema", () => {
-  const msg = invalidArgsError("engram.memory_get", MEMORY_GET_SCHEMA.safeParse({}).error, MEMORY_GET_SCHEMA);
-  // The example should be mentioned in the message
-  assert.match(msg, /Example/);
-  // The example should contain the expected fields
-  assert.match(msg, /memory_id/);
-  assert.match(msg, /<string>/);
+test("invalidArgsError: the shown example actually parses against the schema", () => {
+  const parse = MEMORY_GET_SCHEMA.safeParse({});
+  assert.equal(parse.success, false);
+  const msg = invalidArgsError("engram.memory_get", parse.error, MEMORY_GET_SCHEMA);
+
+  // Anti-drift guarantee, asserted rather than asserted-about: extract the
+  // JSON the message advertises and feed it back through the SAME schema.
+  const match = msg.match(/Example arguments: (\{.*\})$/);
+  assert.ok(match, `message must carry an example object; got: ${msg}`);
+  const example: unknown = JSON.parse(match[1]);
+
+  const reparsed = MEMORY_GET_SCHEMA.safeParse(example);
+  assert.equal(
+    reparsed.success,
+    true,
+    `the advertised example must round-trip through its own schema; zod said: ${JSON.stringify(reparsed.error?.issues)}`,
+  );
+
+  // And it must not smuggle the tool name in as an unrecognized property.
+  assert.ok(
+    typeof example === "object" && example !== null && !("engram.memory_get" in example),
+    "the example must not contain the tool name as a property",
+  );
+});
+
+test("invalidArgsError: an example that cannot round-trip is withheld, not shown", () => {
+  // A schema whose safeParse always fails must produce no example section
+  // rather than an example the caller cannot use.
+  const alwaysFails = {
+    _def: { typeName: "ZodObject", shape: () => ({ field: { _def: { typeName: "ZodString" } } }) },
+    safeParse: () => ({ success: false }),
+  };
+  const parse = MEMORY_GET_SCHEMA.safeParse({});
+  const msg = invalidArgsError("engram.memory_get", parse.error, alwaysFails);
+  assert.doesNotMatch(msg, /Example arguments/, "a non-parsing example must be withheld");
 });
 
 // ─── Rejection semantics are unchanged ─────────────────────────────────────

--- a/packages/remnic-core/src/access-errors.ts
+++ b/packages/remnic-core/src/access-errors.ts
@@ -123,34 +123,66 @@ function buildSuggestion(
 }
 
 /**
+ * Read a Zod type tag without asserting a shape.
+ *
+ * Zod keeps its discriminant at `_def.typeName`. Both hops are narrowed with
+ * `in`/`typeof` rather than an inline cast, so a non-Zod object yields
+ * `undefined` instead of a fabricated read.
+ */
+function zodTypeName(schema: unknown): string | undefined {
+  if (typeof schema !== "object" || schema === null || !("_def" in schema)) return undefined;
+  const def = schema._def;
+  if (typeof def !== "object" || def === null || !("typeName" in def)) return undefined;
+  return typeof def.typeName === "string" ? def.typeName : undefined;
+}
+
+/** Read `_def.<key>` with the same narrowing discipline. */
+function zodDefField(schema: unknown, key: string): unknown {
+  if (typeof schema !== "object" || schema === null || !("_def" in schema)) return undefined;
+  const def = schema._def;
+  if (typeof def !== "object" || def === null) return undefined;
+  return Object.hasOwn(def, key) ? (def as Record<string, unknown>)[key] : undefined;
+}
+
+/**
  * Reverse-engineer ONE synthetic example value from a Zod schema type.
- * Returns a deterministic placeholder that round-trips through parse().
+ * Returns a deterministic placeholder intended to round-trip through parse().
  */
 function exampleFromSchema(schema: unknown): unknown {
-  if (!schema || typeof schema !== "object") return undefined;
-  const obj = schema as Record<string, unknown>;
-  if (obj._def?.typeName === "ZodString") return "<string>";
-  if (obj._def?.typeName === "ZodNumber") return 42;
-  if (obj._def?.typeName === "ZodBoolean") return true;
-  if (obj._def?.typeName === "ZodNullable") return null;
-  if (obj._def?.typeName === "ZodOptional") return undefined;
-  if (obj._def?.typeName === "ZodArray") return [];
-  if (obj._def?.typeName === "ZodObject") {
-    const shape = obj._def.shape?.();
-    if (!shape || typeof shape !== "object") return {};
-    const result: Record<string, unknown> = {};
-    for (const key of Object.getOwnPropertyNames(shape)) {
-      const val = exampleFromSchema(shape[key]);
-      if (val !== undefined) result[key] = val;
+  switch (zodTypeName(schema)) {
+    case "ZodString":
+      return "<string>";
+    case "ZodNumber":
+      return 42;
+    case "ZodBoolean":
+      return true;
+    case "ZodNullable":
+      return null;
+    case "ZodArray":
+      return [];
+    case "ZodOptional":
+      // Optional fields are omitted from the example rather than sent as null.
+      return undefined;
+    case "ZodEnum": {
+      const values = zodDefField(schema, "values");
+      return Array.isArray(values) && values.length > 0 ? values[0] : "<value>";
     }
-    return result;
+    case "ZodObject": {
+      const shapeFn = zodDefField(schema, "shape");
+      const shape = typeof shapeFn === "function" ? shapeFn() : undefined;
+      if (typeof shape !== "object" || shape === null) return {};
+      const result: Record<string, unknown> = {};
+      for (const key of Object.getOwnPropertyNames(shape)) {
+        if (!Object.hasOwn(shape, key)) continue;
+        const field = (shape as Record<string, unknown>)[key];
+        const value = exampleFromSchema(field);
+        if (value !== undefined) result[key] = value;
+      }
+      return result;
+    }
+    default:
+      return undefined;
   }
-  if (obj._def?.typeName === "ZodEnum") {
-    const values = obj._def.values;
-    if (Array.isArray(values) && values.length > 0) return values[0];
-    return "<value>";
-  }
-  return undefined;
 }
 
 /**
@@ -186,7 +218,12 @@ export function invalidArgsError(
 ): string {
   const issues = zodError.issues.map((issue) => {
     const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
-    return `${path}: ${issue.message} (expected ${issue.expected ?? typeof issue})`;
+    // `expected` exists only on the invalid_type / invalid_literal variants of
+    // ZodIssue, so it is read through a presence check rather than assumed.
+    const expected = "expected" in issue ? issue.expected : undefined;
+    return expected === undefined
+      ? `${path}: ${issue.message}`
+      : `${path}: ${issue.message} (expected ${String(expected)})`;
   });
   let message = `Invalid arguments for "${tool}": ${issues.join("; ")}`;
   if (!schema) return message;

--- a/packages/remnic-core/src/access-errors.ts
+++ b/packages/remnic-core/src/access-errors.ts
@@ -76,6 +76,14 @@ export function levenshtein(a: string, b: string): number {
 // ─── Similar-name helpers ─────────────────────────────────────────────────
 
 const SUGGESTION_DISTANCE_CAP = 3;
+/**
+ * Upper bound on the requested tool name. Anything longer is rejected before
+ * the O(n*m) Levenshtein pass (#3042 review, P2): a 128 KB request over ~30
+ * tools would otherwise run hundreds of millions of comparisons and block
+ * the server event loop. The repo documents 64 chars as the tool-name shape;
+ * this matches the limit enforced by every published surface.
+ */
+export const SUGGESTION_REQUEST_MAX_LEN = 64;
 
 export interface SuggestionCandidate {
   name: string;
@@ -92,6 +100,9 @@ export function nearestSuggestions(
   requested: string,
   registeredNames: readonly string[],
 ): SuggestionCandidate[] {
+  // Defense in depth: the entry point already caps; this guards any direct
+  // caller of the helper from an unbounded Levenshtein pass (issue #3042).
+  if (requested.length > SUGGESTION_REQUEST_MAX_LEN) return [];
   const candidates: SuggestionCandidate[] = [];
   for (const name of registeredNames) {
     const distance = levenshtein(requested.toLowerCase(), name.toLowerCase());
@@ -184,7 +195,6 @@ function exampleFromSchema(schema: unknown): unknown {
       return undefined;
   }
 }
-
 /**
  * Build an enriched "unknown tool" error message.
  *
@@ -195,6 +205,13 @@ export function unknownToolError(
   requested: string,
   registeredNames: readonly string[],
 ): string {
+  // Cap the request before the suggestion pass: a 128 KB name would otherwise
+  // pay O(n*m) per registered tool (issue #3042 review, P2). The cap matches
+  // the documented tool-name shape; an over-long request is rejected with a
+  // teaching message rather than a silent truncate.
+  if (requested.length > SUGGESTION_REQUEST_MAX_LEN) {
+    return `Unknown tool: name exceeds ${SUGGESTION_REQUEST_MAX_LEN} characters (got ${requested.length}).`;
+  }
   const suggestion = buildSuggestion(requested, registeredNames);
   return `Unknown tool: ${requested}. ${suggestion}`;
 }

--- a/packages/remnic-core/src/access-errors.ts
+++ b/packages/remnic-core/src/access-errors.ts
@@ -9,6 +9,32 @@
 
 import type { ZodError } from "zod";
 
+// ─── Existing error classes (restored from pre-#3042) ─────────────────────
+
+/** Authenticated caller lacks the required authorization (HTTP 403). */
+export class EngramAccessForbiddenError extends Error {}
+
+/** Invalid caller input (HTTP 400). */
+export class EngramAccessInputError extends Error {}
+
+/**
+ * A write rejected by the namespace write-ACL (issue #1888). Subclasses
+ * EngramAccessInputError so every existing catch/HTTP-400 mapping still
+ * applies, but carries the attempted namespace + principal so the observe/
+ * write surfaces can dead-letter the payload before re-throwing (fail-closed
+ * placement is unchanged; only the destroyed-payload behavior is fixed).
+ */
+export class NamespaceNotWritableError extends EngramAccessInputError {
+  constructor(
+    readonly attemptedNamespace: string,
+    readonly principal: string | undefined,
+    message?: string,
+  ) {
+    super(message ?? `namespace is not writable: ${attemptedNamespace}`);
+    this.name = "NamespaceNotWritableError";
+  }
+}
+
 // ─── Levenshtein distance ─────────────────────────────────────────────────
 
 /**

--- a/packages/remnic-core/src/access-errors.ts
+++ b/packages/remnic-core/src/access-errors.ts
@@ -170,9 +170,14 @@ export function unknownToolError(
 /**
  * Build an enriched "invalid arguments" error message.
  *
+ * The example is generated from the schema (never hand-written, so it cannot
+ * drift) and is shown ONLY when it round-trips through that same schema. It
+ * carries schema-derived fields only: injecting the tool name would add an
+ * unrecognized property and fail a `.strict()` object (#3035 review finding).
+ *
  * @param tool - the tool name that received the invalid args
  * @param zodError - the ZodError from parse()
- * @param schema - the original Zod schema, used to generate example calls
+ * @param schema - the original Zod schema, used to generate the example
  */
 export function invalidArgsError(
   tool: string,
@@ -184,11 +189,32 @@ export function invalidArgsError(
     return `${path}: ${issue.message} (expected ${issue.expected ?? typeof issue})`;
   });
   let message = `Invalid arguments for "${tool}": ${issues.join("; ")}`;
-  if (schema) {
-    const example = exampleFromSchema(schema);
-    if (example && typeof example === "object" && Object.keys(example).length > 0) {
-      message += `. Example: ${JSON.stringify({ ...example, [tool]: "..." }, null, 0)}`;
+  if (!schema) return message;
+
+  const example = exampleFromSchema(schema);
+  if (!example || typeof example !== "object" || Object.keys(example).length === 0) {
+    return message;
+  }
+
+  // Withhold an example that cannot parse against its own schema: a
+  // non-round-tripping example is misinformation, worse than none. Narrowed
+  // with `in`/`typeof` rather than an inline cast so the shape is checked.
+  let roundTrips = false;
+  if (typeof schema === "object" && "safeParse" in schema) {
+    const parser = schema.safeParse;
+    if (typeof parser === "function") {
+      try {
+        const parsed: unknown = parser.call(schema, example);
+        roundTrips =
+          typeof parsed === "object"
+          && parsed !== null
+          && "success" in parsed
+          && parsed.success === true;
+      } catch {
+        roundTrips = false;
+      }
     }
   }
-  return message;
+
+  return roundTrips ? `${message}. Example arguments: ${JSON.stringify(example)}` : message;
 }

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2593,11 +2593,22 @@ export class EngramMcpServer {
     const migrated = MCP_MIGRATED_OPERATIONS[toLegacyToolName(name)];
     if (!migrated) {
       // Teaching rejection (#3035): name the nearest registered tool instead
-      // of a bare "unknown tool". Semantics are unchanged — this still
-      // throws and never executes a guessed correction.
-      throw new Error(
-        unknownToolError(name, Object.getOwnPropertyNames(MCP_MIGRATED_OPERATIONS)),
-      );
+      // of a bare "unknown tool". Semantics are unchanged — this still throws
+      // and never executes a guessed correction.
+      //
+      // Candidates are the SAME capability-filtered set `tools/list` shows
+      // (issue #1850 finding 3). Enumerating the global map here would let a
+      // scoped or deny-all token recover the full tool surface through the
+      // error path, re-opening the leak that fix closed.
+      const caps = tokenCapabilityStore.getStore();
+      const visible = this.tools
+        .filter(
+          (t) =>
+            caps?.ops === undefined
+            || capabilityAllowsOp(caps, MCP_MIGRATED_OPERATIONS[toLegacyToolName(t.name)] ?? ""),
+        )
+        .map((t) => t.name);
+      throw new Error(unknownToolError(name, visible));
     }
     const op = getOperation(migrated);
     if (!op) {

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -23,6 +23,7 @@ import {
   validateRequest,
 } from "./access-schema.js";
 import { EngramAccessInputError, type EngramAccessRecallResponse, type EngramAccessService } from "./access-service.js";
+import { unknownToolError } from "./access-errors.js";
 import "./access-operations.js";
 import { validateBriefingFormat } from "./briefing.js";
 import { processChatMessage } from "./chat/chat-factory.js";
@@ -2591,7 +2592,12 @@ export class EngramMcpServer {
   ): Promise<unknown> {
     const migrated = MCP_MIGRATED_OPERATIONS[toLegacyToolName(name)];
     if (!migrated) {
-      throw new Error(`unknown tool: ${name}`);
+      // Teaching rejection (#3035): name the nearest registered tool instead
+      // of a bare "unknown tool". Semantics are unchanged — this still
+      // throws and never executes a guessed correction.
+      throw new Error(
+        unknownToolError(name, Object.getOwnPropertyNames(MCP_MIGRATED_OPERATIONS)),
+      );
     }
     const op = getOperation(migrated);
     if (!op) {

--- a/packages/remnic-core/tsconfig.dts.json
+++ b/packages/remnic-core/tsconfig.dts.json
@@ -1,0 +1,35 @@
+// Declaration-emit-only project (issue: core DTS build OOM).
+//
+// `tsup`'s dts step uses rollup-plugin-dts, which performs ONE type rollup per
+// entry point. This package declares 438 entries over a ~375k-line type graph,
+// so that is 438 rollups holding a shared program in a single worker thread —
+// it exhausts an 8 GB heap and does not complete at 12 GB either.
+//
+// `tsc --emitDeclarationOnly` builds the program once and writes one .d.ts per
+// source file. Measured on the same tree: 26.7s at the DEFAULT heap, versus an
+// OOM after ~170s for the rollup path. Per-file output is also the shape this
+// package's `exports` map already wants (`./foo` -> `./dist/foo.js`), so the
+// rollup was doing bundling work that is never consumed.
+//
+// Tests are excluded: they are not shipped, and they import `@remnic/core/*`
+// self-referentially, which cannot resolve until dist exists.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  // Only test FILES are excluded. Do NOT exclude `src/testing/**`: the package
+  // publishes `./testing/lifecycle-matrix` with an explicit `types` path, and
+  // plugin-openclaw imports it for the AGENTS.md-mandated lifecycle-matrix
+  // gate. Excluding the directory would leave that types path dangling.
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test-fixture.ts"
+  ]
+}

--- a/packages/remnic-core/tsup.config.ts
+++ b/packages/remnic-core/tsup.config.ts
@@ -48,7 +48,10 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   sourcemap: true,
-  dts: process.env.REMNIC_DOCKER_RUNTIME_BUILD === "1" ? false : true,
+  // Declarations come from `tsc -p tsconfig.dts.json` in scripts/build-with-heap.mjs.
+  // rollup-plugin-dts does one type rollup per entry (438 here) and cannot
+  // complete on this type graph at any heap size; tsc builds the program once.
+  dts: false,
   external: [
     "openclaw",
     "@node-rs/argon2",

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -34,6 +34,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "retrieval-reasoning-trace",
       "coding-recall",
       "procedural-recall",
+      "say-once",
       "ingestion-entity-recall",
       "ingestion-schema-completeness",
       "ingestion-backlink-f1",
@@ -91,6 +92,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
@@ -98,7 +100,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       .filter((benchmark) => benchmark.runnerAvailable)
       .map((benchmark) => benchmark.id)
       .join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,extraction-span-mode,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection,retention-aged-dataset,memcorrect-v1,bounded-memory-contracts,staged-memory-synthetic-v1",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,extraction-span-mode,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,say-once,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection,retention-aged-dataset,memcorrect-v1,bounded-memory-contracts,staged-memory-synthetic-v1",
   );
   // The synthetic ingestion adapter wires all built-in ingestion benchmarks.
   assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, true);


### PR DESCRIPTION
Fixes defects that shipped unaddressed in the #3032–#3037 batch, including two that broke the build on `main`.

## Build-breaking (main is red right now)

| # | Defect | Shipped in |
|---|---|---|
| 1 | `access-errors.ts` was replaced wholesale, **deleting** `EngramAccessForbiddenError`, `EngramAccessInputError`, `NamespaceNotWritableError` — imported by 48 files | #3042 |
| 2 | `cmdReport` import inserted **inside another import's destructuring block** (`index.ts:77`) → `TS1003`/`TS1005` parse failure | #3043 |

Either one alone fails every CI job. Both are fixed.

## Unaddressed reviewer findings now fixed

**#3042 — Codex P1: the builders were dead code.** `unknownToolError`/`invalidArgsError` were exported and unit-tested but never called from any rejection boundary, so the advertised teaching errors could not reach a user. `callTool` still threw the raw `unknown tool` string. Now wired at `access-mcp.ts:2593`.

**#3042 — Codex P2: the generated example could not round-trip.** It injected `[tool]: "..."`, an unrecognized property on a `.strict()` object, and the test only regex-searched the rendered message instead of parsing the example — so the claimed anti-drift guarantee was false. The example now carries schema-derived fields only and is **withheld** unless it parses against its own schema. The test extracts the advertised JSON and feeds it back through the schema.

**#3043 — Codex P1: bench scorecard privacy leak.** `--include-bench` copied the whole scorecard JSON verbatim into an artifact the command tells users to paste into a public issue. Report cards carry questions, answers, and recalled memory content. Replaced with an allow-listed extractor (`summarizeBenchScorecard`) keeping only an identifier-shaped benchmark id, a task count, and finite numeric score means.

## Verification

```
access-errors.test.ts   15 pass / 0 fail
report.test.ts          13 pass / 0 fail
esbuild bundle          Build success, 0 "No matching export"
tsc --noEmit            0 TS1003/TS1005/TS1128 syntax errors
```

All new tests mutation-proven:
- re-injecting the tool name → round-trip assertion fails (15→14/1)
- passthrough scorecard extractor → 2 leak tests fail (13→11/2)

## Not in scope

Remaining P1/P2 findings on #3040 (release channels) and #3041 (recall-why) are behavioral refinements, not build breakage or privacy leaks. Tracked separately so this fix can land fast and unblock `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restored public access errors for forbidden access, invalid input, and non-writable namespaces.
  - Unknown MCP tool errors now suggest the closest caller-visible tool without revealing inaccessible options.
  - Added the Say Once benchmark to the benchmark catalog.

- **Bug Fixes**
  - Corrected CLI command handling.
  - Improved invalid-input examples so they appear only when valid and usable.

- **Security & Reporting**
  - Benchmark reports now include only approved identifiers, task counts, and numeric metrics.
  - Invalid or unexpected scorecard data is safely omitted from Markdown and JSON reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->