### PR TITLE
fix(ci): stop the recursive release wave from rebuilding core mid-build

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -478,8 +478,8 @@ jobs:
 
       - name: Build all packages
         run: |
-          pnpm --filter @remnic/core run build
-          pnpm -r --filter '!@remnic/core' run build
+          node scripts/ensure-core-build.mjs
+          pnpm -r --filter '!@remnic/core' --filter '!remnic-workspace' run build
           pnpm run build
 
 

--- a/scripts/ensure-core-build.mjs
+++ b/scripts/ensure-core-build.mjs
@@ -1,0 +1,25 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ensurePackageBuild } from "./build-staleness.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Release builds must seed the same freshness marker the recursive wave's
+// prebuilds check (scripts/ensure-bench-build-deps.mjs). A plain
+// `pnpm --filter @remnic/core build` writes dist without the fingerprint
+// sidecar, so the first prebuild inside `pnpm -r` treats core as stale,
+// rebuilds it (cleaning dist), and a sibling package's concurrent tsup DTS
+// worker reads the half-cleaned dist and fails with TS2307/TS7016
+// ("Cannot find module '@remnic/core'").
+ensurePackageBuild(
+  repoRoot,
+  "@remnic/core",
+  path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+  [
+    path.join(repoRoot, "packages", "remnic-core", "src"),
+    path.join(repoRoot, "packages", "remnic-core", "package.json"),
+    path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+  ],
+);

--- a/tests/package-release-script-contract.test.ts
+++ b/tests/package-release-script-contract.test.ts
@@ -45,7 +45,7 @@ test("release smoke coverage verifies build artifacts after the build", () => {
     "utf8",
   );
   assert.match(releaseWorkflow, /pnpm run build\s*\n\s*node scripts\/check-release-artifacts\.mjs/);
-  assert.match(releaseWorkflow, /pnpm --filter @remnic\/core run build\s*\n\s*pnpm -r --filter '!@remnic\/core' run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
+  assert.match(releaseWorkflow, /node scripts\/ensure-core-build\.mjs\s*\n\s*pnpm -r --filter '!@remnic\/core' --filter '!remnic-workspace' run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
   assert.match(releaseWorkflow, /- name: Verify root release artifacts\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
 });
 


### PR DESCRIPTION
## Summary

The last two `release-and-publish` runs failed at "Build all packages" before npm publish (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @remnic/capture-audio@9.69.57 build: error TS2307: Cannot find module '@remnic/core'`). This removes the race that killed them, unblocking the queued v9.69.57 release.

## Root cause

`pnpm -r run build` includes the **workspace root project**, so the wave ran the root `build` script — whose first segment is `pnpm --filter @remnic/core build` — concurrently with sibling packages' tsup DTS workers. That rebuild cleans `packages/remnic-core/dist` mid-wave; a concurrent dts worker resolving `@remnic/core` then reads a half-cleaned dist and dies (observed as `TS2307` in `capture-audio` on CI, `TS7016`/`TS2307` in `belief-ledger`/`bench-ui` locally). #3056/#3059 ordered builds correctly but the root project's own rebuild slipped through the filter.

A second contributor: the workflow's direct `pnpm --filter @remnic/core run build` never writes the `.source-fingerprint.json` sidecar that `scripts/build-staleness.mjs ensurePackageBuild` checks, so the wave's prebuilds (`ensure-*-build-deps.mjs`) also treated core as stale and rebuilt it inside the wave.

## Change

- `pnpm -r --filter '!@remnic/core' --filter '!remnic-workspace' run build` — the root project is excluded; it still runs via the following sequential `pnpm run build` (its own core → plugin-openclaw → tsup chain is strictly ordered, no race).
- New `scripts/ensure-core-build.mjs` replaces the direct core build: it goes through the same `ensurePackageBuild` path the prebuilds use, so the freshness sidecar is seeded and every in-wave ensure becomes a no-op instead of a rebuild.
- `tests/package-release-script-contract.test.ts` pins the new block.

## Verification

- Fresh `pnpm install --frozen-lockfile` at the current release commit (`d927b7946b`), then the exact three commands of "Build all packages": exit 0, **zero** in-wave core builds, zero TS7016/TS2307 (previously reproduced the failure twice: capture-audio on CI, belief-ledger + bench-ui locally).
- With the sidecar deliberately poisoned (removed), the unfixed wave reproduced the race deterministically; the fixed chain heals and passes.
- `tests/package-release-script-contract.test.ts`: 4/4 pass.

CI-only diff: no changeset (exempt), no version bump — the release run this PR triggers publishes the queued v9.69.57 (which carries the already-merged #3058 OpenClaw 2.0 delegate fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release builds to ensure the core package is fully prepared before dependent packages are built.
  * Reduced the risk of build failures caused by incomplete or stale generated output during releases.

* **Tests**
  * Updated release workflow validation to verify the revised build preparation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->