### PR TITLE
ci(release): one-time npm bootstrap dispatch for never-published packages

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -10,6 +10,10 @@ on:
         description: 'Exact version to publish (e.g. 9.0.0). Skips auto-bump when set.'
         required: false
         type: string
+      bootstrap_tag:
+        description: 'One-time npm bootstrap: publish never-published @remnic packages from an existing vX.Y.Z release tag. Skips all normal release jobs; hardcoded allowlist only.'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -22,7 +26,7 @@ concurrency:
 
 jobs:
   release-tests:
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && inputs.bootstrap_tag == ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -71,7 +75,7 @@ jobs:
 
   release:
     needs: release-tests
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && inputs.bootstrap_tag == ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -756,3 +760,134 @@ jobs:
           fi
 
           clawhub package rescan "${CLAWHUB_PACKAGE_NAME}" --yes --json || true
+
+  bootstrap-publish:
+    # One-time npm bootstrap for package names that do not exist on the
+    # registry yet: npm's publish API answers E404 when an automation
+    # identity may not CREATE a name, so trusted publishing (OIDC) can never
+    # mint a first version. This job publishes ONLY the hardcoded allowlist
+    # mirrored in scripts/npm-bootstrap-check.mjs, built from an existing
+    # immutable release tag, using the temporary NPM_BOOTSTRAP_TOKEN secret.
+    # It never bumps versions, commits, pushes, or moves dist-tags, and it
+    # cannot run for push events; normal release behavior is unchanged.
+    if: github.actor != 'github-actions[bot]' && github.event_name == 'workflow_dispatch' && inputs.bootstrap_tag != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Validate bootstrap tag
+        id: bootstrap_tag
+        env:
+          BOOTSTRAP_TAG: ${{ inputs.bootstrap_tag }}
+          VERSION_OVERRIDE: ${{ inputs.version_override }}
+        run: |
+          if [ -n "${VERSION_OVERRIDE}" ]; then
+            echo "::error title=Conflicting inputs::version_override and bootstrap_tag are mutually exclusive."
+            exit 1
+          fi
+          if ! [[ "${BOOTSTRAP_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid bootstrap tag::${BOOTSTRAP_TAG} must match vX.Y.Z exactly."
+            exit 1
+          fi
+          echo "tag=${BOOTSTRAP_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout workflow source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Stage bootstrap classifier outside the published tree
+        run: cp scripts/npm-bootstrap-check.mjs "${RUNNER_TEMP}/npm-bootstrap-check.mjs"
+
+      - name: Checkout bootstrap tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.bootstrap_tag.outputs.tag }}
+          path: release-src
+
+      - name: Verify tagged source
+        env:
+          TAG: ${{ steps.bootstrap_tag.outputs.tag }}
+        run: |
+          ACTUAL_TAG="$(git -C release-src describe --exact-match --tags HEAD)"
+          if [ "${ACTUAL_TAG}" != "${TAG}" ]; then
+            echo "::error title=Tag mismatch::release-src is at ${ACTUAL_TAG}, expected ${TAG}."
+            exit 1
+          fi
+          ROOT_VERSION="$(node -p "require('./release-src/package.json').version")"
+          if [ "v${ROOT_VERSION}" != "${TAG}" ]; then
+            echo "::error title=Version mismatch::tagged root package.json is ${ROOT_VERSION}, tag is ${TAG#v}."
+            exit 1
+          fi
+          echo "::notice::Bootstrap source verified: ${TAG} at $(git -C release-src rev-parse HEAD)."
+
+      - name: Classify bootstrap targets against npm
+        # Fail fast on drift or unclassifiable registry state before spending
+        # minutes on install/build; the publish step re-classifies each
+        # target immediately before publishing.
+        run: node "${RUNNER_TEMP}/npm-bootstrap-check.mjs" --root release-src
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+          cache-dependency-path: release-src/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: release-src
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild native modules
+        working-directory: release-src
+        run: pnpm rebuild better-sqlite3
+
+      - name: Build all packages
+        working-directory: release-src
+        run: |
+          node scripts/ensure-core-build.mjs
+          pnpm -r --filter '!@remnic/core' --filter '!remnic-workspace' run build
+          pnpm run build
+
+      - name: Bootstrap absent packages to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::error title=Missing secret::NPM_BOOTSTRAP_TOKEN is not configured; bootstrap cannot publish."
+            exit 1
+          fi
+          publish_log="$(mktemp)"
+          trap 'rm -f "$publish_log"' EXIT
+          for target in @remnic/connector-reitti @remnic/connector-x @remnic/import-okf; do
+            set +e
+            node "${RUNNER_TEMP}/npm-bootstrap-check.mjs" --root release-src --package "${target}"
+            status=$?
+            set -e
+            case "${status}" in
+              0)
+                echo "Publishing bootstrap target ${target} from release-src..."
+                if (cd "release-src/packages/${target#@remnic/}" && pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts) >"$publish_log" 2>&1; then
+                  cat "$publish_log"
+                  echo "::notice::Published ${target} (first version; alpha dist-tag)."
+                else
+                  publish_status=$?
+                  cat "$publish_log"
+                  echo "::error title=Bootstrap publish failed::${target} — inspect the log above."
+                  exit "${publish_status}"
+                fi
+                ;;
+              3)
+                echo "::notice::Skipping ${target}: exact version already published (idempotent retry)."
+                ;;
+              *)
+                echo "::error title=Bootstrap target refused::${target} could not be classified for a first publish (exit ${status})."
+                exit "${status}"
+                ;;
+            esac
+          done
+          echo "::notice::Bootstrap dispatch complete: absent names published to the alpha dist-tag; already-published exact versions skipped."

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -770,7 +770,7 @@ jobs:
     # immutable release tag, using the temporary NPM_BOOTSTRAP_TOKEN secret.
     # It never bumps versions, commits, pushes, or moves dist-tags, and it
     # cannot run for push events; normal release behavior is unchanged.
