### PR TITLE
fix(core): detect LiteLLM from GET / instead of probing /health

### DIFF
--- a/.changeset/3100-litellm-probe.md
+++ b/.changeset/3100-litellm-probe.md
@@ -1,0 +1,12 @@
+---
+"@remnic/core": patch
+---
+
+Stability: stable
+
+Local-LLM backend detection recognises a LiteLLM proxy from `GET /` and no
+longer probes `GET /health` on it. On LiteLLM that endpoint runs a live
+completion against every deployment in the pool, so the once-a-minute probe
+was a permanent load generator on the backends the daemon itself depends on.
+The LiteLLM check now runs ahead of the port-prioritised llama.cpp / vLLM
+probes, and each probe URL is fetched once per detection pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Local-LLM backend detection recognises a LiteLLM proxy from `GET /` and no longer probes `GET /health`, which on LiteLLM runs a live completion against every deployment in the pool once per probe.
+
 ## [v9.69.64] — 2026-09-07
 
 ### Fixed

--- a/packages/remnic-core/src/local-llm-probe-litellm.test.ts
+++ b/packages/remnic-core/src/local-llm-probe-litellm.test.ts
@@ -79,13 +79,21 @@ test("a LiteLLM proxy is detected from GET / and /health is never probed", async
   }
 });
 
