### PR TITLE
test(plugin-pi): match the auto-recovering breaker status text

### DIFF
--- a/.changeset/plugin-pi-breaker-status-test.md
+++ b/.changeset/plugin-pi-breaker-status-test.md
@@ -1,0 +1,7 @@
+---
+"@remnic/plugin-pi": patch
+---
+
+Stability: stable
+
+Align the recall breaker status assertions with the auto-recovering wording (test-only).

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -264,7 +264,7 @@ test("default Pi extension preserves a tripped breaker across reloads", async (t
   await remnicPiExtension(second.pi);
   await second.emit("session_start", {}, secondContext);
 
-  assert.deepEqual(secondStatuses.at(-1), ["remnic", "Remnic recall disabled until restart (timeouts delayed operations)"]);
+  assert.deepEqual(secondStatuses.at(-1), ["remnic", "Remnic recall paused (timeouts delayed operations; auto-retry after cooldown)"]);
 
   fs.writeFileSync(configPath, JSON.stringify({ ...reloadConfig, authToken: "other-token" }));
   const differentCredential = makePiHarness();
@@ -2162,7 +2162,7 @@ test("session_start preserves the recall-disabled status after a successful heal
   await emit("before_agent_start", { prompt: "hi", systemPrompt: "" }, context("breaker-first"));
   await emit("session_start", {}, context("breaker-second"));
 
-  assert.deepEqual(statuses.at(-1), ["remnic", "Remnic recall disabled until restart (timeouts delayed operations)"]);
+  assert.deepEqual(statuses.at(-1), ["remnic", "Remnic recall paused (timeouts delayed operations; auto-retry after cooldown)"]);
 });
 
 test("/remnic-recall bounds retry to the general request budget instead of unbounded retries (review cursor)", async (t) => {


### PR DESCRIPTION
## Summary

`6cc4728` (fix(plugin-pi): auto-recover the recall timeout breaker after a cooldown) changed `RECALL_DISABLED_STATUS` to `Remnic recall paused (timeouts delayed operations; auto-retry after cooldown)` but left the two `index.test.ts` assertions on the old wording, so `tests (packages-1)` is red on `main` and on every PR based on it (e.g. #3074).

Test-only diff: the two expected strings now match the constant. `npm run test:file -- packages/plugin-pi/src/index.test.ts`: 63 pass, 0 fail (was 61/2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated circuit-breaker status messaging to accurately reflect automatic retry after the cooldown period.

* **Tests**
  * Aligned recall status checks with the auto-recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->