### PR TITLE
fix(ci): stop stale-mtime core rebuilds during release package build

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -482,9 +482,6 @@ jobs:
           REMNIC_SKIP_CORE_REBUILD=1 pnpm -r --filter '!@remnic/core' run build
           pnpm run build
 
-
-
-
       - name: Verify root release artifacts
         run: node scripts/check-release-artifacts.mjs
 

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -479,8 +479,9 @@ jobs:
       - name: Build all packages
         run: |
           pnpm --filter @remnic/core run build
-          pnpm -r --filter '!@remnic/core' run build
+          REMNIC_SKIP_CORE_REBUILD=1 pnpm -r --filter '!@remnic/core' run build
           pnpm run build
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Release recursive build sets `REMNIC_SKIP_CORE_REBUILD=1` so staleness-triggered prebuilds cannot clean `@remnic/core` `dist` while dependents emit DTS.
+
+
 ## [v9.69.57] — 2026-08-31
 
 ### Fixed

--- a/scripts/ensure-bench-build-deps.mjs
+++ b/scripts/ensure-bench-build-deps.mjs
@@ -4,17 +4,19 @@ import { ensurePackageBuild } from "./build-staleness.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-ensurePackageBuild(
-  repoRoot,
-  "@remnic/core",
-  path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
-  [
-    path.join(repoRoot, "packages", "remnic-core", "src"),
-    path.join(repoRoot, "packages", "remnic-core", "package.json"),
-    path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
-    path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
-  ],
-);
+if (process.env.REMNIC_SKIP_CORE_REBUILD !== "1") {
+  ensurePackageBuild(
+    repoRoot,
+    "@remnic/core",
+    path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+    [
+      path.join(repoRoot, "packages", "remnic-core", "src"),
+      path.join(repoRoot, "packages", "remnic-core", "package.json"),
+      path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+      path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+    ],
+  );
+}
 
 // #1557: bench now depends on @remnic/coding-graph for the coding-graph
 // benchmark harness. Ensure its dist is built before bench's tsup DTS

--- a/scripts/ensure-cli-bench-build-deps.mjs
+++ b/scripts/ensure-cli-bench-build-deps.mjs
@@ -4,17 +4,19 @@ import { ensurePackageBuild } from "./build-staleness.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-ensurePackageBuild(
-  repoRoot,
-  "@remnic/core",
-  path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
-  [
-    path.join(repoRoot, "packages", "remnic-core", "src"),
-    path.join(repoRoot, "packages", "remnic-core", "package.json"),
-    path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
-    path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
-  ],
-);
+if (process.env.REMNIC_SKIP_CORE_REBUILD !== "1") {
+  ensurePackageBuild(
+    repoRoot,
+    "@remnic/core",
+    path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+    [
+      path.join(repoRoot, "packages", "remnic-core", "src"),
+      path.join(repoRoot, "packages", "remnic-core", "package.json"),
+      path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+      path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+    ],
+  );
+}
 ensurePackageBuild(
   repoRoot,
   "@remnic/plugin-openclaw",

--- a/scripts/ensure-core-build-deps.mjs
+++ b/scripts/ensure-core-build-deps.mjs
@@ -4,14 +4,16 @@ import { ensurePackageBuild } from "./build-staleness.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-ensurePackageBuild(
-  repoRoot,
-  "@remnic/core",
-  path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
-  [
-    path.join(repoRoot, "packages", "remnic-core", "src"),
-    path.join(repoRoot, "packages", "remnic-core", "package.json"),
-    path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
-    path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
-  ],
-);
+if (process.env.REMNIC_SKIP_CORE_REBUILD !== "1") {
+  ensurePackageBuild(
+    repoRoot,
+    "@remnic/core",
+    path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+    [
+      path.join(repoRoot, "packages", "remnic-core", "src"),
+      path.join(repoRoot, "packages", "remnic-core", "package.json"),
+      path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+      path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+    ],
+  );
+}