-    if: github.actor != 'github-actions[bot]' && github.event_name == 'workflow_dispatch' && inputs.bootstrap_tag != ''
+    if: github.actor != 'github-actions[bot]' && github.event_name == 'workflow_dispatch' && inputs.bootstrap_tag != '' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -788,12 +788,23 @@ jobs:
             echo "::error title=Invalid bootstrap tag::${BOOTSTRAP_TAG} must match vX.Y.Z exactly."
             exit 1
           fi
+          # One-time bootstrap: only an approved tag→commit pair may publish.
+          # Anything else is rejected; this is not a generic release path.
+          case "${BOOTSTRAP_TAG}" in
+            v9.69.64) EXPECTED_SHA="70e8607d63f86d4a2410610e97753575aecf075b" ;;
+            *)
+              echo "::error title=Untrusted bootstrap tag::${BOOTSTRAP_TAG} is not an approved bootstrap source."
+              exit 1
+              ;;
+          esac
           echo "tag=${BOOTSTRAP_TAG}" >> "$GITHUB_OUTPUT"
+          echo "expected_sha=${EXPECTED_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout workflow source
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Stage bootstrap classifier outside the published tree
         run: cp scripts/npm-bootstrap-check.mjs "${RUNNER_TEMP}/npm-bootstrap-check.mjs"
@@ -804,10 +815,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.bootstrap_tag.outputs.tag }}
           path: release-src
+          persist-credentials: false
 
       - name: Verify tagged source
         env:
           TAG: ${{ steps.bootstrap_tag.outputs.tag }}
+          EXPECTED_SHA: ${{ steps.bootstrap_tag.outputs.expected_sha }}
         run: |
           ACTUAL_TAG="$(git -C release-src describe --exact-match --tags HEAD)"
           if [ "${ACTUAL_TAG}" != "${TAG}" ]; then
@@ -819,7 +832,12 @@ jobs:
             echo "::error title=Version mismatch::tagged root package.json is ${ROOT_VERSION}, tag is ${TAG#v}."
             exit 1
           fi
-          echo "::notice::Bootstrap source verified: ${TAG} at $(git -C release-src rev-parse HEAD)."
+          ACTUAL_SHA="$(git -C release-src rev-parse HEAD)"
+          if [ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]; then
+            echo "::error title=Untrusted tag target::${TAG} resolves to ${ACTUAL_SHA}, approved source is ${EXPECTED_SHA}."
+            exit 1
+          fi
+          echo "::notice::Bootstrap source verified: ${TAG} at ${ACTUAL_SHA}."
 
       - name: Classify bootstrap targets against npm
         # Fail fast on drift or unclassifiable registry state before spending
@@ -864,30 +882,27 @@ jobs:
           publish_log="$(mktemp)"
           trap 'rm -f "$publish_log"' EXIT
           for target in @remnic/connector-reitti @remnic/connector-x @remnic/import-okf; do
