### PR TITLE
fix(ci): build @remnic/core before recursive release package builds

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -478,8 +478,10 @@ jobs:
 
       - name: Build all packages
         run: |
+          pnpm --filter @remnic/core run build
           pnpm -r run build
           pnpm run build
+
 
       - name: Verify root release artifacts
         run: node scripts/check-release-artifacts.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Release `pnpm -r run build` now builds `@remnic/core` first so tsup DTS in dependents can resolve `@remnic/core`.
+
+
 ## [v9.69.57] — 2026-08-31
 
 ### Fixed


### PR DESCRIPTION
## Summary

Release-and-publish still dies at **Build all packages**. After #3054/#3055 the error is:

```
Cannot find module '@remnic/core' or its corresponding type declarations.
```

in `@remnic/belief-ledger` tsup DTS. Core dist types are not on disk yet when that DTS worker runs.

This PR builds `@remnic/core` first in `.github/workflows/release-and-publish.yml`, then `pnpm -r run build`.

Follow-up to #3053 / #3054 / #3055. Latest failed run: 33406586090.

## Test plan

- [ ] `release-and-publish.yml` **Build all packages** succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release build process so the core package is built before dependent packages, preventing build resolution errors.

* **Documentation**
  * Added an unreleased changelog entry describing the updated build order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->