### PR TITLE
docs(openclaw): document the plugin minimum for OpenClaw 2.0 hosts

### DIFF
--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -693,13 +693,16 @@ If hooks are not firing:
 1. Confirm the plugin is installed under `openclaw-remnic`.
 2. Confirm `plugins.slots.memory` points to `openclaw-remnic`.
 3. Check the gateway log for a slot-selection error or passive-mode warning.
-4. On OpenClaw 2026.8.1 (2.0) with plugin `9.69.56` or older in bridge/delegate
-   mode, hooks fire but the prompt has no memory: upgrade the plugin to
-   `9.69.57` or newer. See "Upgrading to OpenClaw 2.0" above and issue #3057.
 
 ```bash
 grep -i remnic ~/.openclaw/logs/gateway.log | tail -50
 ```
+
+If hooks fire but the prompt contains no memory on OpenClaw 2026.8.1 (2.0)
+with bridge/delegate mode:
+
+Plugin `9.69.56` or older cannot inject on a 2.0 host; upgrade the plugin to
+`9.69.57` or newer. See "Upgrading to OpenClaw 2.0" above and issue #3057.
 
 If you are migrating from the older `openclaw-engram` id, install the
 canonical package and keep the shim only as a temporary compatibility layer.

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -43,6 +43,37 @@ remnic openclaw migrate-engram --yes
 See [OpenClaw Engram to Remnic migration](../guides/openclaw-engram-to-remnic.md)
 for config-key behavior, backup behavior, and local patch preservation notes.
 
+## Upgrading to OpenClaw 2.0
+
+OpenClaw 2026.8.1 (2.0) removed `api.registerMemoryPromptSection`. Plugin
+releases up to and including `9.69.56` relied on that API in bridge/delegate
+mode: on a 2.0 host the plugin loads, reaches the daemon, and captures turns,
+but injects **no memory** into agent prompts. Upgrading the host to 2.0
+requires `@remnic/plugin-openclaw` `9.69.57` or newer. Install or update the
+plugin in the same change as the host upgrade:
+
+```bash
+openclaw plugins install clawhub:@remnic/plugin-openclaw
+```
+
+or through the Remnic installer:
+
+```bash
+remnic openclaw install
+```
+
+Scope of the old pairing:
+
+- OpenClaw 1.x hosts (2026.4 through 2026.7.x) work on every plugin version;
+  the section-builder injection path there is unchanged.
+- Embedded (non-delegate) memory mode was not affected; it injects through the
+  `before_prompt_build` hook result on 2.0.
+- Symptom of the stale pairing on 2.0: gateway logs show
+  `delegate: registered daemon-backed memory capability` and
+  `bridge mode delegate: memory loop backed by daemon`, the recall request
+  reaches the daemon, and the model prompt still contains no memory context.
+  See issue #3057.
+
 ## Publish to ClawHub
 
 Publish ClawHub releases from the built npm/ClawPack tarball, not from the raw
@@ -662,6 +693,9 @@ If hooks are not firing:
 1. Confirm the plugin is installed under `openclaw-remnic`.
 2. Confirm `plugins.slots.memory` points to `openclaw-remnic`.
 3. Check the gateway log for a slot-selection error or passive-mode warning.
+4. On OpenClaw 2026.8.1 (2.0) with plugin `9.69.56` or older in bridge/delegate
+   mode, hooks fire but the prompt has no memory: upgrade the plugin to
+   `9.69.57` or newer. See "Upgrading to OpenClaw 2.0" above and issue #3057.
 
 ```bash
 grep -i remnic ~/.openclaw/logs/gateway.log | tail -50

--- a/llms.txt
+++ b/llms.txt
@@ -292,6 +292,14 @@ The August 14, 2026 Support Passport sweep starts at June 15, 2026. The
 existing `>=2026.4.1` installer floor remains more permissive and stays in
 place.
 
+Host-upgrade pairing: OpenClaw 2026.8.1 (2.0) removed the
+`registerMemoryPromptSection` SDK API. Plugin versions up to and including
+9.69.56 load on 2.0 and run the daemon loop, but bridge/delegate mode injects
+no memory into agent prompts. Upgrading the host to 2.0 requires
+@remnic/plugin-openclaw >= 9.69.57. OpenClaw 1.x hosts (2026.4 through
+2026.7.x) and embedded (non-delegate) memory mode are unaffected on every
+plugin version (issue #3057).
+
 `openclaw.compat.pluginApi` and `openclaw.install.minHostVersion` use one
 `>=2026.4.1` comparator, never a `||` list: OpenClaw's installer splits the
 range on whitespace and AND-evaluates every token (a `||` fails entirely) and

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -243,6 +243,14 @@ OpenClaw 2026.5.30-beta.1 may resolve bare package names npm-first during the
 launch cutover, so operator docs should keep the explicit `clawhub:` prefix for
 deterministic installs.
 
+OpenClaw 2026.8.1 (2.0) removed `api.registerMemoryPromptSection`. Plugin
+releases up to and including `9.69.56` relied on that API in bridge/delegate
+mode: on a 2.0 host the plugin loads, reaches the daemon, and captures turns,
+but injects no memory into agent prompts. Upgrading the host to 2.0 requires
+`@remnic/plugin-openclaw` `9.69.57` or newer. OpenClaw 1.x hosts (2026.4
+through 2026.7.x) and embedded (non-delegate) memory mode are unaffected on
+every plugin version. See issue #3057.
+
 The manifest declares `activation.onStartup: false`, exposes the optional
 plugin-mode OpenAI key through `providerAuthChoices`, and mirrors the
 `OPENAI_API_KEY` env signal through `setup.providers[].envVars` for current


### PR DESCRIPTION
## Summary

Operators and LLM readers upgrading a gateway to OpenClaw 2026.8.1 (2.0) had no doc telling them the plugin must be `9.69.57`+ at the same time. On 2.0, plugin releases up to `9.69.56` load and run the daemon loop but inject no memory in bridge/delegate mode (`registerMemoryPromptSection` was removed upstream; issue #3057, fixed in 9.69.57).

## Change (docs-only, 3 files)

- `docs/plugins/openclaw.md`: new "Upgrading to OpenClaw 2.0" section (scope, upgrade commands, symptom signature) plus a Troubleshooting entry for the stale pairing.
- `packages/plugin-openclaw/README.md`: compatibility-notes paragraph stating the 2.0 host-upgrade pairing (ships with the next published version's npm README).
- `llms.txt`: host-upgrade pairing paragraph in OPENCLAW PLUGIN COMPATIBILITY so LLM readers index the requirement.

## Scope statements (verified against source)

- OpenClaw 1.x hosts (2026.4 through 2026.7.x): unaffected on every plugin version; the section-builder path is unchanged.
- Embedded (non-delegate) memory mode: unaffected on 2.0 — `src/index.ts` returns `{ prependSystemContext }` from the hook when no section builder exists; only `delegate-runtime.ts` had the cache-and-void bet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guidance for OpenClaw 2.0 compatibility.
  * Documented that plugin version 9.69.57 or newer is required for bridge/delegate mode on OpenClaw 2.0.
  * Clarified that OpenClaw 1.x hosts and embedded memory mode remain unaffected.
  * Added troubleshooting guidance for cases where memory is missing from prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->