-            set +e
-            node "${RUNNER_TEMP}/npm-bootstrap-check.mjs" --root release-src --package "${target}"
-            status=$?
-            set -e
-            case "${status}" in
-              0)
-                echo "Publishing bootstrap target ${target} from release-src..."
-                if (cd "release-src/packages/${target#@remnic/}" && pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts) >"$publish_log" 2>&1; then
-                  cat "$publish_log"
-                  echo "::notice::Published ${target} (first version; alpha dist-tag)."
-                else
-                  publish_status=$?
-                  cat "$publish_log"
-                  echo "::error title=Bootstrap publish failed::${target} — inspect the log above."
-                  exit "${publish_status}"
-                fi
-                ;;
-              3)
-                echo "::notice::Skipping ${target}: exact version already published (idempotent retry)."
-                ;;
-              *)
-                echo "::error title=Bootstrap target refused::${target} could not be classified for a first publish (exit ${status})."
-                exit "${status}"
-                ;;
-            esac
+            target_dir="release-src/packages/${target#@remnic/}"
+            target_version="$(node -p "require('./${target_dir}/package.json').version")"
+            # Retry-safe re-checks run with the token stripped from the env;
+            # only the pinned pnpm publish below ever holds it.
+            if env -u NODE_AUTH_TOKEN npm view "${target}@${target_version}" version >/dev/null 2>&1; then
+              echo "::notice::Skipping ${target}@${target_version}: exact version already published (idempotent retry)."
+              continue
+            fi
+            if env -u NODE_AUTH_TOKEN npm view "${target}" version >/dev/null 2>&1; then
+              echo "::error title=Bootstrap target refused::${target} exists at a different version; first-publish scope exceeded."
+              exit 1
+            fi
+            echo "Publishing bootstrap target ${target}@${target_version}..."
+            if (cd "${target_dir}" && pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts --registry=https://registry.npmjs.org) >"$publish_log" 2>&1; then
+              cat "$publish_log"
+              echo "::notice::Published ${target}@${target_version} (first version; alpha dist-tag)."
+            else
+              publish_status=$?
+              cat "$publish_log"
+              echo "::error title=Bootstrap publish failed::${target} — inspect the log above."
+              exit "${publish_status}"
+            fi
           done
           echo "::notice::Bootstrap dispatch complete: absent names published to the alpha dist-tag; already-published exact versions skipped."

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -882,27 +882,34 @@ jobs:
           publish_log="$(mktemp)"
           trap 'rm -f "$publish_log"' EXIT
           for target in @remnic/connector-reitti @remnic/connector-x @remnic/import-okf; do
-            target_dir="release-src/packages/${target#@remnic/}"
-            target_version="$(node -p "require('./${target_dir}/package.json').version")"
-            # Retry-safe re-checks run with the token stripped from the env;
-            # only the pinned pnpm publish below ever holds it.
-            if env -u NODE_AUTH_TOKEN npm view "${target}@${target_version}" version >/dev/null 2>&1; then
-              echo "::notice::Skipping ${target}@${target_version}: exact version already published (idempotent retry)."
-              continue
-            fi
-            if env -u NODE_AUTH_TOKEN npm view "${target}" version >/dev/null 2>&1; then
-              echo "::error title=Bootstrap target refused::${target} exists at a different version; first-publish scope exceeded."
-              exit 1
-            fi
-            echo "Publishing bootstrap target ${target}@${target_version}..."
-            if (cd "${target_dir}" && pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts --registry=https://registry.npmjs.org) >"$publish_log" 2>&1; then
-              cat "$publish_log"
-              echo "::notice::Published ${target}@${target_version} (first version; alpha dist-tag)."
-            else
-              publish_status=$?
-              cat "$publish_log"
-              echo "::error title=Bootstrap publish failed::${target} — inspect the log above."
-              exit "${publish_status}"
-            fi
+            # Fail-closed re-check immediately before publishing: only an
+            # explicit "name absent" (exit 0) or "exact version present"
+            # (exit 3) may proceed; every other registry outcome aborts.
+            # Runs with the token stripped from the env.
+            set +e
+            env -u NODE_AUTH_TOKEN node "${RUNNER_TEMP}/npm-bootstrap-check.mjs" --root release-src --package "${target}"
+            status=$?
+            set -e
+            case "${status}" in
+              3)
+                echo "::notice::Skipping ${target}: exact version already published (idempotent retry)."
+                ;;
+              0)
+                echo "Publishing bootstrap target ${target}..."
+                if (cd "release-src/packages/${target#@remnic/}" && pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts --registry=https://registry.npmjs.org) >"$publish_log" 2>&1; then
+                  cat "$publish_log"
+                  echo "::notice::Published ${target} (first version; alpha dist-tag)."
+                else
+                  publish_status=$?
+                  cat "$publish_log"
+                  echo "::error title=Bootstrap publish failed::${target} — inspect the log above."
+                  exit "${publish_status}"
+                fi
+                ;;
+              *)
+                echo "::error title=Bootstrap target refused::${target} could not be classified for a first publish (exit ${status}); refusing to publish on an unclassifiable registry state."
+                exit "${status}"
+                ;;
+            esac
           done
           echo "::notice::Bootstrap dispatch complete: absent names published to the alpha dist-tag; already-published exact versions skipped."

