### PR TITLE
fix(core): park unresolvable entity canonical-id mappings on boot

### DIFF
--- a/.changeset/3065-entity-migration-boot.md
+++ b/.changeset/3065-entity-migration-boot.md
@@ -1,0 +1,10 @@
+---
+"@remnic/core": patch
+---
+
+Stability: stable
+
+Park unresolvable entity canonical-id mappings (both files gone, or a Type
+that now normalizes to a different target) instead of throwing during
+directory init, so the daemon can boot. Drop parks whose canonical file is
+also gone rather than reviving them into an infinite rescan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Entity canonical-id migration parks missing or retargeted pairs instead of Fatal-exiting the daemon on boot.
+
 ## [v9.69.57] — 2026-08-31
 
 ### Fixed

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -695,18 +695,6 @@ function mergeDiscoveredMappings(
   for (const [legacyId, canonicalId] of Object.entries(discovered)) {
     const previousMapping = merged[legacyId];
     if (previousMapping !== undefined && previousMapping !== canonicalId) {
-      // A -> B collapses to A -> C once B -> C exists, so a rescan that still
-      // reads A -> B off disk is reporting the same chain, not a new target.
-      // Only a target the chain cannot reach is a real conflict.
-      let hop: string | undefined = canonicalId;
-      const seen = new Set<string>();
-      while (hop !== undefined && hop !== previousMapping && !seen.has(hop)) {
-        seen.add(hop);
-        hop = merged[hop];
-      }
-      if (hop !== previousMapping) {
-        throw new Error(`Legacy entity id ${legacyId} changed canonical target during migration.`);
-      }
       continue;
     }
     if (previousMapping === undefined && wouldCreateMappingCycle(merged, legacyId, canonicalId)) continue;
@@ -765,7 +753,7 @@ async function migrateEntityFilePair(
     await assertNotSymlink(canonicalPath, canonicalId);
     const legacyExists = await fileExists(legacyPath);
     const canonicalExists = await fileExists(canonicalPath);
-    if (!legacyExists && !canonicalExists) return { deferred: true, progressed: false };
+    if (!legacyExists && !canonicalExists) return { deferred: false, progressed: false, blocked: true };
     if (legacyExists && canonicalExists) {
       if (await sameFileIdentity(legacyPath, canonicalPath)) return { deferred: false, progressed: false };
       const [legacyContent, canonicalContent, legacyEncrypted, canonicalEncrypted] = await Promise.all([
@@ -944,9 +932,9 @@ export async function migrateLegacyEntityCanonicalIds(
           delete parked[legacyId];
           if (active[legacyId] !== undefined) continue;
           const legacyPath = deps.resolveEntityFilePath(legacyId);
+          const canonicalPath = deps.resolveEntityFilePath(canonicalId);
           if (legacyPath !== null && (await fileExists(legacyPath))) continue;
-          // Source gone: the rename is moot, but references still name it and
-          // this record is the only thing that can still rewrite them.
+          if (canonicalPath === null || !(await fileExists(canonicalPath))) continue;
           active[legacyId] = canonicalId;
           revived = true;
         }
@@ -1070,9 +1058,8 @@ export async function migrateLegacyEntityCanonicalIds(
           if (deferredMappings.length === 0) break;
           if (!progressed) {
             const [legacyId, canonicalId] = deferredMappings[0]!;
-            throw new Error(
-              `Cannot migrate legacy entity id ${legacyId}: both files are missing and no intermediate mapping can advance migration.`,
-            );
+            blocked.set(legacyId, canonicalId);
+            break;
           }
           pendingMappings = deferredMappings;
         }

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -753,7 +753,7 @@ async function migrateEntityFilePair(
     await assertNotSymlink(canonicalPath, canonicalId);
     const legacyExists = await fileExists(legacyPath);
     const canonicalExists = await fileExists(canonicalPath);
-    if (!legacyExists && !canonicalExists) return { deferred: false, progressed: false, blocked: true };
+    if (!legacyExists && !canonicalExists) return { deferred: true, progressed: false };
     if (legacyExists && canonicalExists) {
       if (await sameFileIdentity(legacyPath, canonicalPath)) return { deferred: false, progressed: false };
       const [legacyContent, canonicalContent, legacyEncrypted, canonicalEncrypted] = await Promise.all([
@@ -864,6 +864,11 @@ export async function migrateLegacyEntityCanonicalIds(
         };
       }
       const blocked: BlockedEntityPairs = new Map();
+      // Parks for pairs whose files are GONE, tracked separately from
+      // collision parks: pruneBlocked drops these (the canonical file is gone
+      // too), and the rescan's blocked.clear() would otherwise silence them
+      // before finish() reports anything.
+      const staleParked: BlockedEntityPairs = new Map();
       // ONE aggregated line per run, not one per pair per restart: this used to
       // abort the daemon, so the operator needs the whole list and the remedy.
       const finish = async (): Promise<string | undefined> => {
@@ -872,6 +877,13 @@ export async function migrateLegacyEntityCanonicalIds(
           log.warn(
             `entity canonical-id migration skipped ${blocked.size} unresolvable pair(s): ${pairs}. `
             + "Both files were kept and the legacy id still resolves; merge or delete one side to migrate it.",
+          );
+        }
+        if (staleParked.size > 0) {
+          const pairs = [...staleParked].map(([legacyId, canonicalId]) => `${legacyId} -> ${canonicalId}`).join(", ");
+          log.warn(
+            `entity canonical-id migration dropped ${staleParked.size} mapping(s) whose entity files are gone: ${pairs}. `
+            + "The stale journal entries were removed; references to those legacy ids do not resolve either way.",
           );
         }
         // Every finish() path either just rewrote references (main/reconcile
@@ -1057,8 +1069,12 @@ export async function migrateLegacyEntityCanonicalIds(
           }
           if (deferredMappings.length === 0) break;
           if (!progressed) {
-            const [legacyId, canonicalId] = deferredMappings[0]!;
-            blocked.set(legacyId, canonicalId);
+            // Deferred means both files are missing: no later pass can help
+            // these pairs, so park them all instead of Fatal-exiting.
+            for (const [legacyId, canonicalId] of deferredMappings) {
+              blocked.set(legacyId, canonicalId);
+              staleParked.set(legacyId, canonicalId);
+            }
             break;
           }
           pendingMappings = deferredMappings;

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -956,7 +956,10 @@ export async function migrateLegacyEntityCanonicalIds(
             target = active[target]!;
           }
           const targetPath = deps.resolveEntityFilePath(target);
-          if (targetPath === null || !(await fileExists(targetPath))) continue;
+          if (targetPath === null || !(await fileExists(targetPath))) {
+            staleParked.set(legacyId, canonicalId);
+            continue;
+          }
           active[legacyId] = target;
           revived = true;
         }

--- a/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
+++ b/packages/remnic-core/src/storage/entity-canonical-id-migration.ts
@@ -944,10 +944,20 @@ export async function migrateLegacyEntityCanonicalIds(
           delete parked[legacyId];
           if (active[legacyId] !== undefined) continue;
           const legacyPath = deps.resolveEntityFilePath(legacyId);
-          const canonicalPath = deps.resolveEntityFilePath(canonicalId);
           if (legacyPath !== null && (await fileExists(legacyPath))) continue;
-          if (canonicalPath === null || !(await fileExists(canonicalPath))) continue;
-          active[legacyId] = canonicalId;
+          // Resolve the parked target through ACTIVE moves before deciding
+          // its file is gone: a parked A -> B beside an active B -> C must
+          // promote to A -> C and rewrite, not drop because B was moved
+          // out-of-band. Only a target with no surviving file may drop.
+          let target = canonicalId;
+          const seenTargets = new Set<string>();
+          while (active[target] !== undefined && !seenTargets.has(target)) {
+            seenTargets.add(target);
+            target = active[target]!;
+          }
+          const targetPath = deps.resolveEntityFilePath(target);
+          if (targetPath === null || !(await fileExists(targetPath))) continue;
+          active[legacyId] = target;
           revived = true;
         }
         // Reviving a whole chain at once yields A -> B -> C, and each rewrite

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -773,6 +773,58 @@ test("a persisted mapping whose both entity files are gone does not abort startu
   }
 });
 
+test("a parked target is promoted through an active move before its park is dropped", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-park-promote-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const name = "Task inventory mapping";
+    const legacy = "task-inventory-mapping";
+    const movedTarget = normalizeEntityName(name, "task");
+    const live = normalizeEntityName(name, "automation");
+    assert.notEqual(movedTarget, live);
+    // Only the final canonical file survives on disk; the intermediate
+    // target was moved out-of-band. The journal still parks A -> B beside
+    // the active B -> C.
+    await writeFile(
+      path.join(dir, "entities", `${live}.md`),
+      `---\nid: ${live}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# ${name}\n\n**Type:** automation\n\nLive target.\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({
+        version: 1,
+        complete: false,
+        mappings: { [movedTarget]: live },
+        blocked: { [legacy]: movedTarget },
+      }),
+      "utf8",
+    );
+    const factDir = path.join(dir, "facts", "2026-03-01");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-park-promote.md");
+    await writeFile(
+      factPath,
+      `---\nid: fact-park-promote\ncategory: fact\nconfidence: 0.9\n`
+      + `created: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n`
+      + `entityRef: ${legacy}\nstatus: active\n---\n\nThe mapping tracks tasks.\n`,
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+
+    assert.equal(
+      /^entityRef: (.*)$/m.exec(await readFile(factPath, "utf8"))?.[1],
+      live,
+      "a park must promote through the active move instead of stranding its references",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("a persisted mapping whose Type now normalizes to a new canonical id does not abort startup", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-retarget-"));
   try {

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -747,3 +747,61 @@ test("addEntityRelationship falls back to the legacy file while its rename is in
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a persisted mapping whose both entity files are gone does not abort startup", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-both-missing-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const legacy = "task-inventory-mapping";
+    const canonical = normalizeEntityName("Task inventory mapping", "project");
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: false, mappings: { [legacy]: canonical } }),
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+
+    const journal = JSON.parse(
+      await readFile(path.join(dir, "state", "entity-canonical-id-migration-v1.json"), "utf8"),
+    ) as { mappings?: Record<string, string> };
+    assert.equal(journal.mappings?.[legacy], undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a persisted mapping whose Type now normalizes to a new canonical id does not abort startup", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-retarget-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const name = "Task inventory mapping";
+    const legacy = normalizeEntityName(name, "task");
+    const staleCanonical = normalizeEntityName(name, "project");
+    const liveCanonical = normalizeEntityName(name, "automation");
+    assert.notEqual(staleCanonical, liveCanonical);
+    await writeFile(
+      path.join(dir, "entities", `${legacy}.md`),
+      `---\nid: ${legacy}\ncreated: 2026-03-01T00:00:00.000Z\nupdated: 2026-03-01T00:00:00.000Z\n---\n\n`
+      + `# ${name}\n\n**Type:** automation\n\nLive type.\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: false, mappings: { [legacy]: staleCanonical } }),
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+
+    const live = await readFile(path.join(dir, "entities", `${liveCanonical}.md`), "utf8").catch(() =>
+      readFile(path.join(dir, "entities", `${legacy}.md`), "utf8"),
+    );
+    assert.match(live, /Live type\./);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -765,8 +765,9 @@ test("a persisted mapping whose both entity files are gone does not abort startu
 
     const journal = JSON.parse(
       await readFile(path.join(dir, "state", "entity-canonical-id-migration-v1.json"), "utf8"),
-    ) as { mappings?: Record<string, string> };
+    ) as { mappings?: Record<string, string>; blocked?: Record<string, string> };
     assert.equal(journal.mappings?.[legacy], undefined);
+    assert.equal(journal.blocked?.[legacy], undefined, "a park whose files are gone is dropped, not sealed");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/entity-canonical-id-collision.test.ts
+++ b/tests/entity-canonical-id-collision.test.ts
@@ -825,6 +825,30 @@ test("a parked target is promoted through an active move before its park is drop
   }
 });
 
+test("a persisted blocked pair whose both files are gone is dropped on boot with no abort", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-blocked-gone-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const legacy = "task-inventory-mapping";
+    const target = normalizeEntityName("Task inventory mapping", "project");
+    await writeFile(
+      path.join(dir, "state", "entity-canonical-id-migration-v1.json"),
+      JSON.stringify({ version: 1, complete: false, mappings: {}, blocked: { [legacy]: target } }),
+      "utf8",
+    );
+
+    await new StorageManager(dir).ensureDirectories();
+
+    const journal = JSON.parse(
+      await readFile(path.join(dir, "state", "entity-canonical-id-migration-v1.json"), "utf8"),
+    ) as { blocked?: Record<string, string>; complete?: boolean };
+    assert.equal(journal.blocked?.[legacy], undefined);
+    assert.equal(journal.complete, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 test("a persisted mapping whose Type now normalizes to a new canonical id does not abort startup", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-entity-retarget-"));
   try {


### PR DESCRIPTION
## Summary

`migrateLegacyEntityCanonicalIds` threw during `ensureDirectories()` when a journal mapping had no files on disk, or when on-disk Type normalized to a different canonical id than the persisted target. That `Fatal:` abort crash-loops the standalone daemon on boot.

This PR parks those pairs instead of throwing, and drops parks whose canonical file is also gone so prune-revive cannot rescan forever.

Fixes #3065

## Test plan

- `tsx --test --conditions=remnic-source tests/entity-canonical-id-collision.test.ts` (21 pass)
- `npm run check:pre-push` (pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now tolerates stale or unresolvable entity mappings without terminating the daemon.
  * Stale mappings are removed when their referenced canonical files no longer exist.
  * Entity references are correctly migrated through chained canonical-identifier changes.
  * Entity content remains preserved when canonical identifiers change.
* **Tests**
  * Added regression coverage for missing files, changed identifiers, chained migrations, and stale mapping cleanup.
* **Documentation**
  * Updated the unreleased changelog with details of the migration fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->