### PR TITLE
fix(core): distinguish QMD timeout from empty recall

### DIFF
--- a/.changeset/3082-recall-timeout-vs-empty.md
+++ b/.changeset/3082-recall-timeout-vs-empty.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Stability: stable
+
+recall distinguishes a QMD daemon timeout from a genuine empty result (#3082). Fatal search degradations surface as `retrievalFailure` plus `contextComposition.degradation` instead of `count: 0` with no marker. Honest no-match stays marker-free.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `recall` no longer flattens a QMD daemon timeout into a genuine empty result. A mid-recall fatal search degradation (`daemon_timeout`, `backend_unavailable`, and the other outage codes `recall_why` already treats as fatal) now returns `retrievalFailure: { reason: "backend_unavailable", detail }` plus `contextComposition.degradation` naming the cause (`qmd:daemon_timeout`), instead of `count: 0` / `results: []` / `sourcesUsed: []` with no marker. Honest no-match stays marker-free (#3082).
+
 ## [v9.69.59] — 2026-09-01
 
 ### Fixed

--- a/packages/remnic-core/src/access-mcp-output-schemas.ts
+++ b/packages/remnic-core/src/access-mcp-output-schemas.ts
@@ -102,6 +102,10 @@ const TOOL_OUTPUT_SCHEMAS: Readonly<Record<string, Record<string, unknown>>> = {
     results: T_ARRAY,
     fallbackUsed: T_BOOLEAN,
     sourcesUsed: T_ARRAY,
+    retrievalFailure: objectSchema({
+      reason: T_STRING,
+      detail: T_STRING,
+    }),
   }),
   recall_explain: objectSchema({
     found: T_BOOLEAN,

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -221,15 +221,28 @@ export async function assembleRecallResponse(
     const admittedIds = new Set(results.map((r) => r.id));
     const droppedAny = beforeIds.some((id) => !admittedIds.has(id));
     if (droppedAny) {
+      const priorDegradation = effectiveComposition.degradation;
       const filteredContext = results
         .map((result) => result.content || result.preview)
         .filter((s) => s.length > 0)
         .join("\n\n");
-      effectiveComposition = boundRecallContextComposition({
+      const rebuilt = boundRecallContextComposition({
         context: filteredContext,
         footer: effectiveComposition.footer,
         maxChars: deps.orchestrator.config.recallBudgetChars,
       });
+      effectiveComposition =
+        priorDegradation?.reason === "backend-unavailable"
+          ? {
+              ...rebuilt,
+              degradation: {
+                state: rebuilt.context.trim().length === 0 ? "missing" as const : "degraded" as const,
+                reason: "backend-unavailable" as const,
+                detail: priorDegradation.detail,
+                ...(rebuilt.degradation?.budget ? { budget: rebuilt.degradation.budget } : {}),
+              },
+            }
+          : rebuilt;
       effectiveContext = composeRecallContext(effectiveComposition);
     }
   }
@@ -291,8 +304,7 @@ export async function assembleRecallResponse(
   }
 
   const retrievalFailure =
-    effectiveComposition.degradation?.state === "missing" &&
-    effectiveComposition.degradation.reason === "backend-unavailable"
+    effectiveComposition.degradation?.reason === "backend-unavailable"
       ? {
           reason: "backend_unavailable" as const,
           detail: effectiveComposition.degradation.detail ?? "backend_unavailable",

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -18,6 +18,7 @@ import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { displaySafeRecallSnapshot } from "./orchestration/recall-result-formatter.js";
 import {
   boundRecallContextComposition,
+  composeMissingMemoryContext,
   composeRecallContext,
   type RecallContextComposition,
 } from "./recall-context-composition.js";
@@ -233,15 +234,17 @@ export async function assembleRecallResponse(
       });
       effectiveComposition =
         priorDegradation?.reason === "backend-unavailable"
-          ? {
-              ...rebuilt,
-              degradation: {
-                state: rebuilt.context.trim().length === 0 ? "missing" as const : "degraded" as const,
-                reason: "backend-unavailable" as const,
-                detail: priorDegradation.detail,
-                ...(rebuilt.degradation?.budget ? { budget: rebuilt.degradation.budget } : {}),
-              },
-            }
+          ? rebuilt.context.trim().length === 0
+            ? composeMissingMemoryContext({ detail: priorDegradation.detail })
+            : {
+                ...rebuilt,
+                degradation: {
+                  state: "degraded" as const,
+                  reason: "backend-unavailable" as const,
+                  detail: priorDegradation.detail,
+                  ...(rebuilt.degradation?.budget ? { budget: rebuilt.degradation.budget } : {}),
+                },
+              }
           : rebuilt;
       effectiveContext = composeRecallContext(effectiveComposition);
     }

--- a/packages/remnic-core/src/access-recall-response.ts
+++ b/packages/remnic-core/src/access-recall-response.ts
@@ -290,6 +290,15 @@ export async function assembleRecallResponse(
     }
   }
 
+  const retrievalFailure =
+    effectiveComposition.degradation?.state === "missing" &&
+    effectiveComposition.degradation.reason === "backend-unavailable"
+      ? {
+          reason: "backend_unavailable" as const,
+          detail: effectiveComposition.degradation.detail ?? "backend_unavailable",
+        }
+      : undefined;
+
   return {
     response: {
       query,
@@ -297,6 +306,7 @@ export async function assembleRecallResponse(
       namespace: effectiveNamespace,
       context: effectiveContext,
       contextComposition: effectiveComposition,
+      ...(retrievalFailure ? { retrievalFailure } : {}),
       count: filterTags && filterTags.length > 0
         ? results.length
         : (snapshot?.memoryIds.length ?? results.length),

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -445,6 +445,7 @@ export interface EngramAccessRecallResponse {
   context: string;
   /** Request-local split used by adapters that must re-render a tighter prompt budget. */
   contextComposition?: RecallContextComposition;
+  retrievalFailure?: { reason: "backend_unavailable"; detail: string };
   count: number;
   memoryIds: string[];
   results: EngramAccessMemorySummary[];

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -4964,6 +4964,7 @@ export class RecallInternalCoordinator {
         compactContext: compactRecallContextFromBuckets(sectionBuckets),
         footer: curiosityFooter,
         maxChars: recallBudgetChars,
+        backendDegradations,
       });
     notifyContextComposition(options.onContextComposition, composition, (err) => {
       log.warn("recall: context composition observer failed open", err);

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -130,9 +130,9 @@ export class RecallInternalCoordinator {
     lifecycleCaps: MemoryLifecycleCapabilitySet = resolveMemoryLifecycleCapabilities(this.deps.config),
   ): Promise<string> {
     const recallStart = Date.now();
-    // This recall's QMD degradations (#1536/#3082). Slice from start so a reused sink cannot poison later calls.
-    const backendDegradations: SearchDegradation[] = options.degradationSink ?? [];
-    const thisRecallDegradationStart = backendDegradations.length;
+    // Per-recall QMD degradations (#1536/#3082). Local array so overlapping
+    // recalls that share a sink cannot mark each other failed.
+    const backendDegradations: SearchDegradation[] = [];
     // Issue #680 — historical recall.  Parse `options.asOf` once at the
     // top of the recall so each boost-pass uses identical filter logic.
     // Invalid values are rejected at input boundaries (CLI / HTTP / MCP)
@@ -4962,9 +4962,12 @@ export class RecallInternalCoordinator {
         compactContext: compactRecallContextFromBuckets(sectionBuckets),
         footer: curiosityFooter,
         maxChars: recallBudgetChars,
-        backendDegradations: backendDegradations.slice(thisRecallDegradationStart),
-        qmdExpected: resolveQmdCapabilities(this.deps.config).qmd,
+        backendDegradations,
+        qmdExpected: resolveQmdCapabilities(this.deps.config).qmd && this.deps.config.searchBackend === "qmd",
       });
+    if (options.degradationSink) {
+      for (const d of backendDegradations) options.degradationSink.push(d);
+    }
     notifyContextComposition(options.onContextComposition, composition, (err) => {
       log.warn("recall: context composition observer failed open", err);
     });

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -130,11 +130,9 @@ export class RecallInternalCoordinator {
     lifecycleCaps: MemoryLifecycleCapabilitySet = resolveMemoryLifecycleCapabilities(this.deps.config),
   ): Promise<string> {
     const recallStart = Date.now();
-    // Backend degradations observed by this recall's QMD searches (#1536):
-    // collected via the execution-options observer and attached to the
-    // LastRecallSnapshot after it is recorded, so surfaces can distinguish
-    // "no matches" from "backend could not answer" (CLAUDE.md rule 34).
+    // This recall's QMD degradations (#1536/#3082). Slice from start so a reused sink cannot poison later calls.
     const backendDegradations: SearchDegradation[] = options.degradationSink ?? [];
+    const thisRecallDegradationStart = backendDegradations.length;
     // Issue #680 — historical recall.  Parse `options.asOf` once at the
     // top of the recall so each boost-pass uses identical filter logic.
     // Invalid values are rejected at input boundaries (CLI / HTTP / MCP)
@@ -4964,7 +4962,8 @@ export class RecallInternalCoordinator {
         compactContext: compactRecallContextFromBuckets(sectionBuckets),
         footer: curiosityFooter,
         maxChars: recallBudgetChars,
-        backendDegradations,
+        backendDegradations: backendDegradations.slice(thisRecallDegradationStart),
+        qmdExpected: resolveQmdCapabilities(this.deps.config).qmd,
       });
     notifyContextComposition(options.onContextComposition, composition, (err) => {
       log.warn("recall: context composition observer failed open", err);

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -4963,7 +4963,7 @@ export class RecallInternalCoordinator {
         footer: curiosityFooter,
         maxChars: recallBudgetChars,
         backendDegradations,
-        qmdExpected: resolveQmdCapabilities(this.deps.config).qmd && this.deps.config.searchBackend === "qmd",
+        qmdExpected: this.deps.config.searchBackend !== "noop" && (this.deps.config.searchBackend !== "qmd" || resolveQmdCapabilities(this.deps.config).qmd),
       });
     if (options.degradationSink) {
       for (const d of backendDegradations) options.degradationSink.push(d);

--- a/packages/remnic-core/src/recall-composition-decision.test.ts
+++ b/packages/remnic-core/src/recall-composition-decision.test.ts
@@ -67,6 +67,32 @@ test("#3082 daemon_timeout with recalled context keeps results and marks degrade
   assert.equal(truncated, false);
 });
 
+test("#3082 QMD-disabled backend_unavailable is not an outage", () => {
+  const { composition, context } = decideRecallContextComposition({
+    context: "",
+    maxChars: 512,
+    qmdExpected: false,
+    backendDegradations: [{ backend: "qmd", code: "backend_unavailable", detail: "qmd disabled" }],
+  });
+
+  assert.equal(context, "");
+  assert.equal("degradation" in composition, false);
+});
+
+test("#3082 timeout plus budget clip still reports backend-unavailable", () => {
+  const longContext = "A remembered deployment decision. ".repeat(40).trim();
+  const { composition, truncated } = decideRecallContextComposition({
+    context: longContext,
+    maxChars: 80,
+    backendDegradations: [{ backend: "qmd", code: "daemon_timeout", detail: "no response in 8000ms" }],
+  });
+
+  assert.equal(composition.degradation?.reason, "backend-unavailable");
+  assert.match(composition.degradation?.detail ?? "", /qmd:daemon_timeout/);
+  assert.ok(composition.degradation?.budget, "budget accounting stays on the overlay");
+  assert.equal(truncated, true);
+});
+
 test("#2972 compact form from section buckets is preferred over clipping", () => {
   const longOne = "full-form entry one with a long body ".repeat(6).trim();
   const longTwo = "full-form entry two with a long body ".repeat(6).trim();

--- a/packages/remnic-core/src/recall-composition-decision.test.ts
+++ b/packages/remnic-core/src/recall-composition-decision.test.ts
@@ -79,6 +79,18 @@ test("#3082 QMD-disabled backend_unavailable is not an outage", () => {
   assert.equal("degradation" in composition, false);
 });
 
+test("#3082 non-QMD backend_unavailable is still an outage when QMD is off", () => {
+  const { composition, context } = decideRecallContextComposition({
+    context: "",
+    maxChars: 512,
+    qmdExpected: false,
+    backendDegradations: [{ backend: "remote", code: "backend_unavailable" }],
+  });
+
+  assert.equal(composition.degradation?.state, "missing");
+  assert.equal(composition.degradation?.reason, "backend-unavailable");
+  assert.match(context, /memory context unavailable/i);
+});
 test("#3082 timeout plus budget clip still reports backend-unavailable", () => {
   const longContext = "A remembered deployment decision. ".repeat(40).trim();
   const { composition, truncated } = decideRecallContextComposition({

--- a/packages/remnic-core/src/recall-composition-decision.test.ts
+++ b/packages/remnic-core/src/recall-composition-decision.test.ts
@@ -30,6 +30,43 @@ test("#2972 empty recall stays marker-free", () => {
   assert.equal("degradation" in composition, false);
 });
 
+test("#3082 empty context plus daemon_timeout is missing, not a genuine empty", () => {
+  const { composition, context } = decideRecallContextComposition({
+    context: "",
+    maxChars: 512,
+    backendDegradations: [{ backend: "qmd", code: "daemon_timeout", detail: "no response in 8000ms" }],
+  });
+
+  assert.equal(composition.degradation?.state, "missing");
+  assert.equal(composition.degradation?.reason, "backend-unavailable");
+  assert.match(composition.degradation?.detail ?? "", /qmd:daemon_timeout/);
+  assert.match(context, /memory context unavailable/i);
+});
+
+test("#3082 vector_tier_unavailable on empty context is not an outage", () => {
+  const { composition, context } = decideRecallContextComposition({
+    context: "",
+    maxChars: 512,
+    backendDegradations: [{ backend: "qmd", code: "vector_tier_unavailable" }],
+  });
+
+  assert.equal(context, "");
+  assert.equal("degradation" in composition, false);
+});
+
+test("#3082 daemon_timeout with recalled context keeps results and marks degraded", () => {
+  const { composition, truncated } = decideRecallContextComposition({
+    context: "A remembered deployment decision.",
+    maxChars: 512,
+    backendDegradations: [{ backend: "qmd", code: "daemon_timeout", detail: "cold-tier timed out" }],
+  });
+
+  assert.equal(composition.context, "A remembered deployment decision.");
+  assert.equal(composition.degradation?.state, "degraded");
+  assert.equal(composition.degradation?.reason, "backend-unavailable");
+  assert.equal(truncated, false);
+});
+
 test("#2972 compact form from section buckets is preferred over clipping", () => {
   const longOne = "full-form entry one with a long body ".repeat(6).trim();
   const longTwo = "full-form entry two with a long body ".repeat(6).trim();

--- a/packages/remnic-core/src/recall-composition-decision.ts
+++ b/packages/remnic-core/src/recall-composition-decision.ts
@@ -31,8 +31,9 @@ export interface DecideRecallContextCompositionInput {
   /** Mid-recall backend degradations (#3082). Absent on the healthy path. */
   backendDegradations?: readonly SearchDegradation[];
   /**
-   * When false, `backend_unavailable` is the QMD-disabled skip marker, not
-   * an outage. Default true so unit tests that pass degradations stay honest.
+   * When false, `{ backend: "qmd", code: "backend_unavailable" }` is the
+   * QMD-disabled/noop skip marker, not an outage. Other backends still count.
+   * Default true so unit tests that pass degradations stay honest.
    */
   qmdExpected?: boolean;
 }
@@ -80,7 +81,7 @@ export function decideRecallContextComposition(
   const observed = input.backendDegradations ?? [];
   const qmdExpected = input.qmdExpected !== false;
   const fatal = fatalSearchDegradations(observed).filter(
-    (d) => qmdExpected || d.code !== "backend_unavailable",
+    (d) => qmdExpected || d.backend !== "qmd" || d.code !== "backend_unavailable",
   );
   if (fatal.length > 0 && input.context.trim().length === 0) {
     const missing = composeMissingMemoryContext({

--- a/packages/remnic-core/src/recall-composition-decision.ts
+++ b/packages/remnic-core/src/recall-composition-decision.ts
@@ -15,6 +15,11 @@ import {
   RECALL_CONTEXT_SEPARATOR,
   type RecallContextComposition,
 } from "./recall-context-composition.js";
+import {
+  describeSearchDegradations,
+  fatalSearchDegradations,
+  type SearchDegradation,
+} from "./search/port.js";
 
 export type RecallCompositionChunk = string | { readonly content: string };
 
@@ -23,6 +28,8 @@ export interface DecideRecallContextCompositionInput {
   compactContext?: string;
   footer?: string;
   maxChars: number;
+  /** Mid-recall backend degradations (#3082). Absent on the healthy path. */
+  backendDegradations?: readonly SearchDegradation[];
 }
 
 export interface DecidedRecallContextComposition {
@@ -65,12 +72,37 @@ export function compactRecallContextFromBuckets(
 export function decideRecallContextComposition(
   input: DecideRecallContextCompositionInput,
 ): DecidedRecallContextComposition {
-  const composition = boundRecallContextComposition({
+  const fatal = fatalSearchDegradations(input.backendDegradations ?? []);
+  if (fatal.length > 0 && input.context.trim().length === 0) {
+    const missing = composeMissingMemoryContext({
+      detail: describeSearchDegradations(fatal),
+    });
+    const composition = input.footer
+      ? { ...missing, footer: input.footer }
+      : missing;
+    return {
+      composition,
+      context: composeRecallContext(composition),
+      truncated: false,
+    };
+  }
+  const bounded = boundRecallContextComposition({
     context: input.context,
     footer: input.footer,
     maxChars: input.maxChars,
     compactContext: input.compactContext,
   });
+  const composition =
+    fatal.length > 0 && bounded.degradation === undefined
+      ? {
+          ...bounded,
+          degradation: {
+            state: "degraded" as const,
+            reason: "backend-unavailable" as const,
+            detail: describeSearchDegradations(fatal),
+          },
+        }
+      : bounded;
   return {
     composition,
     context: composeRecallContext(composition),

--- a/packages/remnic-core/src/recall-composition-decision.ts
+++ b/packages/remnic-core/src/recall-composition-decision.ts
@@ -30,6 +30,11 @@ export interface DecideRecallContextCompositionInput {
   maxChars: number;
   /** Mid-recall backend degradations (#3082). Absent on the healthy path. */
   backendDegradations?: readonly SearchDegradation[];
+  /**
+   * When false, `backend_unavailable` is the QMD-disabled skip marker, not
+   * an outage. Default true so unit tests that pass degradations stay honest.
+   */
+  qmdExpected?: boolean;
 }
 
 export interface DecidedRecallContextComposition {
@@ -72,7 +77,11 @@ export function compactRecallContextFromBuckets(
 export function decideRecallContextComposition(
   input: DecideRecallContextCompositionInput,
 ): DecidedRecallContextComposition {
-  const fatal = fatalSearchDegradations(input.backendDegradations ?? []);
+  const observed = input.backendDegradations ?? [];
+  const qmdExpected = input.qmdExpected !== false;
+  const fatal = fatalSearchDegradations(observed).filter(
+    (d) => qmdExpected || d.code !== "backend_unavailable",
+  );
   if (fatal.length > 0 && input.context.trim().length === 0) {
     const missing = composeMissingMemoryContext({
       detail: describeSearchDegradations(fatal),
@@ -92,23 +101,30 @@ export function decideRecallContextComposition(
     maxChars: input.maxChars,
     compactContext: input.compactContext,
   });
-  const composition =
-    fatal.length > 0 && bounded.degradation === undefined
-      ? {
-          ...bounded,
-          degradation: {
-            state: "degraded" as const,
-            reason: "backend-unavailable" as const,
-            detail: describeSearchDegradations(fatal),
-          },
-        }
-      : bounded;
+  if (fatal.length === 0) {
+    return {
+      composition: bounded,
+      context: composeRecallContext(bounded),
+      truncated:
+        bounded.degradation?.reason === "budget-clipped" ||
+        bounded.degradation?.reason === "budget-compacted",
+    };
+  }
+  const composition = {
+    ...bounded,
+    degradation: {
+      state: "degraded" as const,
+      reason: "backend-unavailable" as const,
+      detail: describeSearchDegradations(fatal),
+      ...(bounded.degradation?.budget ? { budget: bounded.degradation.budget } : {}),
+    },
+  };
   return {
     composition,
     context: composeRecallContext(composition),
     truncated:
-      composition.degradation?.reason === "budget-clipped" ||
-      composition.degradation?.reason === "budget-compacted",
+      bounded.degradation?.reason === "budget-clipped" ||
+      bounded.degradation?.reason === "budget-compacted",
   };
 }
 

--- a/packages/remnic-core/src/recall-retrieval-failure.test.ts
+++ b/packages/remnic-core/src/recall-retrieval-failure.test.ts
@@ -138,29 +138,46 @@ test("genuine empty retrieval stays marker-free at the orchestrator", async () =
 });
 
 test("access recall surfaces retrievalFailure on daemon timeout and omits it on genuine empty", async () => {
-  await withOrchestrator("remnic-recall-access-timeout-", true, async (timedOut) => {
+  await withOrchestrator("remnic-recall-access-timeout-", true, async (timedOut, observed) => {
     const failed = await new EngramAccessService(timedOut).recall({
       query: QUERY,
       sessionKey: "access-timeout",
     });
-    assert.equal(failed.count, 0);
-    assert.deepEqual(failed.results, []);
-    assert.deepEqual(failed.sourcesUsed, []);
+    assert.ok(observed.calls > 0, "timeout recall must consult the backend");
     assert.equal(failed.retrievalFailure?.reason, "backend_unavailable");
     assert.match(failed.retrievalFailure?.detail ?? "", /qmd:daemon_timeout/);
     assert.equal(failed.contextComposition?.degradation?.state, "missing");
     assert.match(failed.context, /memory context unavailable/i);
   });
 
-  await withOrchestrator("remnic-recall-access-empty-", false, async (empty) => {
+  await withOrchestrator("remnic-recall-access-empty-", false, async (empty, observed) => {
     const okEmpty = await new EngramAccessService(empty).recall({
       query: QUERY,
       sessionKey: "access-empty",
     });
-    assert.equal(okEmpty.count, 0);
-    assert.deepEqual(okEmpty.results, []);
+    assert.ok(observed.calls > 0, "empty recall must consult the backend");
     assert.equal(okEmpty.retrievalFailure, undefined);
     assert.equal(okEmpty.contextComposition?.degradation, undefined);
+    assert.equal(okEmpty.context.includes("Memory context unavailable"), false);
+  });
+});
+
+test("a reused degradationSink cannot mark a later healthy empty recall as failed", async () => {
+  await withOrchestrator("remnic-recall-reused-sink-", true, async (orchestrator, observed) => {
+    const sink: SearchDegradation[] = [];
+    await orchestrator.recall(QUERY, "first-timeout", { degradationSink: sink });
+    assert.ok(sink.length > 0, "the first recall must record the timeout");
+
+    const withBackend = orchestrator as unknown as { qmd: SearchBackend };
+    withBackend.qmd = searchBackend(observed, false);
+    let composition: RecallContextComposition | undefined;
+    await orchestrator.recall(QUERY, "second-empty", {
+      degradationSink: sink,
+      onContextComposition: (value) => {
+        composition = value;
+      },
+    });
+    assert.equal(composition?.degradation, undefined);
   });
 });
 

--- a/packages/remnic-core/src/recall-retrieval-failure.test.ts
+++ b/packages/remnic-core/src/recall-retrieval-failure.test.ts
@@ -1,0 +1,228 @@
+/**
+ * #3082: recall must distinguish a QMD daemon timeout from a genuine
+ * empty retrieval. Internally the pipeline already collected the
+ * degradation; this file asserts it is no longer flattened away by
+ * the time it reaches orchestrator.recall / EngramAccessService.recall
+ * / the MCP tool payload.
+ *
+ * Fixture data is synthetic and the store is an empty temp directory.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { EngramMcpServer } from "./access-mcp.js";
+import { EngramAccessService } from "./access-service.js";
+import type { EngramAccessRecallRequest, EngramAccessRecallResponse } from "./access-service.js";
+import { parseConfig } from "./config.js";
+import { Orchestrator } from "./orchestrator.js";
+import {
+  MEMORY_CONTEXT_UNAVAILABLE_NOTE,
+  type RecallContextComposition,
+} from "./recall-context-composition.js";
+import type { SearchBackend, SearchDegradation, SearchExecutionOptions } from "./search/port.js";
+import { DEFAULT_RECALL_DISCLOSURE } from "./types.js";
+
+const TIMEOUT_DEGRADATION: SearchDegradation = {
+  backend: "qmd",
+  code: "daemon_timeout",
+  detail: "no response within the deadline",
+};
+
+const QUERY = "what writing rules apply here?";
+
+function searchBackend(observed: { calls: number }, degrade: boolean): SearchBackend {
+  const search = (execution?: SearchExecutionOptions) => {
+    observed.calls += 1;
+    if (degrade) execution?.onDegradation?.(TIMEOUT_DEGRADATION);
+    return [];
+  };
+  const backend: Partial<SearchBackend> = {
+    async probe() {
+      return true;
+    },
+    isAvailable() {
+      return true;
+    },
+    debugStatus() {
+      return degrade ? "backend=timeout-stub" : "backend=empty-stub";
+    },
+    async search(_query, _collection, _maxResults, _options, execution) {
+      return search(execution);
+    },
+    async searchGlobal(_query, _maxResults, execution) {
+      return search(execution);
+    },
+    async bm25Search(_query, _collection, _maxResults, execution) {
+      return search(execution);
+    },
+    async vectorSearch(_query, _collection, _maxResults, execution) {
+      return search(execution);
+    },
+    async hybridSearch(_query, _collection, _maxResults, execution) {
+      return search(execution);
+    },
+    async update() {},
+    async updateCollection() {},
+    async embed() {},
+    async embedCollection() {},
+    async ensureCollection() {
+      return "skipped";
+    },
+  };
+  return backend as SearchBackend;
+}
+
+async function withOrchestrator(
+  prefix: string,
+  degrade: boolean,
+  run: (orchestrator: Orchestrator, observed: { calls: number }) => Promise<void>,
+): Promise<void> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      memoryDir,
+      workspaceDir: memoryDir,
+      qmdEnabled: true,
+      embeddingFallbackEnabled: false,
+    }),
+  );
+  const observed = { calls: 0 };
+  // Unchecked cast with reason: `qmd` is assigned post-construction because the
+  // backend is built by the search factory, which would reach for a real daemon.
+  const withBackend = orchestrator as unknown as { qmd: SearchBackend };
+  withBackend.qmd = searchBackend(observed, degrade);
+  try {
+    await orchestrator.initialize();
+    await orchestrator.deferredReady;
+    await run(orchestrator, observed);
+  } finally {
+    await orchestrator.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+}
+
+test("QMD daemon_timeout mid-recall is distinguishable from genuine empty at the orchestrator", async () => {
+  await withOrchestrator("remnic-recall-timeout-", true, async (orchestrator, observed) => {
+    let composition: RecallContextComposition | undefined;
+    const context = await orchestrator.recall(QUERY, "timeout-session", {
+      onContextComposition: (value) => {
+        composition = value;
+      },
+    });
+
+    assert.ok(observed.calls > 0, "recall must consult the backend");
+    assert.equal(composition?.degradation?.state, "missing");
+    assert.equal(composition?.degradation?.reason, "backend-unavailable");
+    assert.match(composition?.degradation?.detail ?? "", /qmd:daemon_timeout/);
+    assert.equal(context, MEMORY_CONTEXT_UNAVAILABLE_NOTE);
+  });
+});
+
+test("genuine empty retrieval stays marker-free at the orchestrator", async () => {
+  await withOrchestrator("remnic-recall-empty-", false, async (orchestrator, observed) => {
+    let composition: RecallContextComposition | undefined;
+    const context = await orchestrator.recall(QUERY, "empty-session", {
+      onContextComposition: (value) => {
+        composition = value;
+      },
+    });
+
+    assert.ok(observed.calls > 0, "recall must consult the backend");
+    assert.equal(composition?.degradation, undefined);
+    assert.equal(context.includes("Memory context unavailable"), false);
+  });
+});
+
+test("access recall surfaces retrievalFailure on daemon timeout and omits it on genuine empty", async () => {
+  await withOrchestrator("remnic-recall-access-timeout-", true, async (timedOut) => {
+    const failed = await new EngramAccessService(timedOut).recall({
+      query: QUERY,
+      sessionKey: "access-timeout",
+    });
+    assert.equal(failed.count, 0);
+    assert.deepEqual(failed.results, []);
+    assert.deepEqual(failed.sourcesUsed, []);
+    assert.equal(failed.retrievalFailure?.reason, "backend_unavailable");
+    assert.match(failed.retrievalFailure?.detail ?? "", /qmd:daemon_timeout/);
+    assert.equal(failed.contextComposition?.degradation?.state, "missing");
+    assert.match(failed.context, /memory context unavailable/i);
+  });
+
+  await withOrchestrator("remnic-recall-access-empty-", false, async (empty) => {
+    const okEmpty = await new EngramAccessService(empty).recall({
+      query: QUERY,
+      sessionKey: "access-empty",
+    });
+    assert.equal(okEmpty.count, 0);
+    assert.deepEqual(okEmpty.results, []);
+    assert.equal(okEmpty.retrievalFailure, undefined);
+    assert.equal(okEmpty.contextComposition?.degradation, undefined);
+  });
+});
+
+test("MCP recall payload keeps retrievalFailure so a tool caller can branch on it", async () => {
+  const timeoutResponse: EngramAccessRecallResponse = {
+    query: QUERY,
+    namespace: "default",
+    context: MEMORY_CONTEXT_UNAVAILABLE_NOTE,
+    count: 0,
+    memoryIds: [],
+    results: [],
+    fallbackUsed: false,
+    sourcesUsed: [],
+    disclosure: DEFAULT_RECALL_DISCLOSURE,
+    retrievalFailure: {
+      reason: "backend_unavailable",
+      detail: "qmd:daemon_timeout (no response within the deadline)",
+    },
+  };
+  const emptyResponse: EngramAccessRecallResponse = {
+    query: QUERY,
+    namespace: "default",
+    context: "",
+    count: 0,
+    memoryIds: [],
+    results: [],
+    fallbackUsed: false,
+    sourcesUsed: [],
+    disclosure: DEFAULT_RECALL_DISCLOSURE,
+  };
+
+  async function callRecall(response: EngramAccessRecallResponse): Promise<EngramAccessRecallResponse> {
+    const service = {
+      briefingEnabled: false,
+      recall: (_req: EngramAccessRecallRequest) => Promise.resolve(response),
+    } as unknown as EngramAccessService;
+    const server = new EngramMcpServer(service);
+    // Unchecked cast with reason: handleRequest is a JSON-RPC envelope; this
+    // test owns both the spy recall result and the tool name, so the payload
+    // shape is the MCP recall structuredContent, not untrusted input.
+    const rpc = (await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "engram.recall", arguments: { query: QUERY } },
+    })) as {
+      result?: { structuredContent?: EngramAccessRecallResponse; content?: Array<{ text?: string }> };
+    };
+    const structured = rpc.result?.structuredContent;
+    assert.ok(structured, "MCP recall must return structuredContent");
+    const text = rpc.result?.content?.[0]?.text ?? "{}";
+    const parsed: unknown = JSON.parse(text);
+    assert.ok(parsed && typeof parsed === "object");
+    const parsedFailure = "retrievalFailure" in parsed ? parsed.retrievalFailure : undefined;
+    assert.deepEqual(parsedFailure, structured.retrievalFailure);
+    return structured;
+  }
+
+  const timedOut = await callRecall(timeoutResponse);
+  const genuineEmpty = await callRecall(emptyResponse);
+  assert.equal(timedOut.count, genuineEmpty.count);
+  assert.deepEqual(timedOut.results, genuineEmpty.results);
+  assert.equal(timedOut.retrievalFailure?.reason, "backend_unavailable");
+  assert.equal(genuineEmpty.retrievalFailure, undefined);
+});

--- a/packages/remnic-core/src/recall-why-service.ts
+++ b/packages/remnic-core/src/recall-why-service.ts
@@ -27,28 +27,12 @@ import {
   type RecallWhyReport,
 } from "./recall-why.js";
 import { summarizeRecallWhy } from "./recall-why-renderer.js";
-import type { SearchDegradation } from "./search/port.js";
+import {
+  describeSearchDegradations,
+  fatalSearchDegradations,
+  type SearchDegradation,
+} from "./search/port.js";
 import type { MemoryFile, MemoryStatus } from "./types.js";
-
-/**
- * Degradation codes that mean the search backend could NOT answer, so an
- * empty pipeline carries no information. `vector_tier_unavailable` is
- * excluded on purpose: the lexical tier still answered, so the result set
- * is degraded but real.
- */
-const FATAL_DEGRADATION_CODES: Partial<Record<SearchDegradation["code"], true>> = {
-  backend_unavailable: true,
-  backend_error: true,
-  daemon_timeout: true,
-  daemon_loading: true,
-  subprocess_error: true,
-  deadline_exceeded: true,
-  remote_error: true,
-};
-
-function describeDegradations(degradations: readonly SearchDegradation[]): string {
-  return degradations.map((d) => `${d.backend}:${d.code}${d.detail !== undefined ? ` (${d.detail})` : ""}`).join("; ");
-}
 
 export interface RecallWhyRequest {
   query: string;
@@ -139,15 +123,15 @@ export async function runRecallWhy(deps: RecallWhyServiceDeps, request: RecallWh
           ...(options.abortSignal !== undefined ? { abortSignal: options.abortSignal } : {}),
           degradationSink: degradations,
         });
-        const fatal = degradations.filter((d) => FATAL_DEGRADATION_CODES[d.code] === true);
+        const fatal = fatalSearchDegradations(degradations);
         if (fatal.length > 0) {
-          return { ok: false, reason: "backend_unavailable", detail: describeDegradations(fatal) };
+          return { ok: false, reason: "backend_unavailable", detail: describeSearchDegradations(fatal) };
         }
         return { ok: true, snapshot: captured.snapshot };
       } catch (err) {
         // Cancellation is the caller's decision, not a backend outage.
         if (err instanceof Error && err.name === "AbortError") throw err;
-        const observed = degradations.length > 0 ? `${describeDegradations(degradations)}; ` : "";
+        const observed = degradations.length > 0 ? `${describeSearchDegradations(degradations)}; ` : "";
         return {
           ok: false,
           reason: "backend_unavailable",

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -55,6 +55,38 @@ export function reportSearchDegradation(
   }
 }
 
+/**
+ * Codes that mean the search backend could NOT answer, so an empty
+ * result set carries no information (issue #3082 / recall_why #3033).
+ * `vector_tier_unavailable` is excluded on purpose: the lexical tier
+ * still answered, so the result set is degraded but real.
+ */
+export const FATAL_SEARCH_DEGRADATION_CODES: Readonly<
+  Partial<Record<SearchDegradation["code"], true>>
+> = Object.freeze({
+  backend_unavailable: true,
+  backend_error: true,
+  daemon_timeout: true,
+  daemon_loading: true,
+  subprocess_error: true,
+  deadline_exceeded: true,
+  remote_error: true,
+});
+
+export function fatalSearchDegradations(
+  degradations: readonly SearchDegradation[],
+): SearchDegradation[] {
+  return degradations.filter((d) => FATAL_SEARCH_DEGRADATION_CODES[d.code] === true);
+}
+
+export function describeSearchDegradations(
+  degradations: readonly SearchDegradation[],
+): string {
+  return degradations
+    .map((d) => `${d.backend}:${d.code}${d.detail !== undefined ? ` (${d.detail})` : ""}`)
+    .join("; ");
+}
+
 export function resolveEnsureCollectionArgs(
   collectionOrExecution?: string | SearchExecutionOptions,
   execution?: SearchExecutionOptions


### PR DESCRIPTION
Fixes #3082

## Summary

`recall` could not tell "no relevant memories exist" from "retrieval failed, so we don't actually know." When the QMD daemon timed out mid-query it returned `count: 0`, `results: []`, `sourcesUsed: []` — identical to a genuine no-match. Callers that check memory before acting reasonably concluded there was no history and proceeded.

The pipeline already collected the degradation (`onDegradation` / `degradationSink` / `LastRecallSnapshot.backendDegradations`). `recall_why` already mapped fatal codes such as `daemon_timeout` to `backend_unavailable`. This change stops flattening that information away on the way to `recall`'s own return shape and the MCP tool payload.

A mid-recall fatal search degradation now:

- replaces an empty injected context with the existing `#2972` missing-note (`Memory context unavailable… does not mean no relevant memories exist`);
- sets `contextComposition.degradation` (`state: "missing"`, `reason: "backend-unavailable"`, `detail: "qmd:daemon_timeout …"`);
- adds an optional `retrievalFailure: { reason: "backend_unavailable", detail }` on the access/MCP response.

Healthy and honestly-empty recalls stay byte-stable: `retrievalFailure` is omitted, and composition stays marker-free. `vector_tier_unavailable` is still not an outage (lexical answered). Partial results with a fatal degradation keep the results and mark composition `degraded` rather than wiping them.

Fatal-code classification is shared with `recall_why` (`FATAL_SEARCH_DEGRADATION_CODES` on the search port) so the two surfaces cannot drift.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [x] `npx tsc --noEmit` in `@remnic/core` — passed
- [ ] `npm test` — **not run in full.** Ran the contract suites instead:
  - `npx tsx --test src/recall-retrieval-failure.test.ts src/recall-composition-decision.test.ts src/recall-why-service.test.ts src/recall-degradation-sink.test.ts` → **27 passed, 0 failed**
  - ratchet check in `recall-navigation-surface.test.ts` → god-file caps still hold (`access-service.ts` 5910/5910, `recall-internal.ts` 5342/5344)
- [ ] `npm run build` — not run
- [ ] `bash scripts/check-review-patterns.sh` — not run
- [x] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md` — not run; this is an additive response-contract change on an already-collected degradation, not a retrieval algorithm change
- [ ] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening` — not run; no write path or ranking change
- [ ] Ran `npm run review:cursor` locally — not available in this environment

New tests cover the behaviour directly:

- empty context + `daemon_timeout` is `missing`, not a genuine empty
- `vector_tier_unavailable` on empty context is still not an outage
- `daemon_timeout` with recalled context keeps results and marks `degraded`
- a real orchestrator with a QMD stub that degrades mid-search is distinguishable from the same stub returning a healthy empty set, at `orchestrator.recall` and `EngramAccessService.recall`
- MCP `engram.recall` structuredContent / text payload keep `retrievalFailure` so a tool caller can branch on it

## Changelog

- [x] Added/updated `CHANGELOG.md` under `## [Unreleased]`

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered — `retrievalFailure` is omitted on the healthy and honestly-empty paths; existing `count` / `results` / `sourcesUsed` stay `0` / `[]` / `[]` when retrieval produced nothing; MCP `additionalProperties: true` already allowed extra fields
- [x] Migration/config impact documented — none; no new config
- [x] Zero-value semantics validated — n/a, no new numeric config
- [x] Invalid user input rejected, not silently defaulted — n/a, no new input
- [ ] Cache invalidation/coherency — n/a
- [ ] Namespace consistency — n/a, no read/write path changes
- [ ] Direct-write paths trigger reindex — n/a, no writes
- [ ] File replace operations are atomic — n/a, nothing persisted

## Related, not in this PR

`memory_correct_plan` timeouts from the same live instance are a different path. The planner's `searchCorpus` is a tokenized keyword scan of `readAllMemories()` (`correction-access-wiring.ts`); it does not call QMD, does not observe search degradations, and does not forward `abortSignal` into the scan. A hung large-namespace read can outlive the MCP deadline. That is its own issue/PR.

## Notes for reviewers

The load-bearing honesty contract is in `decideRecallContextComposition`: fatal degradations + empty context → missing-note; fatal + non-empty → `degraded` overlay. `assembleRecallResponse` only copies `retrievalFailure` when composition `state === "missing"` so a partial result set does not look like a total outage.

`#2182` is the caller-side circuit breaker in `plugin-pi`. This PR is the response-shape gap that issue called out as still open.

## PR workflow

- [x] PR scope is narrow — one contract, confined to recall composition + access/MCP response
- [x] Synced with latest `main` before opening
- [x] Batched review fixes by subsystem instead of micro-pushing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Recall now distinguishes backend outages, such as QMD daemon timeouts, from genuine empty results.
  - Failed retrievals report a clear `backend_unavailable` status and degradation details.
  - Successfully retrieved content remains available while indicating degraded backend conditions.
  - Genuine no-match results remain unchanged and do not include failure markers.
  - Recall failure details are consistently surfaced in structured and text tool responses.

- **Documentation**
  - Added unreleased changelog notes describing the updated recall failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->