--- a/tests/package-release-script-contract.test.ts
+++ b/tests/package-release-script-contract.test.ts
@@ -45,7 +45,7 @@ test("release smoke coverage verifies build artifacts after the build", () => {
     "utf8",
   );
   assert.match(releaseWorkflow, /pnpm run build\s*\n\s*node scripts\/check-release-artifacts\.mjs/);
-  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s{0,4}\n\s{0,4}(?:REMNIC_SKIP_CORE_REBUILD=1 )?pnpm -r --filter '!@remnic\/core' run build\s{0,4}\n\s{0,4}pnpm run build\s{0,4}\n\s{0,4}\n\s{0,4}- name: Verify root release artifacts/);
+  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s{0,12}\n\s{0,12}(?:REMNIC_SKIP_CORE_REBUILD=1 )?pnpm -r --filter '!@remnic\/core' run build\s{0,12}\n\s{0,12}pnpm run build\s{0,12}\n\s{0,12}\n\s{0,12}- name: Verify root release artifacts/);
   assert.match(releaseWorkflow, /- name: Verify root release artifacts\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
 });
 

--- a/tests/package-release-script-contract.test.ts
+++ b/tests/package-release-script-contract.test.ts
@@ -45,7 +45,7 @@ test("release smoke coverage verifies build artifacts after the build", () => {
     "utf8",
   );
   assert.match(releaseWorkflow, /pnpm run build\s*\n\s*node scripts\/check-release-artifacts\.mjs/);
-  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s*\n\s*pnpm -r --filter '!@remnic\/core' run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
+  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s*\n\s*(?:REMNIC_SKIP_CORE_REBUILD=1 )?pnpm -r --filter '!@remnic\/core' run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
   assert.match(releaseWorkflow, /- name: Verify root release artifacts\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
 });
 

--- a/tests/package-release-script-contract.test.ts
+++ b/tests/package-release-script-contract.test.ts
@@ -45,7 +45,7 @@ test("release smoke coverage verifies build artifacts after the build", () => {
     "utf8",
   );
   assert.match(releaseWorkflow, /pnpm run build\s*\n\s*node scripts\/check-release-artifacts\.mjs/);
-  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s{0,12}\n\s{0,12}(?:REMNIC_SKIP_CORE_REBUILD=1 )?pnpm -r --filter '!@remnic\/core' run build\s{0,12}\n\s{0,12}pnpm run build\s{0,12}\n\s{0,12}\n\s{0,12}- name: Verify root release artifacts/);
+  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s{0,12}\n\s{0,12}REMNIC_SKIP_CORE_REBUILD=1 pnpm -r --filter '!@remnic\/core' run build\s{0,12}\n\s{0,12}pnpm run build\s{0,12}\n\s{0,12}\n\s{0,12}- name: Verify root release artifacts/);
   assert.match(releaseWorkflow, /- name: Verify root release artifacts\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
 });
 

--- a/tests/package-release-script-contract.test.ts
+++ b/tests/package-release-script-contract.test.ts
@@ -45,7 +45,7 @@ test("release smoke coverage verifies build artifacts after the build", () => {
     "utf8",
   );
   assert.match(releaseWorkflow, /pnpm run build\s*\n\s*node scripts\/check-release-artifacts\.mjs/);
-  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s*\n\s*(?:REMNIC_SKIP_CORE_REBUILD=1 )?pnpm -r --filter '!@remnic\/core' run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
+  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s{0,4}\n\s{0,4}(?:REMNIC_SKIP_CORE_REBUILD=1 )?pnpm -r --filter '!@remnic\/core' run build\s{0,4}\n\s{0,4}pnpm run build\s{0,4}\n\s{0,4}\n\s{0,4}- name: Verify root release artifacts/);
   assert.match(releaseWorkflow, /- name: Verify root release artifacts\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
 });
 


### PR DESCRIPTION
## Summary

Run 33418936225: after #3059's filter, a package prebuild still rebuilt `@remnic/core`. `scripts/ensure-bench-build-deps.mjs` treats checkout-refreshed `src` mtimes as staleness and rebuilds core — cleaning `dist` while dependent tsup DTS runs.

The release recursive build now sets `REMNIC_SKIP_CORE_REBUILD=1`; the ensure helper skips its core rebuild when that is set.

## Test plan

- [x] release-script contract test updated and green
- [x] `npm run check:pre-push`
- [ ] `release-and-publish.yml` **Build all packages** succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package release builds to prevent unnecessary core package rebuilds during dependent package compilation.
  - Helped avoid missing or overwritten build artifacts during release publishing.

- **Documentation**
  - Updated the unreleased changelog with details about the release build fix.

- **Tests**
  - Updated release build validation to cover the revised build sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->