### PR TITLE
fix(ci): do not rebuild @remnic/core during recursive release build

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -479,8 +479,9 @@ jobs:
       - name: Build all packages
         run: |
           pnpm --filter @remnic/core run build
-          pnpm -r run build
+          pnpm -r --filter '!@remnic/core' run build
           pnpm run build
+
 
 
       - name: Verify root release artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Release recursive package build excludes `@remnic/core` after the dedicated core build so tsup does not wipe core `dist` mid-flight.
+
+
 ## [v9.69.57] — 2026-08-31
 
 ### Fixed

--- a/tests/package-release-script-contract.test.ts
+++ b/tests/package-release-script-contract.test.ts
@@ -45,7 +45,7 @@ test("release smoke coverage verifies build artifacts after the build", () => {
     "utf8",
   );
   assert.match(releaseWorkflow, /pnpm run build\s*\n\s*node scripts\/check-release-artifacts\.mjs/);
-  assert.match(releaseWorkflow, /pnpm -r run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
+  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s*\n\s*pnpm -r --filter '!@remnic\/core' run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
   assert.match(releaseWorkflow, /- name: Verify root release artifacts\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
 });
 


### PR DESCRIPTION
## Summary

Run 33410226382 built `@remnic/core` first (from #3056). Belief-ledger DTS then succeeded. `pnpm -r run build` started core **again**, cleaned `dist`, and `capture-audio` tsup DTS failed with `Cannot find module '@remnic/core'`.

This PR keeps the dedicated core build, then runs `pnpm -r --filter '!@remnic/core' run build`.

## Test plan

- [ ] `release-and-publish.yml` **Build all packages** succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed release builds so the core package’s compiled output is preserved and published correctly.
  - Prevented duplicate package builds from overwriting generated files.

- **Documentation**
  - Added a changelog entry describing the release-build correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->