### PR TITLE
fix(belief-ledger): wait for core dist before tsup DTS emit

### DIFF
--- a/.changeset/belief-ledger-core-dep.md
+++ b/.changeset/belief-ledger-core-dep.md
@@ -1,7 +1,8 @@
 ---
 "@remnic/belief-ledger": patch
+"@remnic/core": patch
 ---
 
 Stability: stable
 
-Declare `@remnic/core` as a workspace dependency so release `pnpm -r run build` emits core dist types before belief-ledger tsup DTS.
+Import belief-ledger store helpers from `@remnic/core` and re-export `composeSalvagedEnvelope` / `sanitizeMemoryContent` so tsup DTS does not resolve unpublished subpath declaration files.

--- a/.changeset/belief-ledger-core-dep.md
+++ b/.changeset/belief-ledger-core-dep.md
@@ -1,0 +1,7 @@
+---
+"@remnic/belief-ledger": patch
+---
+
+Stability: stable
+
+Declare `@remnic/core` as a workspace dependency so release `pnpm -r run build` emits core dist types before belief-ledger tsup DTS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `@remnic/belief-ledger` depends on `@remnic/core` as a workspace package so `pnpm -r run build` waits for core dist types before tsup DTS emit.
+- `@remnic/belief-ledger` imports store helpers from `@remnic/core` instead of subpath exports, so tsup DTS emit does not need `dist/storage.d.ts` and friends to already exist.
 
 
 ## [v9.69.57] — 2026-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `@remnic/belief-ledger` depends on `@remnic/core` as a workspace package so `pnpm -r run build` waits for core dist types before tsup DTS emit.
+
+
 ## [v9.69.57] — 2026-08-31
 
 ### Fixed

--- a/packages/belief-ledger/package.json
+++ b/packages/belief-ledger/package.json
@@ -27,13 +27,11 @@
     "access": "public",
     "provenance": true
   },
-  "dependencies": {
-    "@remnic/core": "workspace:^"
-  },
   "peerDependencies": {
     "@remnic/core": "^9.69.57"
   },
   "devDependencies": {
+    "@remnic/core": "workspace:*",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0"

--- a/packages/belief-ledger/package.json
+++ b/packages/belief-ledger/package.json
@@ -27,11 +27,13 @@
     "access": "public",
     "provenance": true
   },
+  "dependencies": {
+    "@remnic/core": "workspace:^"
+  },
   "peerDependencies": {
     "@remnic/core": "^9.69.57"
   },
   "devDependencies": {
-    "@remnic/core": "workspace:*",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0"

--- a/packages/belief-ledger/src/remnic-store.ts
+++ b/packages/belief-ledger/src/remnic-store.ts
@@ -1,8 +1,12 @@
-import { composeSalvagedEnvelope } from "@remnic/core/salvage-envelope";
-import type { MemoryFile, StorageManager } from "@remnic/core";
-import { sanitizeMemoryContent } from "@remnic/core/sanitize";
-import { STRUCTURED_ATTRIBUTE_LIMITS } from "@remnic/core/write-envelope";
-import { ContentHashIndex, normalizeAttributePairs } from "@remnic/core/storage";
+import {
+  composeSalvagedEnvelope,
+  ContentHashIndex,
+  normalizeAttributePairs,
+  sanitizeMemoryContent,
+  STRUCTURED_ATTRIBUTE_LIMITS,
+  type MemoryFile,
+  type StorageManager,
+} from "@remnic/core";
 import {
   claimFromMemory,
   claimTags,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -130,6 +130,8 @@ export {
   type ObserveFingerprintParts,
   type ComposeEnvelopeOptions,
 } from "./write-envelope.js";
+export { composeSalvagedEnvelope } from "./salvage-envelope.js";
+export { sanitizeMemoryContent } from "./sanitize.js";
 export {
   getHostEmbeddingProvider,
   normalizeHostEmbeddingVector,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,10 +105,11 @@ importers:
         version: 0.26.2
 
   packages/belief-ledger:
-    devDependencies:
+    dependencies:
       '@remnic/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../remnic-core
+    devDependencies:
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.26)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -162,9 +163,6 @@ importers:
         specifier: ^7.18.2
         version: 7.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
-      '@remnic/bench':
-        specifier: workspace:^
-        version: link:../bench
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,10 @@ importers:
         version: 0.26.2
 
   packages/belief-ledger:
-    dependencies:
-      '@remnic/core':
-        specifier: workspace:^
-        version: link:../remnic-core
     devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.26)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)


### PR DESCRIPTION
## Summary

Release-and-publish run 33400459708 passed belief-ledger LLM option DTS, then failed here:

```
Cannot find module '@remnic/core/storage'
Cannot find module '@remnic/core/write-envelope'
Cannot find module '@remnic/core/sanitize'
Cannot find module '@remnic/core/salvage-envelope'
```

`pnpm -r run build` started `@remnic/belief-ledger` before `@remnic/core` dist types existed because core was only a peer/devDependency.

This PR declares `@remnic/core` as a workspace `dependencies` entry so the recursive build waits for core.

Follow-up to #3054 / #3053.

## Test plan

- [ ] `release-and-publish.yml` **Build all packages** succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package build ordering so required type definitions are available before declaration generation.
  * Updated the belief-ledger package to correctly declare its core package dependency.

* **Documentation**
  * Added the dependency and build-order correction to the unreleased changelog.

* **Release**
  * Prepared a patch release for the belief-ledger package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->