--- a/scripts/npm-bootstrap-check.mjs
+++ b/scripts/npm-bootstrap-check.mjs
@@ -38,6 +38,7 @@ export const BOOTSTRAP_TARGETS = Object.freeze([
 
 const E404 = /npm error code E404/;
 const NPM_VIEW_TIMEOUT_MS = 30_000;
+const NPMJS_REGISTRY = "https://registry.npmjs.org";
 
 /**
  * Pure classification from two `npm view` outcomes. `version` is
@@ -80,6 +81,9 @@ function targetVersion(root, rootVersion, target) {
   }
   if (manifest.version !== rootVersion) {
     fail(`version drift: ${target.dir} is ${manifest.version}, tagged root is ${rootVersion}`);
+  }
+  if (manifest.publishConfig?.registry && manifest.publishConfig.registry !== NPMJS_REGISTRY) {
+    fail(`registry override: ${target.dir} publishConfig.registry is ${manifest.publishConfig.registry}, refusing to send credentials anywhere but ${NPMJS_REGISTRY}`);
   }
   return manifest.version;
 }

--- a/scripts/npm-bootstrap-check.mjs
+++ b/scripts/npm-bootstrap-check.mjs
@@ -1,0 +1,124 @@
+/**
+ * One-time npm bootstrap target classifier for release-and-publish.yml
+ * (`bootstrap_tag` dispatches).
+ *
+ * npm's publish API answers E404 when an automation identity may not CREATE
+ * a package name, so OIDC-only publishing can never mint a first version.
+ * This script classifies each allowlisted target against the public registry
+ * so the bootstrap publish step only ever creates genuinely absent names:
+ *
+ * - publish: the name is absent (npm answers E404 for the bare name)
+ * - skip:    the exact name@version is already published (idempotent retry)
+ * - refuse:  the name exists but the requested version does not — no longer a
+ *            first publish; minting a new version exceeds bootstrap scope
+ * - error:   the registry answered with anything other than E404 — the state
+ *            is unclassifiable and must never publish
+ *
+ * Target manifests must live under `--root` (the checked-out release tag in
+ * the workflow), carry exactly the allowlisted name, and carry the tagged
+ * root version. The workflow stages this script from the trusted dispatch
+ * ref into RUNNER_TEMP. Exit codes: 0 = publish (single-target mode) or no
+ * refuse/error (full mode); 3 = skip (single-target mode); 1 = refuse,
+ * error, or manifest/version drift. Lookups are unauthenticated; only
+ * package names are transmitted.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export const BOOTSTRAP_TARGETS = Object.freeze([
+  { name: "@remnic/connector-reitti", dir: "packages/connector-reitti" },
+  { name: "@remnic/connector-x", dir: "packages/connector-x" },
+  { name: "@remnic/import-okf", dir: "packages/import-okf" },
+]);
+
+const E404 = /npm error code E404/;
+const NPM_VIEW_TIMEOUT_MS = 30_000;
+
+/**
+ * Pure classification from two `npm view` outcomes. `version` is
+ * `npm view <name>@<version> version`; `name` is `npm view <name> version`,
+ * needed only once the exact version turned out to be absent.
+ */
+export function classify({ version, name }) {
+  if (version.ok) return { action: "skip", reason: "exact version already published" };
+  if (!E404.test(version.stderr ?? "")) {
+    return { action: "error", reason: firstLine(version.stderr, "version query") };
+  }
+  if (name.ok) {
+    return { action: "refuse", reason: "package name exists at a different version; bootstrap only creates absent names" };
+  }
+  if (E404.test(name.stderr ?? "")) return { action: "publish", reason: "package name absent from registry" };
+  return { action: "error", reason: firstLine(name.stderr, "name query") };
+}
+
+function firstLine(stderr, label) {
+  return `registry not classifiable (${label}: ${(stderr ?? "").split("\n", 1)[0] || "no output"})`;
+}
+
+function npmView(spec) {
+  const result = spawnSync("npm", ["view", spec, "version"], {
+    encoding: "utf8",
+    timeout: NPM_VIEW_TIMEOUT_MS,
+  });
+  return { ok: result.status === 0, stderr: result.stderr ?? "" };
+}
+
+function fail(message) {
+  console.error(`::error title=Bootstrap target rejected::${message}`);
+  process.exit(1);
+}
+
+function targetVersion(root, rootVersion, target) {
+  const manifest = JSON.parse(readFileSync(path.join(root, target.dir, "package.json"), "utf8"));
+  if (manifest.name !== target.name) {
+    fail(`manifest drift: ${target.dir}/package.json is "${manifest.name}", allowlist expects "${target.name}"`);
+  }
+  if (manifest.version !== rootVersion) {
+    fail(`version drift: ${target.dir} is ${manifest.version}, tagged root is ${rootVersion}`);
+  }
+  return manifest.version;
+}
+
+function main(argv) {
+  let root = REPO_ROOT;
+  const rootIndex = argv.indexOf("--root");
+  if (rootIndex !== -1) root = path.resolve(argv[rootIndex + 1]);
+
+  const packageIndex = argv.indexOf("--package");
+  const single = packageIndex !== -1 ? argv[packageIndex + 1] : null;
+  const selected = single
+    ? BOOTSTRAP_TARGETS.filter((target) => target.name === single)
+    : BOOTSTRAP_TARGETS;
+  if (single && selected.length === 0) fail(`unknown bootstrap target: ${single}`);
+
+  const rootVersion = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8")).version;
+
+  for (const target of selected) {
+    const version = targetVersion(root, rootVersion, target);
+    const versionQuery = npmView(`${target.name}@${version}`);
+    if (versionQuery.ok) {
+      console.log(`skip ${target.name}@${version}: exact version already published`);
+      if (single) process.exit(3);
+      continue;
+    }
+    const outcome = classify({ version: versionQuery, name: npmView(target.name) });
+    const label = `${target.name}@${version}`;
+    if (outcome.action === "publish") {
+      console.log(`publish ${label}: ${outcome.reason}`);
+    } else if (outcome.action === "skip") {
+      console.log(`skip ${label}: ${outcome.reason}`);
+      if (single) process.exit(3);
+    } else {
+      fail(`${label}: ${outcome.reason}`);
+    }
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main(process.argv.slice(2));
+}

--- a/tests/release-channel-workflows.test.mjs
+++ b/tests/release-channel-workflows.test.mjs
@@ -141,7 +141,7 @@ test("the release-discipline gate runs as a standard pull_request workflow", () 
  * Update these literals only in a PR that deliberately changes CI ordering.
  */
 const EXPECTED_JOB_GRAPHS = Object.freeze({
-  "release-and-publish.yml": { "release-tests": [], release: ["release-tests"] },
+  "release-and-publish.yml": { "release-tests": [], release: ["release-tests"], "bootstrap-publish": [] },
   "changelog-guard.yml": { "changelog-guard": [] },
   "release-promote.yml": { promote: [] },
 });

--- a/tests/release-workflow-bootstrap.test.mjs
+++ b/tests/release-workflow-bootstrap.test.mjs
@@ -115,7 +115,8 @@ test("NPM_BOOTSTRAP_TOKEN appears once, in the publish step, with scripts disabl
   assert.ok(publish, "publish step must exist");
   assert.equal(publish.env.NODE_AUTH_TOKEN, "${{ secrets.NPM_BOOTSTRAP_TOKEN }}");
   assert.match(publish.run, /pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts --registry=https:\/\/registry\.npmjs\.org/);
-  assert.match(publish.run, /env -u NODE_AUTH_TOKEN npm view/, "pre-publish re-checks must run without the token");
+  assert.match(publish.run, /env -u NODE_AUTH_TOKEN node "\$\{RUNNER_TEMP\}\/npm-bootstrap-check\.mjs" --root release-src --package/, "pre-publish re-checks must reuse the fail-closed classifier without the token");
+  assert.match(publish.run, /case "\$\{status\}" in[\s\S]*exit "\$\{status\}"/, "non-publish and non-skip classifier outcomes must abort the run");
   for (const step of steps) {
     if (step.name === PUBLISH_STEP) continue;
     assert.doesNotMatch(JSON.stringify(step.env ?? {}), /NODE_AUTH_TOKEN/, `${step.name} must not see publish credentials`);

--- a/tests/release-workflow-bootstrap.test.mjs
+++ b/tests/release-workflow-bootstrap.test.mjs
@@ -51,6 +51,7 @@ test("normal release jobs never run in bootstrap mode", () => {
   assert.match(condition, /github\.event_name == 'workflow_dispatch'/);
   assert.match(condition, /inputs\.bootstrap_tag != ''/);
   assert.match(condition, /github\.actor != 'github-actions\[bot\]'/);
+  assert.match(condition, /github\.ref == 'refs\/heads\/main'/, "token-bearing job must only run from main");
 });
 
 test("bootstrap validates the tag before checkout and never interpolates the raw input", () => {
@@ -64,9 +65,12 @@ test("bootstrap validates the tag before checkout and never interpolates the raw
   assert.match(validate.run, /\[\[ "\$\{BOOTSTRAP_TAG\}" =~ \^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$ \]\]/, "tag must match vX.Y.Z on the whole string");
   assert.doesNotMatch(validate.run, /grep -Eq/, "line-oriented grep must not validate a potentially multiline value");
   assert.equal(validate.env.BOOTSTRAP_TAG, "${{ inputs.bootstrap_tag }}", "input must reach bash via env");
+  assert.match(validate.run, /v9\.69\.64\) EXPECTED_SHA="70e8607d63f86d4a2410610e97753575aecf075b"/, "only the approved tag→commit pair may bootstrap");
+  assert.match(validate.run, /not an approved bootstrap source/, "any other tag value must be rejected");
   const checkout = steps[checkoutIndex];
   assert.equal(checkout.with.ref, "${{ steps.bootstrap_tag.outputs.tag }}");
   assert.equal(checkout.with.path, "release-src");
+  assert.equal(checkout.with["persist-credentials"], false, "checkout must not persist credentials");
   for (const step of steps) {
     assert.doesNotMatch(step.run ?? "", /\$\{\{ ?inputs\.bootstrap_tag/, "raw input must never be interpolated into run scripts");
   }
@@ -77,6 +81,7 @@ test("bootstrap source is a separate immutable checkout, built and published fro
   const workflowCheckout = steps.find((step) => step.name === "Checkout workflow source");
   assert.ok(workflowCheckout, "trusted workflow source must be checked out for the classifier");
   assert.equal(workflowCheckout.with.ref, "${{ github.sha }}");
+  assert.equal(workflowCheckout.with["persist-credentials"], false, "checkout must not persist credentials");
   const stage = steps.find((step) => /Stage bootstrap classifier/.test(step.name));
   assert.ok(stage, "classifier must be staged before the tag replaces the workspace tree");
   assert.match(stage.run, /cp scripts\/npm-bootstrap-check\.mjs "\$\{RUNNER_TEMP\}/);
@@ -87,10 +92,11 @@ test("bootstrap source is a separate immutable checkout, built and published fro
     .join("\n");
   assert.match(runs, /git -C release-src describe --exact-match --tags HEAD/);
   assert.match(runs, /require\('\.\/release-src\/package\.json'\)\.version/);
-  // The helper only ever runs from RUNNER_TEMP with an explicit source root;
-  // the tagged tree has no copy of it, and nothing may fall back to the
-  // (absent) tag-tree path.
-  assert.match(runs, /npm-bootstrap-check\.mjs"? --root release-src --package/);
+  const verify = steps.find((step) => step.name === "Verify tagged source");
+  assert.ok(verify, "tagged source verification step must exist");
+  assert.equal(verify.env.EXPECTED_SHA, "${{ steps.bootstrap_tag.outputs.expected_sha }}");
+  assert.match(verify.run, /"\$\{ACTUAL_SHA\}" != "\$\{EXPECTED_SHA\}"/, "checkout SHA must equal the approved commit");
+  assert.match(runs, /npm-bootstrap-check\.mjs"? --root release-src/);
   for (const step of steps) {
     if (/Stage bootstrap classifier/.test(step.name)) continue;
     assert.doesNotMatch(step.run ?? "", /(?<!\$\{RUNNER_TEMP\}\/)npm-bootstrap-check\.mjs/, `${step.name} must use the staged RUNNER_TEMP classifier`);
@@ -108,7 +114,8 @@ test("NPM_BOOTSTRAP_TOKEN appears once, in the publish step, with scripts disabl
   const publish = steps.find((step) => step.name === PUBLISH_STEP);
   assert.ok(publish, "publish step must exist");
   assert.equal(publish.env.NODE_AUTH_TOKEN, "${{ secrets.NPM_BOOTSTRAP_TOKEN }}");
-  assert.match(publish.run, /pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts/);
+  assert.match(publish.run, /pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts --registry=https:\/\/registry\.npmjs\.org/);
+  assert.match(publish.run, /env -u NODE_AUTH_TOKEN npm view/, "pre-publish re-checks must run without the token");
   for (const step of steps) {
     if (step.name === PUBLISH_STEP) continue;
     assert.doesNotMatch(JSON.stringify(step.env ?? {}), /NODE_AUTH_TOKEN/, `${step.name} must not see publish credentials`);
@@ -181,4 +188,22 @@ test("classifier refuses version drift against the tagged root without touching 
   );
   assert.equal(result.status, 1);
   assert.match(result.stderr, /version drift/);
+});
+
+test("classifier refuses a publishConfig registry override without touching the network", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "npm-bootstrap-check-"));
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "remnic", version: "9.69.64" }));
+  const dir = path.join(root, "packages/connector-reitti");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "@remnic/connector-reitti", version: "9.69.64", publishConfig: { registry: "https://registry.example.test" } }),
+  );
+  const result = spawnSync(
+    process.execPath,
+    [path.join(REPO_ROOT, CLASSIFIER), "--root", root, "--package", "@remnic/connector-reitti"],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /registry override/);
 });

--- a/tests/release-workflow-bootstrap.test.mjs
+++ b/tests/release-workflow-bootstrap.test.mjs
@@ -1,0 +1,184 @@
+/**
+ * One-time npm bootstrap path in release-and-publish.yml.
+ *
+ * Pins the safety properties of `bootstrap_tag` dispatches: strict input
+ * validation before checkout, the trusted workflow source checked out
+ * separately from the immutable tagged source, a hardcoded three-package
+ * publish allowlist, registry E404-vs-error classification with
+ * no-overwrite guarantees, and NPM_BOOTSTRAP_TOKEN confined to the single
+ * publish step with pack scripts disabled. The normal push-triggered
+ * release path must stay untouched by bootstrap dispatches.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parse } from "yaml";
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const raw = readFileSync(path.join(REPO_ROOT, ".github/workflows/release-and-publish.yml"), "utf8");
+const workflow = parse(raw);
+
+const BOOTSTRAP_JOB = "bootstrap-publish";
+const PUBLISH_STEP = "Bootstrap absent packages to npm";
+const CLASSIFIER = "scripts/npm-bootstrap-check.mjs";
+const ALLOWLIST = Object.freeze([
+  { name: "@remnic/connector-reitti", dir: "packages/connector-reitti" },
+  { name: "@remnic/connector-x", dir: "packages/connector-x" },
+  { name: "@remnic/import-okf", dir: "packages/import-okf" },
+]);
+
+const check = await import(pathToFileURL(path.join(REPO_ROOT, CLASSIFIER)));
+
+test("bootstrap is dispatch-only via one optional tag input", () => {
+  assert.deepEqual(Object.keys(workflow.on).sort(), ["push", "workflow_dispatch"]);
+  assert.deepEqual(workflow.on.push.branches, ["main"]);
+  const inputs = workflow.on.workflow_dispatch.inputs;
+  assert.deepEqual(Object.keys(inputs).sort(), ["bootstrap_tag", "version_override"]);
+  assert.equal(inputs.bootstrap_tag.required, false);
+  assert.equal(inputs.bootstrap_tag.type, "string");
+});
+
+test("normal release jobs never run in bootstrap mode", () => {
+  for (const jobId of ["release-tests", "release"]) {
+    assert.match(workflow.jobs[jobId].if, /inputs\.bootstrap_tag == ''/, `${jobId} must skip on bootstrap dispatches`);
+  }
+  const condition = workflow.jobs[BOOTSTRAP_JOB].if;
+  assert.match(condition, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(condition, /inputs\.bootstrap_tag != ''/);
+  assert.match(condition, /github\.actor != 'github-actions\[bot\]'/);
+});
+
+test("bootstrap validates the tag before checkout and never interpolates the raw input", () => {
+  const steps = workflow.jobs[BOOTSTRAP_JOB].steps;
+  const validateIndex = steps.findIndex((step) => step.name === "Validate bootstrap tag");
+  const checkoutIndex = steps.findIndex((step) => step.name === "Checkout bootstrap tag");
+  assert.ok(validateIndex !== -1, "validation step must exist");
+  assert.ok(checkoutIndex !== -1, "tag checkout step must exist");
+  assert.ok(validateIndex < checkoutIndex, "tag format must be validated before checkout");
+  const validate = steps[validateIndex];
+  assert.match(validate.run, /\[\[ "\$\{BOOTSTRAP_TAG\}" =~ \^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$ \]\]/, "tag must match vX.Y.Z on the whole string");
+  assert.doesNotMatch(validate.run, /grep -Eq/, "line-oriented grep must not validate a potentially multiline value");
+  assert.equal(validate.env.BOOTSTRAP_TAG, "${{ inputs.bootstrap_tag }}", "input must reach bash via env");
+  const checkout = steps[checkoutIndex];
+  assert.equal(checkout.with.ref, "${{ steps.bootstrap_tag.outputs.tag }}");
+  assert.equal(checkout.with.path, "release-src");
+  for (const step of steps) {
+    assert.doesNotMatch(step.run ?? "", /\$\{\{ ?inputs\.bootstrap_tag/, "raw input must never be interpolated into run scripts");
+  }
+});
+
+test("bootstrap source is a separate immutable checkout, built and published from it", () => {
+  const steps = workflow.jobs[BOOTSTRAP_JOB].steps;
+  const workflowCheckout = steps.find((step) => step.name === "Checkout workflow source");
+  assert.ok(workflowCheckout, "trusted workflow source must be checked out for the classifier");
+  assert.equal(workflowCheckout.with.ref, "${{ github.sha }}");
+  const stage = steps.find((step) => /Stage bootstrap classifier/.test(step.name));
+  assert.ok(stage, "classifier must be staged before the tag replaces the workspace tree");
+  assert.match(stage.run, /cp scripts\/npm-bootstrap-check\.mjs "\$\{RUNNER_TEMP\}/);
+
+  const runs = steps
+    .filter((step) => step.run)
+    .map((step) => step.run)
+    .join("\n");
+  assert.match(runs, /git -C release-src describe --exact-match --tags HEAD/);
+  assert.match(runs, /require\('\.\/release-src\/package\.json'\)\.version/);
+  // The helper only ever runs from RUNNER_TEMP with an explicit source root;
+  // the tagged tree has no copy of it, and nothing may fall back to the
+  // (absent) tag-tree path.
+  assert.match(runs, /npm-bootstrap-check\.mjs"? --root release-src --package/);
+  for (const step of steps) {
+    if (/Stage bootstrap classifier/.test(step.name)) continue;
+    assert.doesNotMatch(step.run ?? "", /(?<!\$\{RUNNER_TEMP\}\/)npm-bootstrap-check\.mjs/, `${step.name} must use the staged RUNNER_TEMP classifier`);
+  }
+  const classifyIndex = steps.findIndex((step) => step.name === "Classify bootstrap targets against npm");
+  const installIndex = steps.findIndex((step) => step.name === "Install dependencies");
+  assert.ok(classifyIndex !== -1, "fail-fast classification step must exist");
+  assert.ok(classifyIndex < installIndex, "registry state must be classified before the long install/build");
+});
+
+test("NPM_BOOTSTRAP_TOKEN appears once, in the publish step, with scripts disabled", () => {
+  const secretRef = /\$\{\{ ?secrets\.NPM_BOOTSTRAP_TOKEN \}\}/;
+  assert.equal((raw.match(new RegExp(secretRef.source, "g")) ?? []).length, 1, "the token secret must be resolved exactly once");
+  const steps = workflow.jobs[BOOTSTRAP_JOB].steps;
+  const publish = steps.find((step) => step.name === PUBLISH_STEP);
+  assert.ok(publish, "publish step must exist");
+  assert.equal(publish.env.NODE_AUTH_TOKEN, "${{ secrets.NPM_BOOTSTRAP_TOKEN }}");
+  assert.match(publish.run, /pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts/);
+  for (const step of steps) {
+    if (step.name === PUBLISH_STEP) continue;
+    assert.doesNotMatch(JSON.stringify(step.env ?? {}), /NODE_AUTH_TOKEN/, `${step.name} must not see publish credentials`);
+  }
+});
+
+test("bootstrap never mutates git state, versions, or dist-tags", () => {
+  const runs = workflow.jobs[BOOTSTRAP_JOB].steps
+    .filter((step) => step.run)
+    .map((step) => step.run)
+    .join("\n");
+  for (const forbidden of [/git commit/, /git push/, /dist-tag (add|delete|ls|rm)/, /set-release-version/, /CHANGELOG/]) {
+    assert.doesNotMatch(runs, forbidden);
+  }
+});
+
+test("publish targets are the hardcoded three-package allowlist", () => {
+  assert.deepEqual(check.BOOTSTRAP_TARGETS, ALLOWLIST);
+});
+
+test("registry classification distinguishes absence, existence, and errors", () => {
+  const e404 = "npm error code E404\nnpm error 404 Not Found - GET";
+  const netfail = "npm error code ENOTFOUND";
+  const t = (overrides) =>
+    check.classify({
+      version: { ok: false, stderr: e404 },
+      name: { ok: false, stderr: e404 },
+      ...overrides,
+    });
+  assert.equal(t({ version: { ok: true, stderr: "" } }).action, "skip");
+  assert.equal(t().action, "publish");
+  assert.equal(t({ name: { ok: true, stderr: "" } }).action, "refuse");
+  assert.equal(t({ version: { ok: false, stderr: netfail } }).action, "error");
+  assert.equal(t({ name: { ok: false, stderr: netfail } }).action, "error");
+});
+
+test("classifier rejects unknown targets without touching the network", () => {
+  const result = spawnSync(process.execPath, [path.join(REPO_ROOT, CLASSIFIER), "--package", "@remnic/unknown"], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown bootstrap target/);
+});
+
+test("classifier refuses manifest drift via explicit --root without touching the network", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "npm-bootstrap-check-"));
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "remnic", version: "9.69.64" }));
+  const dir = path.join(root, "packages/connector-x");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "@remnic/impostor", version: "0.0.0" }));
+  const result = spawnSync(
+    process.execPath,
+    [path.join(REPO_ROOT, CLASSIFIER), "--root", root, "--package", "@remnic/connector-x"],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /manifest drift/);
+});
+
+test("classifier refuses version drift against the tagged root without touching the network", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "npm-bootstrap-check-"));
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "remnic", version: "9.69.64" }));
+  const dir = path.join(root, "packages/import-okf");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "@remnic/import-okf", version: "9.0.0" }));
+  const result = spawnSync(
+    process.execPath,
+    [path.join(REPO_ROOT, CLASSIFIER), "--root", root, "--package", "@remnic/import-okf"],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /version drift/);
+});


### PR DESCRIPTION
## Problem

`@remnic/connector-reitti`, `@remnic/connector-x`, and `@remnic/import-okf` have never been published. npm's publish API answers E404 when an automation identity may not CREATE a package name, so trusted publishing (OIDC) alone can never mint their first version — the regular release workflow correctly reports them as unprovisioned and the names stay stranded. npm requires the packages to exist before trusted publishing can be configured for them.

## Change

Adds one `workflow_dispatch` input, `bootstrap_tag` (strict `vX.Y.Z`), to `.github/workflows/release-and-publish.yml`. When set, a dedicated `bootstrap-publish` job runs and every normal release job skips; nothing about push-triggered releases changes.

The job:

1. validates the tag on the whole string (`[[ ... =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]`) BEFORE any checkout, via env (the raw input is never interpolated into a script); `version_override` is mutually exclusive;
2. checks out the trusted workflow source (for the classifier) and the release tag into `release-src/` separately;
3. verifies the tagged source: `git describe --exact-match` equals the input tag, root `package.json` version equals the tag version, and every target manifest's name and version equal the allowlist entry and the tagged root version;
4. classifies each allowlisted target against the registry (fail-fast before install/build, and again immediately before each publish):
   - E404 on the bare name → publish (first version)
   - exact `name@version` present → skip (idempotent retry after partial success)
   - name present at a different version → refuse (minting a new version exceeds first-publish scope)
   - any other registry outcome → abort (never publish on an unclassifiable state)
5. installs and builds entirely from the immutable tagged source;
6. publishes each still-absent target with `pnpm publish --access public --provenance --no-git-checks --tag alpha --ignore-scripts`, with `NODE_AUTH_TOKEN` sourced solely from the `NPM_BOOTSTRAP_TOKEN` secret in that one step. `--ignore-scripts` ensures no pack-time lifecycle script runs with the token in the environment (targets carry only a `prepublishOnly` rebuild, already done explicitly).

The allowlist is hardcoded in the workflow loop and mirrored in `scripts/npm-bootstrap-check.mjs` (tested for equality). The job never bumps versions, commits, pushes, creates tags, or moves dist-tags.

## Verification

- New `tests/release-workflow-bootstrap.test.mjs` (11 tests): input surface, normal-job gating, validate-before-checkout + no raw-input interpolation, separate immutable checkout + RUNNER_TEMP-only classifier use, single token reference confined to the publish step with scripts disabled, no git/dist-tag mutation, allowlist equality, E404-vs-error classification unit cases, and network-free CLI regression tests for unknown targets, manifest drift, and version drift.
- Live classifier run against the registry confirms all three names are absent at 9.69.64 and a non-allowlisted name is rejected.
- `npm run check:pre-push` green; `check-release-discipline` clean (CI-only diff). The four `tsc` errors `preflight:quick` surfaces in `tests/bench-ui-*` / `tests/relay-*` reproduce on a clean checkout of this commit's parent and are unrelated to this diff.

## Maintainer runbook (after merge)

1. Create the `NPM_BOOTSTRAP_TOKEN` repository secret: a temporary npm granular token, minimum scope (publish rights for the three names / `@remnic` scope), short expiry.
2. Dispatch: `gh workflow run release-and-publish.yml --ref main -f bootstrap_tag=v9.69.64`
3. Retry is safe: already-published exact versions are skipped; only genuinely absent names are published.
4. Delete the secret and revoke the token once the three names exist and trusted publishing is configured for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual one-time npm bootstrap release option using an approved immutable version tag.
  * Bootstrap releases publish only eligible packages that are not already available at the requested version, using the `alpha` distribution tag.
  * Existing releases continue to follow the standard release and publishing process.

* **Bug Fixes**
  * Added validation for package versions, tags, registry state, credentials, and source integrity.
  * Prevented bootstrap releases from overwriting existing versions or modifying repository release state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->