### PR TITLE
fix(plugin-openclaw): inject delegate recall directly on OpenClaw 2.0

### DIFF
--- a/.changeset/3057-openclaw2-delegate-inject.md
+++ b/.changeset/3057-openclaw2-delegate-inject.md
@@ -1,0 +1,7 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Stability: stable
+
+Restore delegate-mode memory injection on OpenClaw 2.0. 2.0 removed `registerMemoryPromptSection`, and the delegate recall hook assumed the unified memory capability's `promptBuilder` would inject the cached recall lines. That builder is synchronous and is read during host prompt assembly, which never runs `before_prompt_build` first, so cached lines were never consumed and the hook's void return injected nothing. The pre-compute-then-consume contract now applies only to section-builder hosts (OpenClaw 1.x, behavior unchanged); everywhere else the hook returns `prependSystemContext` itself. Closes #3057.

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -2066,6 +2066,53 @@ test("delegate uses the section builder on hosts that expose it (no hook injecti
   }
 });
 
+test("an OpenClaw 2.0 host (capability, no section builder) gets the hook's own injection (#3057)", async () => {
+  // 2.0 removed registerMemoryPromptSection, and its synchronous capability
+  // promptBuilder is read during host prompt assembly — which never runs this
+  // hook. A void hook return therefore injected nothing: the hook must return
+  // the injection itself, and the capability builder must have no cached lines
+  // to double-inject behind it.
+  const stub = await startDaemonStub(() => ({ context: "bridge daemon context", count: 2 }));
+  try {
+    const api = recordingApi();
+    const capabilities: Array<{
+      promptBuilder?: (params: { sessionKey?: string }) => string[] | null;
+    }> = [];
+    const capabilityApi = Object.assign(api, {
+      registerMemoryCapability(capability: unknown): void {
+        capabilities.push(
+          capability as { promptBuilder?: (params: { sessionKey?: string }) => string[] | null },
+        );
+      },
+    });
+    registerDelegateRuntime(capabilityApi, optionsFor(stub.port));
+
+    const result = (await invoke(
+      api,
+      "before_prompt_build",
+      { prompt: "what did we decide about the rollout?" },
+      { sessionKey: "v2" },
+    )) as Record<string, unknown>;
+    assert.ok(result, "the hook injects on a capability-only host");
+    assert.match(String(result.prependSystemContext), /## Memory Context \(Remnic\)/);
+    assert.match(String(result.prependSystemContext), /bridge daemon context/);
+    assert.equal(
+      result.prependContext,
+      undefined,
+      "before_prompt_build returns only prependSystemContext",
+    );
+    const promptBuilder = capabilities[0]?.promptBuilder;
+    assert.equal(typeof promptBuilder, "function", "the capability exposed a promptBuilder");
+    assert.equal(
+      promptBuilder?.({ sessionKey: "v2" }) ?? null,
+      null,
+      "the capability builder has no cached lines to double-inject",
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
 test("maybeRegisterDelegateRuntime deduplicates hook binding per api object", async () => {
   const stub = await startDaemonStub(() => ({ context: "ctx" }));
   try {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -308,14 +308,14 @@ export function registerDelegateRuntime(
   // Embedded zero-limit contract: recallBudgetChars === 0 disables injection.
   const promptInjectionEnabled = options.allowPromptInjection && options.recallBudgetChars !== 0;
   const useSectionBuilder = typeof api.registerMemoryPromptSection === "function";
-  // A host with no section builder but a unified memory capability injects
-  // through the capability's promptBuilder, which reads the same cache. Only
-  // when NEITHER exists does the hook return the injection fields itself —
-  // otherwise the capability builder would always see an empty cache while the
-  // hook injected separately (or, worse, both would inject).
-  const useCapabilityBuilder =
-    !useSectionBuilder && typeof api.registerMemoryCapability === "function";
-  const cachePromptLines = useSectionBuilder || useCapabilityBuilder;
+  // Only a SECTION-builder host (registerMemoryPromptSection, OpenClaw 1.x)
+  // gets the pre-compute-then-consume contract: its builder runs after this
+  // hook and injects the cached lines. OpenClaw 2.0 removed that API — the
+  // capability's synchronous promptBuilder is read during host prompt
+  // assembly, which never runs this hook first (issue #3057), so cached lines
+  // would never be consumed and a void return would inject nothing. On such
+  // hosts the hook returns the injection itself.
+  const cachePromptLines = useSectionBuilder;
 
   const capability = registerDelegateMemoryCapability(api, {
     serviceId: options.serviceId,
@@ -356,14 +356,10 @@ export function registerDelegateRuntime(
     workspaceDir: options.capability.workspaceDir,
     agentIds: options.capability.agentIds,
     allowPromptInjection: promptInjectionEnabled,
-    // The section builder owns the destructive read when it exists; otherwise
-    // the capability builder IS the sole consumer and must evict, or a stale
-    // section would be re-injected on the next turn.
-    readPromptLines: (sessionKey) => {
-      const lines = promptLinesBySession.get(sessionKey) ?? null;
-      if (!useSectionBuilder) promptLinesBySession.delete(sessionKey);
-      return lines;
-    },
+    // Peek only. The section builder's own builder function owns eviction,
+    // and on hosts without one (OpenClaw 2.0) the hook never caches — it
+    // injects directly — so this can never double-inject behind the hook.
+    readPromptLines: (sessionKey) => promptLinesBySession.get(sessionKey) ?? null,
     extractionMaxTurnChars: options.capability.extractionMaxTurnChars,
     flushModel: options.capability.flushModel,
     configuredSearchBackend: options.capability.configuredSearchBackend,
@@ -447,7 +443,7 @@ export function registerDelegateRuntime(
         if (!rendered) return undefined;
         const prompt = rendered.prompt;
         if (cachePromptLines) {
-          // A registered builder injects; the hook only pre-computes.
+          // A registered section builder injects; the hook only pre-computes.
           // Returning injection fields here too would double-inject.
           promptLinesBySession.set(sessionKey, rendered.lines);
           return undefined;


### PR DESCRIPTION
## Summary

On OpenClaw 2.0 (`2026.8.1`), delegate/bridge mode loaded, reached the daemon, and injected no memory. 2.0 removed `api.registerMemoryPromptSection`; the delegate runtime then treated the unified memory capability's `promptBuilder` as the injector and the recall hook cached the rendered lines and returned `undefined`. That builder is synchronous and is read during host prompt assembly (`prepareMemoryPromptSection`), which never runs `before_prompt_build` first — so cached lines were never consumed and the void hook return injected nothing. Closes #3057.

## Change

`packages/plugin-openclaw/src/delegate-runtime.ts`:

- `cachePromptLines` is now `useSectionBuilder` only. The pre-compute-then-consume contract applies exclusively to hosts that expose `registerMemoryPromptSection` (OpenClaw 1.x).
- On every other host (2.0 capability-only, or neither surface), the `before_prompt_build` handler returns `{ prependSystemContext, degradation? }` itself.
- `readPromptLines` (the capability's `promptBuilder`) is now a pure peek: on non-section hosts the hook never caches, so the builder can never double-inject behind the hook.

## Compatibility

- OpenClaw 1.x (section-builder hosts): behavior byte-identical — hook caches and returns `undefined`, the registered section builder consumes and evicts. Pinned by the existing test `delegate uses the section builder on hosts that expose it (no hook injection)`.
- OpenClaw 2.0: verified against upstream `v2026.8.1` — `registerMemoryPromptSection` survives only in `docs/plugins/sdk-migration.md` (removed from the SDK), while `before_prompt_build` → `prependSystemContext?: string` remains the hook result contract (`src/plugins/hook-before-agent-start.types.ts`).
- No manifest/compat metadata changes; floors untouched.

## Verification

- New test `an OpenClaw 2.0 host (capability, no section builder) gets the hook's own injection (#3057)`: asserts the hook returns `prependSystemContext` with the daemon context, no dual injection keys, and the capability's `promptBuilder` has no cached lines to double-inject.
- Discrimination proven: with the source fix stashed the new test fails (`not ok`, 0 pass / 1 fail); with the fix it passes.
- `npm run test:file packages/plugin-openclaw/src/delegate-runtime.test.ts` — 82/82 pass.
- `npm run check-types` — OK. `npm run preflight:quick` — OK (quick). `npm run check:pre-push` — all cheap CI gates pass.
- Changeset `.changeset/3057-openclaw2-delegate-inject.md` (`@remnic/plugin-openclaw` patch, Stability: stable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored delegate-mode memory recall injection for OpenClaw 2.0.
  - Ensured cached recall context is included in prompts without being duplicated.
  - Preserved existing behavior for OpenClaw 1.x hosts using section-based prompt builders.

- **Tests**
  - Added coverage verifying memory context injection and preventing duplicate prompt content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->