-test("LiteLLM is probed first even when the port matches llama.cpp or vLLM", () => {
-  for (const port of [8080, 8000, 11434, 1234, 4000]) {
-    const order = orderedLocalServers(`http://127.0.0.1:${port}/v1`).map((s) => s.type);
-    assert.equal(order[0], "litellm", `port ${port}: ${order.join(" > ")}`);
+test("LiteLLM is probed before any /health probe on every port; other orders are unchanged", () => {
+  for (const port of [8080, 8000, 11434, 1234, 4000, null]) {
+    const url = port === null ? "http://127.0.0.1/v1" : `http://127.0.0.1:${port}/v1`;
+    const order = orderedLocalServers(url);
+    const types = order.map((s) => s.type);
+    const litellmAt = types.indexOf("litellm");
+    const firstHealth = order.findIndex((s) => s.healthEndpoint === "/health");
+    assert.ok(litellmAt !== -1 && litellmAt < firstHealth, `${url}: ${types.join(" > ")}`);
   }
-  const llamaFirst = orderedLocalServers("http://127.0.0.1:8080/v1").map((s) => s.type);
-  assert.equal(llamaFirst[1], "llamacpp", "port priority still applies after LiteLLM");
+  // Port-matched shapes with harmless probes keep the lead they had before.
+  assert.equal(orderedLocalServers("http://127.0.0.1:1234/v1")[0]?.type, "lmstudio");
+  assert.equal(orderedLocalServers("http://127.0.0.1:11434/v1")[0]?.type, "ollama");
+  // LiteLLM displaces the port-matched llama.cpp / vLLM /health probes.
+  assert.deepEqual(orderedLocalServers("http://127.0.0.1:8080/v1").map((s) => s.type).slice(0, 3), ["litellm", "llamacpp", "mlx"]);
+  assert.deepEqual(orderedLocalServers("http://127.0.0.1:8000/v1").map((s) => s.type).slice(0, 2), ["litellm", "vllm"]);
 });
 
 test("a root response is fetched once even when a later detector matches it", async () => {

--- a/packages/remnic-core/src/local-llm-probe-litellm.test.ts
+++ b/packages/remnic-core/src/local-llm-probe-litellm.test.ts
@@ -3,7 +3,7 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import test from "node:test";
 
-import { LocalLlmClient } from "./local-llm.js";
+import { LocalLlmClient, orderedLocalServers } from "./local-llm.js";
 import type { PluginConfig } from "./types.js";
 
 /**
@@ -34,22 +34,14 @@ function createConfig(localLlmUrl: string): PluginConfig {
   } as unknown as PluginConfig;
 }
 
-async function startLiteLlmShapedServer(): Promise<{ url: string; paths: string[]; close(): Promise<void> }> {
+async function startServer(
+  handle: (path: string, res: http.ServerResponse) => void,
+): Promise<{ url: string; paths: string[]; close(): Promise<void> }> {
   const paths: string[] = [];
   const server = http.createServer((req, res) => {
-    paths.push(req.url ?? "");
-    if (req.url === "/") {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify("LiteLLM: RUNNING"));
-      return;
-    }
-    if (req.url === "/v1/models") {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ data: [{ id: "test-local-model" }] }));
-      return;
-    }
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ healthy_endpoints: [], unhealthy_endpoints: [] }));
+    const path = req.url ?? "";
+    paths.push(path);
+    handle(path, res);
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address() as AddressInfo;
@@ -60,6 +52,19 @@ async function startLiteLlmShapedServer(): Promise<{ url: string; paths: string[
   };
 }
 
+function json(res: http.ServerResponse, body: unknown): void {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function startLiteLlmShapedServer() {
+  return startServer((path, res) => {
+    if (path === "/") return json(res, "LiteLLM: RUNNING");
+    if (path === "/v1/models") return json(res, { data: [{ id: "test-local-model" }] });
+    json(res, { healthy_endpoints: [], unhealthy_endpoints: [] });
+  });
+}
+
 test("a LiteLLM proxy is detected from GET / and /health is never probed", async () => {
   const server = await startLiteLlmShapedServer();
   try {
@@ -68,6 +73,34 @@ test("a LiteLLM proxy is detected from GET / and /health is never probed", async
     assert.equal(client.getDetectedType(), "litellm");
     assert.ok(!server.paths.includes("/health"), `probe hit /health: ${server.paths.join(", ")}`);
     assert.equal(server.paths.filter((p) => p === "/").length, 1, "GET / must be fetched once per pass");
+  } finally {
+    await server.close();
+  }
+});
+
+test("LiteLLM is probed first even when the port matches llama.cpp or vLLM", () => {
+  for (const port of [8080, 8000, 11434, 1234, 4000]) {
+    const order = orderedLocalServers(`http://127.0.0.1:${port}/v1`).map((s) => s.type);
+    assert.equal(order[0], "litellm", `port ${port}: ${order.join(" > ")}`);
+  }
+  const llamaFirst = orderedLocalServers("http://127.0.0.1:8080/v1").map((s) => s.type);
+  assert.equal(llamaFirst[1], "llamacpp", "port priority still applies after LiteLLM");
+});
+
+test("a root response is fetched once even when a later detector matches it", async () => {
+  const server = await startServer((path, res) => {
+    if (path === "/") {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("Ollama is running");
+      return;
+    }
+    json(res, {});
+  });
+  try {
+    const client = new LocalLlmClient(createConfig(server.url));
+    assert.equal(await client.checkAvailability(), true);
+    assert.equal(client.getDetectedType(), "ollama");
+    assert.equal(server.paths.filter((p) => p === "/").length, 1, `paths: ${server.paths.join(", ")}`);
   } finally {
     await server.close();
   }

--- a/packages/remnic-core/src/local-llm-probe-litellm.test.ts
+++ b/packages/remnic-core/src/local-llm-probe-litellm.test.ts
@@ -3,7 +3,8 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import test from "node:test";
 
-import { LocalLlmClient, orderedLocalServers } from "./local-llm.js";
+import { LocalLlmClient } from "./local-llm.js";
+import { orderedLocalServers } from "./local-llm-servers.js";
 import type { PluginConfig } from "./types.js";
 
 /**

--- a/packages/remnic-core/src/local-llm-probe-litellm.test.ts
+++ b/packages/remnic-core/src/local-llm-probe-litellm.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import test from "node:test";
+
+import { LocalLlmClient } from "./local-llm.js";
+import type { PluginConfig } from "./types.js";
+
+/**
+ * A LiteLLM proxy answers `GET /` with the JSON string "LiteLLM: RUNNING" and
+ * runs a live completion against every deployment in its pool on `GET /health`.
+ * The availability probe must classify LiteLLM from `/` and never reach
+ * `/health`; before this test the once-a-minute probe was the largest load
+ * source on the pool behind the proxy.
+ */
+
+function createConfig(localLlmUrl: string): PluginConfig {
+  return {
+    localLlmEnabled: true,
+    localLlmModel: "test-local-model",
+    localLlmUrl,
+    localLlmTimeoutMs: 1_000,
+    localLlmRetry5xxCount: 0,
+    localLlmRetryBackoffMs: 1,
+    localLlmHeaders: {},
+    localLlmApiKey: undefined,
+    localLlmAuthHeader: false,
+    localLlm400TripThreshold: 3,
+    localLlm400CooldownMs: 60_000,
+    debug: false,
+    localLlmReasoningEffort: "none",
+    slowLogEnabled: false,
+    slowLogThresholdMs: 1_000,
+  } as unknown as PluginConfig;
+}
+
+async function startLiteLlmShapedServer(): Promise<{ url: string; paths: string[]; close(): Promise<void> }> {
+  const paths: string[] = [];
+  const server = http.createServer((req, res) => {
+    paths.push(req.url ?? "");
+    if (req.url === "/") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify("LiteLLM: RUNNING"));
+      return;
+    }
+    if (req.url === "/v1/models") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "test-local-model" }] }));
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ healthy_endpoints: [], unhealthy_endpoints: [] }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/v1`,
+    paths,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+test("a LiteLLM proxy is detected from GET / and /health is never probed", async () => {
+  const server = await startLiteLlmShapedServer();
+  try {
+    const client = new LocalLlmClient(createConfig(server.url));
+    assert.equal(await client.checkAvailability(), true);
+    assert.equal(client.getDetectedType(), "litellm");
+    assert.ok(!server.paths.includes("/health"), `probe hit /health: ${server.paths.join(", ")}`);
+    assert.equal(server.paths.filter((p) => p === "/").length, 1, "GET / must be fetched once per pass");
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/remnic-core/src/local-llm-servers.ts
+++ b/packages/remnic-core/src/local-llm-servers.ts
@@ -1,0 +1,102 @@
+/**
+ * Server shapes the local-LLM availability probe can recognise, and the order
+ * in which they are tried for a configured base URL. Split from local-llm.ts
+ * (file-size ratchet) — no runtime dependency on the client.
+ */
+
+export type LocalLlmType = "litellm" | "lmstudio" | "ollama" | "mlx" | "vllm" | "llamacpp" | "generic";
+
+export interface LocalServerConfig {
+  type: LocalLlmType;
+  defaultPort: number;
+  healthEndpoint: string;
+  modelsEndpoint: string;
+  detectFn: (response: unknown) => boolean;
+}
+
+export function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function explicitPortFromUrl(s: string): number | null {
+  try {
+    const parsed = new URL(s);
+    if (!parsed.port) return null;
+    const port = Number(parsed.port);
+    return Number.isInteger(port) ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+// LiteLLM must be recognised before the llama.cpp / vLLM probes: on a LiteLLM
+// proxy `GET /health` runs a live completion against EVERY deployment in its
+// pool, so a once-a-minute 2 s probe turns into a permanent load generator on
+// the backends (4,600 probe completions in 12 h observed). `GET /` is
+// auth-gated on LiteLLM and answers the JSON string "LiteLLM: RUNNING".
+const LITELLM_SERVER: LocalServerConfig = {
+  type: "litellm",
+  defaultPort: 4000,
+  healthEndpoint: "/",
+  modelsEndpoint: "/v1/models",
+  detectFn: (resp) => typeof resp === "string" && resp.includes("LiteLLM"),
+};
+
+const LOCAL_SERVERS: LocalServerConfig[] = [
+  LITELLM_SERVER,
+  {
+    type: "ollama",
+    defaultPort: 11434,
+    healthEndpoint: "/",
+    modelsEndpoint: "/api/tags",
+    detectFn: (resp) => typeof resp === "string" && resp.includes("Ollama"),
+  },
+  {
+    type: "llamacpp",
+    defaultPort: 8080,
+    healthEndpoint: "/health",
+    modelsEndpoint: "/v1/models",
+    detectFn: (resp) => isObjectRecord(resp) && resp.status === "ok",
+  },
+  {
+    type: "mlx",
+    defaultPort: 8080,
+    healthEndpoint: "/v1/models",
+    modelsEndpoint: "/v1/models",
+    detectFn: (resp) => isObjectRecord(resp) && Array.isArray(resp.data),
+  },
+  {
+    type: "lmstudio",
+    defaultPort: 1234,
+    healthEndpoint: "/v1/models",
+    modelsEndpoint: "/v1/models",
+    detectFn: (resp) => isObjectRecord(resp) && Array.isArray(resp.data),
+  },
+  {
+    type: "vllm",
+    defaultPort: 8000,
+    healthEndpoint: "/health",
+    modelsEndpoint: "/v1/models",
+    detectFn: (resp) => resp === "" || (isObjectRecord(resp) && !("status" in resp)),
+  },
+];
+
+/**
+ * Probe order for a configured base URL. Entries whose default port matches
+ * the URL's explicit port go first, except that the LiteLLM entry always
+ * leads: its `GET /` probe is harmless on every server shape, while the
+ * llama.cpp / vLLM `GET /health` probe is a pool-wide completion on LiteLLM.
+ */
+export function orderedLocalServers(configuredBaseUrl: string): LocalServerConfig[] {
+  const configuredPort = explicitPortFromUrl(configuredBaseUrl);
+  if (configuredPort === null) return LOCAL_SERVERS;
+  const rest = LOCAL_SERVERS.filter((serverConfig) => serverConfig !== LITELLM_SERVER);
+  const matching = rest.filter((serverConfig) => serverConfig.defaultPort === configuredPort);
+  if (matching.length === 0) return LOCAL_SERVERS;
+  const matchingTypes = new Set(matching.map((serverConfig) => serverConfig.type));
+  return [
+    LITELLM_SERVER,
+    ...matching,
+    ...rest.filter((serverConfig) => !matchingTypes.has(serverConfig.type)),
+  ];
+}

--- a/packages/remnic-core/src/local-llm-servers.ts
+++ b/packages/remnic-core/src/local-llm-servers.ts
@@ -34,6 +34,7 @@ function explicitPortFromUrl(s: string): number | null {
 // pool, so a once-a-minute 2 s probe turns into a permanent load generator on
 // the backends (4,600 probe completions in 12 h observed). `GET /` is
 // auth-gated on LiteLLM and answers the JSON string "LiteLLM: RUNNING".
+// Not part of LOCAL_SERVERS: `orderedLocalServers` positions it explicitly.
 const LITELLM_SERVER: LocalServerConfig = {
   type: "litellm",
   defaultPort: 4000,
@@ -43,7 +44,6 @@ const LITELLM_SERVER: LocalServerConfig = {
 };
 
 const LOCAL_SERVERS: LocalServerConfig[] = [
-  LITELLM_SERVER,
   {
     type: "ollama",
     defaultPort: 11434,
@@ -83,20 +83,22 @@ const LOCAL_SERVERS: LocalServerConfig[] = [
 
 /**
  * Probe order for a configured base URL. Entries whose default port matches
- * the URL's explicit port go first, except that the LiteLLM entry always
- * leads: its `GET /` probe is harmless on every server shape, while the
- * llama.cpp / vLLM `GET /health` probe is a pool-wide completion on LiteLLM.
+ * the URL's explicit port go first, in the same order as before; the LiteLLM
+ * entry is placed immediately ahead of the first entry that would probe
+ * `GET /health`, so that request never reaches a LiteLLM proxy on any port.
+ * LM Studio / Ollama / MLX probes are harmless on LiteLLM and keep their spot.
  */
 export function orderedLocalServers(configuredBaseUrl: string): LocalServerConfig[] {
   const configuredPort = explicitPortFromUrl(configuredBaseUrl);
-  if (configuredPort === null) return LOCAL_SERVERS;
-  const rest = LOCAL_SERVERS.filter((serverConfig) => serverConfig !== LITELLM_SERVER);
-  const matching = rest.filter((serverConfig) => serverConfig.defaultPort === configuredPort);
-  if (matching.length === 0) return LOCAL_SERVERS;
+  const matching = configuredPort === null
+    ? []
+    : LOCAL_SERVERS.filter((serverConfig) => serverConfig.defaultPort === configuredPort);
   const matchingTypes = new Set(matching.map((serverConfig) => serverConfig.type));
-  return [
-    LITELLM_SERVER,
+  const ordered = [
     ...matching,
-    ...rest.filter((serverConfig) => !matchingTypes.has(serverConfig.type)),
+    ...LOCAL_SERVERS.filter((serverConfig) => !matchingTypes.has(serverConfig.type)),
   ];
+  const firstHealthProbe = ordered.findIndex((serverConfig) => serverConfig.healthEndpoint === "/health");
+  ordered.splice(firstHealthProbe === -1 ? ordered.length : firstHealthProbe, 0, LITELLM_SERVER);
+  return ordered;
 }

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -125,7 +125,7 @@ function isLmStudioNativeModelsResponse(value: unknown): boolean {
  * Provides privacy-preserving, cost-effective LLM operations with
  * graceful fallback to cloud providers when local LLM is unavailable.
  */
-export type LocalLlmType = "lmstudio" | "ollama" | "mlx" | "vllm" | "llamacpp" | "generic";
+export type LocalLlmType = "litellm" | "lmstudio" | "ollama" | "mlx" | "vllm" | "llamacpp" | "generic";
 
 /**
  * Backends known to honor `chat_template_kwargs: { enable_thinking: false }`
@@ -169,6 +169,19 @@ interface LocalServerConfig {
 }
 
 const LOCAL_SERVERS: LocalServerConfig[] = [
+  // LiteLLM must be recognised before the llama.cpp probe: on a LiteLLM proxy
+  // `GET /health` runs a live completion against EVERY deployment in its
+  // pool, so a once-a-minute 2 s probe turns into a permanent load
+  // generator on the backends (4,600 probe completions in 12 h observed).
+  // `GET /` is auth-gated on LiteLLM and answers the JSON string
+  // "LiteLLM: RUNNING".
+  {
+    type: "litellm",
+    defaultPort: 4000,
+    healthEndpoint: "/",
+    modelsEndpoint: "/v1/models",
+    detectFn: (resp) => typeof resp === "string" && resp.includes("LiteLLM"),
+  },
   {
     type: "ollama",
     defaultPort: 11434,
@@ -435,6 +448,16 @@ export class LocalLlmClient {
     // is down (issue #2210). Tracked separately so a loaded daemon cannot cache
     // itself into a blackout.
     let sawAbortedProbe = false;
+    // Several server shapes share a probe URL (LiteLLM and Ollama both use
+    // `/`); fetch each URL once per pass.
+    const probed = new Map<string, ProbeFetchResult>();
+    const probeOnce = async (url: string): Promise<ProbeFetchResult> => {
+      const cached = probed.get(url);
+      if (cached) return cached;
+      const result = await this.fetchWithTimeout(url, 2000, undefined, signal);
+      probed.set(url, result);
+      return result;
+    };
 
     // Try to detect which server type is running
     if (signal?.aborted) return false;
@@ -442,7 +465,7 @@ export class LocalLlmClient {
       const healthUrl = `${probeBaseUrl}${serverConfig.healthEndpoint}`;
       log.debug(`checking ${serverConfig.type} at ${healthUrl}`);
 
-      const result = await this.fetchWithTimeout(healthUrl, 2000, undefined, signal);
+      const result = await probeOnce(healthUrl);
       if (result.aborted) sawAbortedProbe = true;
       if (signal?.aborted) return false;
       if (result.ok && serverConfig.detectFn(result.data)) {

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -22,6 +22,13 @@ import {
   type LocalLlmChatCompletionOptions,
   type LocalLlmChatCompletionResult,
 } from "./local-llm-helpers.js";
+import {
+  isObjectRecord,
+  orderedLocalServers,
+  type LocalLlmType,
+} from "./local-llm-servers.js";
+
+export type { LocalLlmType } from "./local-llm-servers.js";
 
 /** Trim trailing slash characters without backtracking regex. */
 function trimTrailingSlashes(s: string): string {
@@ -32,21 +39,6 @@ function trimTrailingSlashes(s: string): string {
 
 function stripTrailingV1Path(s: string): string {
   return s.endsWith("/v1") ? s.slice(0, -3) : s;
-}
-
-function explicitPortFromUrl(s: string): number | null {
-  try {
-    const parsed = new URL(s);
-    if (!parsed.port) return null;
-    const port = Number(parsed.port);
-    return Number.isInteger(port) ? port : null;
-  } catch {
-    return null;
-  }
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }
 
 function isLlamaCppPropsResponse(value: unknown): boolean {
@@ -119,15 +111,6 @@ function isLmStudioNativeModelsResponse(value: unknown): boolean {
 }
 
 /**
- * Local LLM client for OpenAI-compatible endpoints (LM Studio, Ollama, MLX, etc.)
- *
- * Based on openclaw-tactician's provider detection patterns for consistency.
- * Provides privacy-preserving, cost-effective LLM operations with
- * graceful fallback to cloud providers when local LLM is unavailable.
- */
-export type LocalLlmType = "litellm" | "lmstudio" | "ollama" | "mlx" | "vllm" | "llamacpp" | "generic";
-
-/**
  * Backends known to honor `chat_template_kwargs: { enable_thinking: false }`
  * on OpenAI-compatible `/v1/chat/completions`.  LM Studio, vLLM, and
  * llama.cpp forward this field to the jinja chat template, where thinking-capable
@@ -160,87 +143,6 @@ const THINKING_SUPPRESSED_OPERATIONS: ReadonlySet<string> = new Set([
   "hourly_summary_extended",
 ]);
 
-export interface LocalServerConfig {
-  type: LocalLlmType;
-  defaultPort: number;
-  healthEndpoint: string;
-  modelsEndpoint: string;
-  detectFn: (response: unknown) => boolean;
-}
-
-// LiteLLM must be recognised before the llama.cpp / vLLM probes: on a LiteLLM
-// proxy `GET /health` runs a live completion against EVERY deployment in its
-// pool, so a once-a-minute 2 s probe turns into a permanent load generator on
-// the backends (4,600 probe completions in 12 h observed). `GET /` is
-// auth-gated on LiteLLM and answers the JSON string "LiteLLM: RUNNING".
-const LITELLM_SERVER: LocalServerConfig = {
-  type: "litellm",
-  defaultPort: 4000,
-  healthEndpoint: "/",
-  modelsEndpoint: "/v1/models",
-  detectFn: (resp) => typeof resp === "string" && resp.includes("LiteLLM"),
-};
-
-const LOCAL_SERVERS: LocalServerConfig[] = [
-  LITELLM_SERVER,
-  {
-    type: "ollama",
-    defaultPort: 11434,
-    healthEndpoint: "/",
-    modelsEndpoint: "/api/tags",
-    detectFn: (resp) => typeof resp === "string" && resp.includes("Ollama"),
-  },
-  {
-    type: "llamacpp",
-    defaultPort: 8080,
-    healthEndpoint: "/health",
-    modelsEndpoint: "/v1/models",
-    detectFn: (resp) => isObjectRecord(resp) && resp.status === "ok",
-  },
-  {
-    type: "mlx",
-    defaultPort: 8080,
-    healthEndpoint: "/v1/models",
-    modelsEndpoint: "/v1/models",
-    detectFn: (resp) => isObjectRecord(resp) && Array.isArray(resp.data),
-  },
-  {
-    type: "lmstudio",
-    defaultPort: 1234,
-    healthEndpoint: "/v1/models",
-    modelsEndpoint: "/v1/models",
-    detectFn: (resp) => isObjectRecord(resp) && Array.isArray(resp.data),
-  },
-  {
-    type: "vllm",
-    defaultPort: 8000,
-    healthEndpoint: "/health",
-    modelsEndpoint: "/v1/models",
-    detectFn: (resp) => resp === "" || (isObjectRecord(resp) && !("status" in resp)),
-  },
-];
-
-/**
- * Probe order for a configured base URL. Entries whose default port matches
- * the URL's explicit port go first, except that the LiteLLM entry always
- * leads: its `GET /` probe is harmless on every server shape, while the
- * llama.cpp / vLLM `GET /health` probe is a pool-wide completion on LiteLLM.
- * Exported for tests.
- */
-export function orderedLocalServers(configuredBaseUrl: string): LocalServerConfig[] {
-  const configuredPort = explicitPortFromUrl(configuredBaseUrl);
-  if (configuredPort === null) return LOCAL_SERVERS;
-  const rest = LOCAL_SERVERS.filter((serverConfig) => serverConfig !== LITELLM_SERVER);
-  const matching = rest.filter((serverConfig) => serverConfig.defaultPort === configuredPort);
-  if (matching.length === 0) return LOCAL_SERVERS;
-  const matchingTypes = new Set(matching.map((serverConfig) => serverConfig.type));
-  return [
-    LITELLM_SERVER,
-    ...matching,
-    ...rest.filter((serverConfig) => !matchingTypes.has(serverConfig.type)),
-  ];
-}
-
 export interface LocalModelInfo {
   id: string;
   contextWindow?: number;
@@ -265,6 +167,13 @@ type LocalLlmBackendState = {
   untilMs: number;
   reason: string;
 };
+/**
+ * Local LLM client for OpenAI-compatible endpoints (LM Studio, Ollama, MLX, etc.)
+ *
+ * Based on openclaw-tactician's provider detection patterns for consistency.
+ * Provides privacy-preserving, cost-effective LLM operations with
+ * graceful fallback to cloud providers when local LLM is unavailable.
+ */
 export class LocalLlmClient {
   private config: PluginConfig;
   private isAvailable: boolean | null = null;

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -160,7 +160,7 @@ const THINKING_SUPPRESSED_OPERATIONS: ReadonlySet<string> = new Set([
   "hourly_summary_extended",
 ]);
 
-interface LocalServerConfig {
+export interface LocalServerConfig {
   type: LocalLlmType;
   defaultPort: number;
   healthEndpoint: string;
@@ -168,20 +168,21 @@ interface LocalServerConfig {
   detectFn: (response: unknown) => boolean;
 }
 
+// LiteLLM must be recognised before the llama.cpp / vLLM probes: on a LiteLLM
+// proxy `GET /health` runs a live completion against EVERY deployment in its
+// pool, so a once-a-minute 2 s probe turns into a permanent load generator on
+// the backends (4,600 probe completions in 12 h observed). `GET /` is
+// auth-gated on LiteLLM and answers the JSON string "LiteLLM: RUNNING".
+const LITELLM_SERVER: LocalServerConfig = {
+  type: "litellm",
+  defaultPort: 4000,
+  healthEndpoint: "/",
+  modelsEndpoint: "/v1/models",
+  detectFn: (resp) => typeof resp === "string" && resp.includes("LiteLLM"),
+};
+
 const LOCAL_SERVERS: LocalServerConfig[] = [
-  // LiteLLM must be recognised before the llama.cpp probe: on a LiteLLM proxy
-  // `GET /health` runs a live completion against EVERY deployment in its
-  // pool, so a once-a-minute 2 s probe turns into a permanent load
-  // generator on the backends (4,600 probe completions in 12 h observed).
-  // `GET /` is auth-gated on LiteLLM and answers the JSON string
-  // "LiteLLM: RUNNING".
-  {
-    type: "litellm",
-    defaultPort: 4000,
-    healthEndpoint: "/",
-    modelsEndpoint: "/v1/models",
-    detectFn: (resp) => typeof resp === "string" && resp.includes("LiteLLM"),
-  },
+  LITELLM_SERVER,
   {
     type: "ollama",
     defaultPort: 11434,
@@ -219,17 +220,24 @@ const LOCAL_SERVERS: LocalServerConfig[] = [
   },
 ];
 
-function orderedLocalServers(configuredBaseUrl: string): LocalServerConfig[] {
+/**
+ * Probe order for a configured base URL. Entries whose default port matches
+ * the URL's explicit port go first, except that the LiteLLM entry always
+ * leads: its `GET /` probe is harmless on every server shape, while the
+ * llama.cpp / vLLM `GET /health` probe is a pool-wide completion on LiteLLM.
+ * Exported for tests.
+ */
+export function orderedLocalServers(configuredBaseUrl: string): LocalServerConfig[] {
   const configuredPort = explicitPortFromUrl(configuredBaseUrl);
   if (configuredPort === null) return LOCAL_SERVERS;
-  const matching = LOCAL_SERVERS.filter(
-    (serverConfig) => serverConfig.defaultPort === configuredPort,
-  );
+  const rest = LOCAL_SERVERS.filter((serverConfig) => serverConfig !== LITELLM_SERVER);
+  const matching = rest.filter((serverConfig) => serverConfig.defaultPort === configuredPort);
   if (matching.length === 0) return LOCAL_SERVERS;
   const matchingTypes = new Set(matching.map((serverConfig) => serverConfig.type));
   return [
+    LITELLM_SERVER,
     ...matching,
-    ...LOCAL_SERVERS.filter((serverConfig) => !matchingTypes.has(serverConfig.type)),
+    ...rest.filter((serverConfig) => !matchingTypes.has(serverConfig.type)),
   ];
 }
 


### PR DESCRIPTION
## Summary

`LocalLlmClient.probeAvailability` walks `GET /`, `GET /health`, `GET /v1/models` (plus LM Studio native paths) once a minute per client with a 2 s timeout. On a LiteLLM proxy, `GET /health` runs a live completion against **every deployment in its pool**, and the client's 2 s abort does not cancel that server-side work. With two daemons (primary + failover) pointed at one LiteLLM VIP, the proxy's spend logs showed 4,615 `litellm-internal-health-check` completions in 12 h (491k since July): every backend, every 1–3 minutes. On single-concurrency Mac engines that was 82% of all requests, a permanently full scheduler queue, 8-token replies in 240–500 s, and `lcm-summarize` / extraction calls from the same daemons timing out behind their own probes.

This adds a `litellm` server shape that matches the `"LiteLLM: RUNNING"` body of `GET /` and sits ahead of the llama.cpp probe, so a LiteLLM base URL is classified before `/health` is ever requested. Each probe URL is now fetched once per detection pass, so the Ollama check (also `GET /`) reuses that response instead of adding a request.

`litellm` is deliberately not in `THINKING_COMPATIBLE_BACKENDS`: whether `chat_template_kwargs` survives depends on the proxy's `drop_params` and per-deployment `extra_body`, so it keeps the fail-open behavior these URLs already had when they were classified as `mlx`.

## Type of change

- [x] Bug fix

## Validation

- [x] `tsc --noEmit -p packages/remnic-core/tsconfig.json` clean
- [x] `packages/remnic-core`: `local-llm-probe-litellm.test.ts` + `local-llm-headers-timeout.test.ts` + `local-llm-thinking.test.ts`: 35/35. The new test fails on `main` (`actual: 'mlx'`, `/health` requested) and passes with the fix.
- [x] `bash scripts/check-review-patterns.sh` PASSED
- [x] Added tests for behavior change
- [ ] `npm run review:cursor` not run (not available in this environment)

## Changelog

- [x] Added under `## [Unreleased]`

## Risk assessment

Low. Only affects backend-type classification for URLs whose `GET /` returns a string containing `LiteLLM`; all other shapes probe in the same order as before. Production evidence: the same load disappeared on the live router when `/health` was made a no-op server-side (0 probe completions after the change, backend queues 33 → 1–3 connections), which is what this PR fixes at the client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for detecting LiteLLM local backends through the root endpoint, including deployments not using the default port.
  - LiteLLM detection is prioritized ahead of other local backend checks.

- **Bug Fixes**
  - Prevented availability checks from triggering unnecessary live completions through LiteLLM health endpoints.
  - Avoided duplicate requests when multiple backend configurations share the same endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->