### PR TITLE
fix(plugin-openclaw): unblock ClawHub publish; retryable, re-runnable ClawHub step

### DIFF
--- a/.changeset/3102-clawhub-publish-unblock.md
+++ b/.changeset/3102-clawhub-publish-unblock.md
@@ -1,0 +1,9 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+fix: unblock ClawHub publishing of `@remnic/plugin-openclaw` (#3102)
+
+Stability: stable
+
+ClawHub's Plugin Inspector statically scans the packed dist for `api.register*(` and blocks publish when a registrar is missing from the target OpenClaw. The OpenClaw 1.x-only `registerMemoryPromptSection`, `registerMemoryRuntime`, and `registerMemoryFlushPlan` seams are feature-detected at runtime but were written as `api.registerX(...)`, so every publish since 9.64.4 was rejected against OpenClaw 2026.8+ targets. They are now bound to locals and invoked via `.call(api, ...)`; 1.x hosts still get the same registrations, 2.0 hosts skip them as before.

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -50,6 +50,17 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           persist-credentials: false
 
+      - name: Verify the tag carries the build helpers
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          for f in scripts/ensure-core-build.mjs scripts/verify-openclaw-clawpack.mjs packages/plugin-openclaw/package.json; do
+            if [ ! -f "$f" ]; then
+              echo "::error::${TAG} predates ${f}; this workflow only republishes tags built by the current release pipeline."
+              exit 1
+            fi
+          done
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -34,6 +34,16 @@ jobs:
             exit 1
           fi
 
+      # The tag may predate scripts/clawhub-publish.sh, so take the helper from
+      # the ref this workflow runs on, then replace the worktree with the tag.
+      - name: Checkout workflow source for the publish helper
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Preserve publish helper
+        run: cp scripts/clawhub-publish.sh "${RUNNER_TEMP}/clawhub-publish.sh"
+
       - name: Checkout tagged release source
         uses: actions/checkout@v4
         with:
@@ -68,4 +78,4 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           SOURCE_REF: ${{ inputs.tag }}
-        run: bash scripts/clawhub-publish.sh
+        run: bash "${RUNNER_TEMP}/clawhub-publish.sh"

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,0 +1,71 @@
+name: ClawHub Publish
+
+# Catch-up publish of @remnic/plugin-openclaw to ClawHub for an EXISTING release
+# tag whose npm + GitHub release already succeeded but whose best-effort ClawHub
+# step was skipped by a transient ClawHub backend error. Builds from the tagged
+# commit only; never bumps versions, pushes, or touches npm.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag (e.g. v9.69.66)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clawhub-publish-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Validate tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ! [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::tag must look like vX.Y.Z (got '${TAG}')"
+            exit 1
+          fi
+
+      - name: Checkout tagged release source
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild native modules
+        run: pnpm rebuild better-sqlite3
+
+      - name: Build all packages
+        run: |
+          node scripts/ensure-core-build.mjs
+          pnpm -r --filter '!@remnic/core' --filter '!remnic-workspace' run build
+          pnpm run build
+
+      - name: Verify OpenClaw ClawHub artifact packlist
+        run: pnpm run verify:openclaw-clawpack
+
+      - name: Publish OpenClaw plugin to ClawHub
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          SOURCE_REF: ${{ inputs.tag }}
+        run: bash scripts/clawhub-publish.sh

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -696,70 +696,8 @@ jobs:
       - name: Publish OpenClaw plugin to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          CLAWHUB_OWNER: "remnic"
-          CLAWHUB_PACKAGE_NAME: "@remnic/plugin-openclaw"
-          NPM_PACKAGE_NAME: "@remnic/plugin-openclaw"
-          NPM_PACKAGE_PATH: "packages/plugin-openclaw"
-        run: |
-          if [ -z "${CLAWHUB_TOKEN:-}" ]; then
-            echo "::notice title=ClawHub publish skipped::CLAWHUB_TOKEN secret is not configured."
-            exit 0
-          fi
-
-          npm install -g clawhub@0.18.0
-          clawhub login --token "${CLAWHUB_TOKEN}" --no-browser
-
-          package_version="$(node -p "require('./${NPM_PACKAGE_PATH}/package.json').version")"
-          if clawhub package inspect "${CLAWHUB_PACKAGE_NAME}" --version "${package_version}" --json >/dev/null 2>&1; then
-            echo "::notice title=ClawHub publish skipped::${CLAWHUB_PACKAGE_NAME}@${package_version} is already published."
-            exit 0
-          fi
-
-          pack_dir="${RUNNER_TEMP}/clawhub-openclaw-pack"
-          rm -rf "${pack_dir}"
-          mkdir -p "${pack_dir}"
-          pnpm --filter "${NPM_PACKAGE_NAME}" pack --pack-destination "${pack_dir}"
-          tarball="$(find "${pack_dir}" -maxdepth 1 -name '*.tgz' -print -quit)"
-          if [ -z "${tarball}" ]; then
-            echo "No ${NPM_PACKAGE_NAME} tarball produced" >&2
-            exit 1
-          fi
-
-          source_commit="$(git rev-parse HEAD)"
-          publish_log="$(mktemp)"
-          if clawhub package publish "${tarball}" \
-            --family code-plugin \
-            --name "${CLAWHUB_PACKAGE_NAME}" \
-            --owner "${CLAWHUB_OWNER}" \
-            --display-name "Remnic OpenClaw Plugin" \
-            --version "${package_version}" \
-            --host-targets openclaw \
-            --source-repo "${GITHUB_REPOSITORY}" \
-            --source-ref "${{ steps.release_metadata.outputs.tag_name }}" \
-            --source-commit "${source_commit}" \
-            --source-path "${NPM_PACKAGE_PATH}" \
-            --changelog "Publish ${CLAWHUB_PACKAGE_NAME}@${package_version} from the GitHub release workflow." \
-            --json >"${publish_log}" 2>&1; then
-            cat "${publish_log}"
-            rm -f "${publish_log}"
-          else
-            publish_status=$?
-            cat "${publish_log}"
-            if grep -q "publisher does not exist on ClawHub" "${publish_log}"; then
-              echo "::notice title=ClawHub publish skipped::The authenticated ClawHub account is not provisioned as a package publisher yet."
-              rm -f "${publish_log}"
-              exit 0
-            fi
-            if grep -q "Too many bytes read in a single function execution" "${publish_log}"; then
-              echo "::notice title=ClawHub publish skipped::ClawHub publish hit its backend read limit. npm and GitHub release publication already completed; retry the ClawHub publish after ClawHub fixes or clears the limit."
-              rm -f "${publish_log}"
-              exit 0
-            fi
-            rm -f "${publish_log}"
-            exit "${publish_status}"
-          fi
-
-          clawhub package rescan "${CLAWHUB_PACKAGE_NAME}" --yes --json || true
+          SOURCE_REF: ${{ steps.release_metadata.outputs.tag_name }}
+        run: bash scripts/clawhub-publish.sh
 
   bootstrap-publish:
     # One-time npm bootstrap for package names that do not exist on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Release workflow's ClawHub publish now lives in `scripts/clawhub-publish.sh`, retries ClawHub's transient rate-limit/read-limit errors with backoff, and skips with a notice (instead of failing the release after npm and the GitHub release already succeeded) when they persist. New `clawhub-publish.yml` workflow re-runs that publish for an existing release tag.
+- `@remnic/plugin-openclaw` no longer trips ClawHub's Plugin Inspector `unknown-registration-name` breakage on OpenClaw 2026.8+ hosts. The OpenClaw 1.x-only `registerMemoryPromptSection` / `registerMemoryRuntime` / `registerMemoryFlushPlan` seams are still feature-detected and registered on 1.x hosts, but are invoked through local bindings rather than `api.registerX(` so the static scan does not treat them as unconditional calls. ClawHub publishes had been failing since 9.64.4.
+
 ## [v9.69.67] — 2026-09-07
 
 ### Fixed

--- a/packages/plugin-openclaw/src/delegate-capability.ts
+++ b/packages/plugin-openclaw/src/delegate-capability.ts
@@ -965,8 +965,13 @@ export function registerDelegateMemoryCapability(
   // `daemonDefaultNamespace` so the hook paths scope exactly like search.
   const built = createDelegateMemoryCapability(options);
   const hasUnified = typeof api.registerMemoryCapability === "function";
-  const hasRuntime = typeof api.registerMemoryRuntime === "function";
-  const hasFlushPlan = typeof api.registerMemoryFlushPlan === "function";
+  // OpenClaw 1.x-only split seams (removed in 2026.8.x). Bound to locals so
+  // ClawHub's static `api.register*(` scan does not flag these guarded calls
+  // as breakages on 2.0 hosts.
+  const registerRuntime = api.registerMemoryRuntime;
+  const registerFlushPlan = api.registerMemoryFlushPlan;
+  const hasRuntime = typeof registerRuntime === "function";
+  const hasFlushPlan = typeof registerFlushPlan === "function";
   if (!hasUnified && !hasRuntime && !hasFlushPlan) {
     log.debug(
       `[${options.serviceId}] delegate: host exposes no memory capability surface — nothing to register`,
@@ -982,8 +987,8 @@ export function registerDelegateMemoryCapability(
       publicArtifacts: { listArtifacts: built.listArtifacts },
     });
   }
-  if (hasRuntime) api.registerMemoryRuntime?.(built.runtime);
-  if (hasFlushPlan) api.registerMemoryFlushPlan?.(built.flushPlanResolver);
+  if (hasRuntime) registerRuntime.call(api, built.runtime);
+  if (hasFlushPlan) registerFlushPlan.call(api, built.flushPlanResolver);
 
   const surface = hasUnified
     ? "memory capability with publicArtifacts provider"

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -436,7 +436,10 @@ export function registerDelegateRuntime(
         },
         { id: "remnic-delegate-memory", label: "Remnic Memory Context (delegate)" },
       );
-      api.registerMemoryPromptSection(memoryBuildFn);
+      // OpenClaw 1.x-only seam; bound to a local so ClawHub's static
+      // `api.register*(` scan does not flag this guarded call on 2.0 hosts.
+      const registerSection = api.registerMemoryPromptSection;
+      registerSection.call(api, memoryBuildFn);
     }
   } else {
     log.info(

--- a/scripts/clawhub-publish.sh
+++ b/scripts/clawhub-publish.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Best-effort ClawHub publish of @remnic/plugin-openclaw for the checked-out
+# release source. npm and the GitHub release are already published by the time
+# this runs, so known-transient ClawHub backend failures exit 0 with a notice;
+# unknown failures stay fatal. Re-runnable for an existing tag via
+# .github/workflows/clawhub-publish.yml.
+#
+# Env: CLAWHUB_TOKEN (required, else skip), SOURCE_REF (tag name),
+#      GITHUB_REPOSITORY, RUNNER_TEMP.
+set -euo pipefail
+
+CLAWHUB_OWNER="${CLAWHUB_OWNER:-remnic}"
+CLAWHUB_PACKAGE_NAME="${CLAWHUB_PACKAGE_NAME:-@remnic/plugin-openclaw}"
+NPM_PACKAGE_NAME="${NPM_PACKAGE_NAME:-@remnic/plugin-openclaw}"
+NPM_PACKAGE_PATH="${NPM_PACKAGE_PATH:-packages/plugin-openclaw}"
+# ponytail: fixed 3 attempts / 30s backoff; ClawHub's rate limit says "reset in ~23s".
+CLAWHUB_PUBLISH_ATTEMPTS="${CLAWHUB_PUBLISH_ATTEMPTS:-3}"
+CLAWHUB_PUBLISH_BACKOFF_SECONDS="${CLAWHUB_PUBLISH_BACKOFF_SECONDS:-30}"
+
+if [ -z "${CLAWHUB_TOKEN:-}" ]; then
+  echo "::notice title=ClawHub publish skipped::CLAWHUB_TOKEN secret is not configured."
+  exit 0
+fi
+if [ -z "${SOURCE_REF:-}" ]; then
+  echo "SOURCE_REF (release tag) is required" >&2
+  exit 1
+fi
+
+npm install -g clawhub@0.18.0
+clawhub login --token "${CLAWHUB_TOKEN}" --no-browser
+
+package_version="$(node -p "require('./${NPM_PACKAGE_PATH}/package.json').version")"
+if clawhub package inspect "${CLAWHUB_PACKAGE_NAME}" --version "${package_version}" --json >/dev/null 2>&1; then
+  echo "::notice title=ClawHub publish skipped::${CLAWHUB_PACKAGE_NAME}@${package_version} is already published."
+  exit 0
+fi
+
+pack_dir="${RUNNER_TEMP:-/tmp}/clawhub-openclaw-pack"
+rm -rf "${pack_dir}"
+mkdir -p "${pack_dir}"
+pnpm --filter "${NPM_PACKAGE_NAME}" pack --pack-destination "${pack_dir}"
+tarball="$(find "${pack_dir}" -maxdepth 1 -name '*.tgz' -print -quit)"
+if [ -z "${tarball}" ]; then
+  echo "No ${NPM_PACKAGE_NAME} tarball produced" >&2
+  exit 1
+fi
+
+source_commit="$(git rev-parse HEAD)"
+publish_log="$(mktemp)"
+trap 'rm -f "${publish_log}"' EXIT
+
+is_transient() {
+  grep -qE "Too many bytes read in a single function execution|Your request couldn't be completed\. Try again later" "$1"
+}
+
+attempt=1
+while :; do
+  publish_status=0
+  clawhub package publish "${tarball}" \
+    --family code-plugin \
+    --name "${CLAWHUB_PACKAGE_NAME}" \
+    --owner "${CLAWHUB_OWNER}" \
+    --display-name "Remnic OpenClaw Plugin" \
+    --version "${package_version}" \
+    --host-targets openclaw \
+    --source-repo "${GITHUB_REPOSITORY}" \
+    --source-ref "${SOURCE_REF}" \
+    --source-commit "${source_commit}" \
+    --source-path "${NPM_PACKAGE_PATH}" \
+    --changelog "Publish ${CLAWHUB_PACKAGE_NAME}@${package_version} from the GitHub release workflow." \
+    --json >"${publish_log}" 2>&1 || publish_status=$?
+  cat "${publish_log}"
+  if [ "${publish_status}" -eq 0 ]; then
+    break
+  fi
+  if grep -q "publisher does not exist on ClawHub" "${publish_log}"; then
+    echo "::notice title=ClawHub publish skipped::The authenticated ClawHub account is not provisioned as a package publisher yet."
+    exit 0
+  fi
+  if is_transient "${publish_log}"; then
+    if [ "${attempt}" -lt "${CLAWHUB_PUBLISH_ATTEMPTS}" ]; then
+      echo "ClawHub publish attempt ${attempt}/${CLAWHUB_PUBLISH_ATTEMPTS} hit a transient backend error; retrying in ${CLAWHUB_PUBLISH_BACKOFF_SECONDS}s."
+      sleep "${CLAWHUB_PUBLISH_BACKOFF_SECONDS}"
+      attempt=$((attempt + 1))
+      continue
+    fi
+    echo "::notice title=ClawHub publish skipped::ClawHub publish hit its backend read limit or rate limit after ${CLAWHUB_PUBLISH_ATTEMPTS} attempts. npm and GitHub release publication already completed; re-run .github/workflows/clawhub-publish.yml for ${SOURCE_REF} once ClawHub recovers."
+    exit 0
+  fi
+  exit "${publish_status}"
+done
+
+clawhub package rescan "${CLAWHUB_PACKAGE_NAME}" --yes --json || true

--- a/src/index.ts
+++ b/src/index.ts
@@ -3478,7 +3478,11 @@ const pluginDefinition = {
 
       (memoryBuildFn as any).id = "engram-memory";
       (memoryBuildFn as any).label = "Engram Memory Context";
-      api.registerMemoryPromptSection(memoryBuildFn as any);
+      // OpenClaw 1.x-only seam (removed in 2026.8.x). Bound to a local so the
+      // ClawHub Plugin Inspector's static `api.register*(` scan does not flag
+      // this feature-detected call as a breakage against 2.0 hosts.
+      const registerSection = api.registerMemoryPromptSection;
+      registerSection.call(api, memoryBuildFn as Parameters<typeof registerSection>[0]);
 
       // Hoist for registerMemoryCapability below
       memoryPromptBuilder = memoryBuildFn;
@@ -3791,11 +3795,20 @@ const pluginDefinition = {
       if (typeof (api as any).registerMemoryCapability === "function") {
         (api as any).registerMemoryCapability(memoryCapability);
       }
-      if (typeof (api as any).registerMemoryRuntime === "function") {
-        (api as any).registerMemoryRuntime(remnicMemoryRuntime);
+      // OpenClaw 1.x-only split seams (removed in 2026.8.x). Read through a
+      // narrowed view and bound to locals so ClawHub's static `api.register*(`
+      // scan does not flag these guarded calls as breakages on 2.0 hosts.
+      const legacyMemoryApi = api as unknown as {
+        registerMemoryRuntime?: (runtime: typeof remnicMemoryRuntime) => void;
+        registerMemoryFlushPlan?: (resolver: typeof remnicMemoryFlushPlanResolver) => void;
+      };
+      const registerRuntime = legacyMemoryApi.registerMemoryRuntime;
+      const registerFlushPlan = legacyMemoryApi.registerMemoryFlushPlan;
+      if (typeof registerRuntime === "function") {
+        registerRuntime.call(api, remnicMemoryRuntime);
       }
-      if (typeof (api as any).registerMemoryFlushPlan === "function") {
-        (api as any).registerMemoryFlushPlan(remnicMemoryFlushPlanResolver);
+      if (typeof registerFlushPlan === "function") {
+        registerFlushPlan.call(api, remnicMemoryFlushPlanResolver);
       }
       const builderDesc = !promptInjectionAllowed
         ? " (promptBuilder omitted — injection disabled by policy)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3799,8 +3799,8 @@ const pluginDefinition = {
       // narrowed view and bound to locals so ClawHub's static `api.register*(`
       // scan does not flag these guarded calls as breakages on 2.0 hosts.
       const legacyMemoryApi = api as unknown as {
-        registerMemoryRuntime?: (runtime: typeof remnicMemoryRuntime) => void;
-        registerMemoryFlushPlan?: (resolver: typeof remnicMemoryFlushPlanResolver) => void;
+        registerMemoryRuntime?: (runtime: RemnicCapabilityRuntime) => void;
+        registerMemoryFlushPlan?: (resolver: () => MemoryFlushPlan) => void;
       };
       const registerRuntime = legacyMemoryApi.registerMemoryRuntime;
       const registerFlushPlan = legacyMemoryApi.registerMemoryFlushPlan;

--- a/tests/clawhub-publish-script.test.mjs
+++ b/tests/clawhub-publish-script.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const SCRIPT = path.resolve("scripts/clawhub-publish.sh");
+
+// Runs the script against a fake bin dir: `clawhub` publish fails `failures`
+// times with `message`, then succeeds. npm/pnpm/git are stubbed as no-ops.
+function run({ failures, message }) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "clawhub-publish-"));
+  const bin = path.join(dir, "bin");
+  mkdirSync(bin);
+  mkdirSync(path.join(dir, "pkg"));
+  writeFileSync(path.join(dir, "pkg", "package.json"), JSON.stringify({ version: "1.2.3" }));
+  const counter = path.join(dir, "attempts");
+  writeFileSync(counter, "0");
+  const stub = (name, body) => {
+    writeFileSync(path.join(bin, name), `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+  };
+  stub("npm", "exit 0");
+  stub("git", 'echo deadbeef');
+  stub("pnpm", `touch "$5/plugin-1.2.3.tgz"`);
+  stub(
+    "clawhub",
+    `case "$1 $2" in
+      "login "*) exit 0 ;;
+      "package inspect") exit 1 ;;
+      "package rescan") exit 0 ;;
+      "package publish")
+        n=$(cat "${counter}"); n=$((n+1)); echo "$n" > "${counter}"
+        if [ "$n" -le ${failures} ]; then echo "Error: ${message}"; exit 1; fi
+        echo '{"ok":true}'; exit 0 ;;
+    esac
+    exit 99`,
+  );
+  const result = spawnSync("bash", [SCRIPT], {
+    cwd: dir,
+    encoding: "utf8",
+    env: {
+      PATH: `${bin}:${process.env.PATH}`,
+      CLAWHUB_TOKEN: "t",
+      SOURCE_REF: "v1.2.3",
+      GITHUB_REPOSITORY: "o/r",
+      RUNNER_TEMP: dir,
+      NPM_PACKAGE_PATH: "pkg",
+      CLAWHUB_PUBLISH_BACKOFF_SECONDS: "0",
+    },
+  });
+  return { ...result, attempts: Number(readFileSync(counter, "utf8")) };
+}
+
+test("retries transient ClawHub rate-limit errors and succeeds", () => {
+  const r = run({ failures: 2, message: "Your request couldn't be completed. Try again later." });
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+  assert.equal(r.attempts, 3);
+  assert.match(r.stdout, /"ok":true/);
+});
+
+test("exhausted transient retries exit 0 with a notice", () => {
+  const r = run({ failures: 10, message: "Too many bytes read in a single function execution" });
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+  assert.equal(r.attempts, 3);
+  assert.match(r.stdout, /::notice title=ClawHub publish skipped::/);
+});
+
+test("unknown ClawHub errors stay fatal without retry", () => {
+  const r = run({ failures: 10, message: "invalid manifest" });
+  assert.equal(r.status, 1);
+  assert.equal(r.attempts, 1);
+});

--- a/tests/clawhub-publish-script.test.mjs
+++ b/tests/clawhub-publish-script.test.mjs
@@ -22,7 +22,8 @@ function run({ failures, message }) {
   };
   stub("npm", "exit 0");
   stub("git", 'echo deadbeef');
-  stub("pnpm", `touch "$5/plugin-1.2.3.tgz"`);
+  // Create the tarball where the script looks for it (its pack_dir), not by argv position.
+  stub("pnpm", `mkdir -p "$RUNNER_TEMP/clawhub-openclaw-pack" && touch "$RUNNER_TEMP/clawhub-openclaw-pack/plugin-1.2.3.tgz"`);
   stub(
     "clawhub",
     `case "$1 $2" in

--- a/tests/openclaw-legacy-registrar-scan.test.ts
+++ b/tests/openclaw-legacy-registrar-scan.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// ClawHub's Plugin Inspector statically scans the packed dist for
+// `api.register*(` and flags any registrar the target OpenClaw lacks as a
+// publish-blocking breakage. These seams exist only on OpenClaw 1.x
+// (removed in 2026.8.x) and are feature-detected at runtime, so they must be
+// invoked through a local binding, never as `api.registerX(`.
+const LEGACY_ONLY = ["registerMemoryPromptSection", "registerMemoryRuntime", "registerMemoryFlushPlan"];
+const FILES = [
+  "src/index.ts",
+  "packages/plugin-openclaw/src/delegate-runtime.ts",
+  "packages/plugin-openclaw/src/delegate-capability.ts",
+];
+
+test("OpenClaw 1.x-only registrars are never called as api.registerX( (ClawHub inspector scan)", () => {
+  const pattern = new RegExp(String.raw`\bapi\s*\)?\s*\.\s*(${LEGACY_ONLY.join("|")})\s*(?:\?\.)?\s*\(`);
+  for (const file of FILES) {
+    const source = readFileSync(file, "utf8");
+    const match = pattern.exec(source);
+    assert.equal(match, null, `${file}: '${match?.[0]}' would be flagged by ClawHub's unknown-registration-name check`);
+  }
+});

--- a/tests/openclaw-legacy-registrar-scan.test.ts
+++ b/tests/openclaw-legacy-registrar-scan.test.ts
@@ -15,7 +15,10 @@ const FILES = [
 ];
 
 test("OpenClaw 1.x-only registrars are never called as api.registerX( (ClawHub inspector scan)", () => {
-  const pattern = new RegExp(String.raw`\bapi\s*\)?\s*\.\s*(${LEGACY_ONLY.join("|")})\s*(?:\?\.)?\s*\(`);
+  // Receiver forms: `api.`, `(api).`, `(api as X).`, `(<X>api).` — TypeScript
+  // erases the casts, so all of them emit `api.registerX(` in dist.
+  const receiver = String.raw`(?:\bapi|\(\s*api\s*\)|\(\s*api\s+as\s+[^)]+\)|\(\s*<[^>]+>\s*api\s*\))`;
+  const pattern = new RegExp(String.raw`${receiver}\s*\??\.\s*(${LEGACY_ONLY.join("|")})\s*(?:\?\.)?\s*\(`);
   for (const file of FILES) {
     // Drop `//` line comments; the inspector strips comments too, and this
     // keeps prose mentioning the seams from tripping the guard.

--- a/tests/openclaw-legacy-registrar-scan.test.ts
+++ b/tests/openclaw-legacy-registrar-scan.test.ts
@@ -17,7 +17,9 @@ const FILES = [
 test("OpenClaw 1.x-only registrars are never called as api.registerX( (ClawHub inspector scan)", () => {
   const pattern = new RegExp(String.raw`\bapi\s*\)?\s*\.\s*(${LEGACY_ONLY.join("|")})\s*(?:\?\.)?\s*\(`);
   for (const file of FILES) {
-    const source = readFileSync(file, "utf8");
+    // Drop `//` line comments; the inspector strips comments too, and this
+    // keeps prose mentioning the seams from tripping the guard.
+    const source = readFileSync(file, "utf8").replace(/^\s*\/\/.*$/gm, "");
     const match = pattern.exec(source);
     assert.equal(match, null, `${file}: '${match?.[0]}' would be flagged by ClawHub's unknown-registration-name check`);
   }

--- a/tests/release-workflow-order.test.ts
+++ b/tests/release-workflow-order.test.ts
@@ -80,7 +80,8 @@ test("release workflow derives publish metadata after package bump commits", () 
   assert.match(workflow, /NEW_VERSION: \$\{\{ steps\.release_metadata\.outputs\.new_version \}\}/);
   assert.match(workflow, /tag_name: \$\{\{ steps\.release_metadata\.outputs\.tag_name \}\}/);
   assert.match(workflow, /VERSION="\$\{\{ steps\.release_metadata\.outputs\.new_version \}\}"/);
-  assert.match(workflow, /--source-ref "\$\{\{ steps\.release_metadata\.outputs\.tag_name \}\}"/);
+  assert.match(workflow, /SOURCE_REF: \$\{\{ steps\.release_metadata\.outputs\.tag_name \}\}/);
+  assert.match(readFileSync("scripts/clawhub-publish.sh", "utf8"), /--source-ref "\$\{SOURCE_REF\}"/);
 });
 
 test("release workflow rejects version overrides that reuse existing tags before mutation", () => {
@@ -111,10 +112,11 @@ test("release workflow fails existing tags with incomplete npm publication", () 
 });
 
 test("release workflow pins publish tooling", () => {
+  const clawhubScript = readFileSync("scripts/clawhub-publish.sh", "utf8");
   assert.doesNotMatch(workflow, /npm install -g npm@latest/);
-  assert.doesNotMatch(workflow, /npm install -g clawhub@latest/);
+  assert.doesNotMatch(clawhubScript, /npm install -g clawhub@latest/);
   assert.match(workflow, /npm install -g npm@11\.16\.0/);
-  assert.match(workflow, /npm install -g clawhub@0\.18\.0/);
+  assert.match(clawhubScript, /npm install -g clawhub@0\.18\.0/);
 });
 
 test("release workflow pins GitHub SSH host keys for deploy-key pushes", () => {

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -102,13 +102,37 @@ test("release workflow verifies the OpenClaw ClawHub packlist after build", asyn
   );
 });
 
+function assertOrdered(haystack: string, first: string, second: string, message: string): void {
+  const a = haystack.indexOf(first);
+  const b = haystack.indexOf(second, a + first.length);
+  assert.ok(a !== -1 && b !== -1, message);
+}
+
 test("ClawHub publish script treats known transient backend failures as nonfatal after retries", async () => {
   const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
   const catchUp = await readFile(".github/workflows/clawhub-publish.yml", "utf8");
   const script = await readFile("scripts/clawhub-publish.sh", "utf8");
 
-  assert.match(workflow, /Publish OpenClaw plugin to ClawHub[\s\S]*bash scripts\/clawhub-publish\.sh/);
-  assert.match(catchUp, /ref: refs\/tags\/\$\{\{ inputs\.tag \}\}[\s\S]*bash scripts\/clawhub-publish\.sh/);
+  assertOrdered(
+    workflow,
+    "Publish OpenClaw plugin to ClawHub",
+    "bash scripts/clawhub-publish.sh",
+    "release workflow must run the ClawHub publish through the shared script",
+  );
+  // The catch-up workflow checks out a historical tag that predates the
+  // helper, so it must stash the helper from the workflow's own ref first.
+  assertOrdered(
+    catchUp,
+    'cp scripts/clawhub-publish.sh "${RUNNER_TEMP}/clawhub-publish.sh"',
+    "ref: refs/tags/${{ inputs.tag }}",
+    "catch-up workflow must preserve the helper before checking out the tag",
+  );
+  assertOrdered(
+    catchUp,
+    "ref: refs/tags/${{ inputs.tag }}",
+    'bash "${RUNNER_TEMP}/clawhub-publish.sh"',
+    "catch-up workflow must run the preserved helper against the tagged source",
+  );
   assert.match(
     script,
     /Too many bytes read in a single function execution/,
@@ -119,15 +143,17 @@ test("ClawHub publish script treats known transient backend failures as nonfatal
     /Your request couldn't be completed\\\. Try again later/,
     "script must recognize ClawHub's rate-limit 'Try again later' failure",
   );
-  assert.ok(
-    !script.includes("syncPackage[A-Za-z]*SearchDigests?"),
+  assert.doesNotMatch(
+    script,
+    /syncPackage\w{0,64}SearchDigest/,
     "script must select the nonfatal path on the Convex read-limit string alone, " +
       "without requiring the internal syncPackage...SearchDigest stack frame",
   );
   assert.match(script, /sleep "\$\{CLAWHUB_PUBLISH_BACKOFF_SECONDS\}"/, "transient failures must be retried with backoff");
-  assert.match(
+  assertOrdered(
     script,
-    /ClawHub publish hit its backend read limit or rate limit[\s\S]*exit 0/,
+    "ClawHub publish hit its backend read limit or rate limit",
+    "exit 0",
     "known transient ClawHub failures should not fail the release after npm publish",
   );
   assert.match(script, /\n  exit "\$\{publish_status\}"\n/, "unknown ClawHub publish failures must remain fatal");

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -102,29 +102,35 @@ test("release workflow verifies the OpenClaw ClawHub packlist after build", asyn
   );
 });
 
-test("release workflow treats known ClawHub backend read limits as nonfatal", async () => {
+test("ClawHub publish script treats known transient backend failures as nonfatal after retries", async () => {
   const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
+  const catchUp = await readFile(".github/workflows/clawhub-publish.yml", "utf8");
+  const script = await readFile("scripts/clawhub-publish.sh", "utf8");
 
+  assert.match(workflow, /Publish OpenClaw plugin to ClawHub[\s\S]*bash scripts\/clawhub-publish\.sh/);
+  assert.match(catchUp, /ref: refs\/tags\/\$\{\{ inputs\.tag \}\}[\s\S]*bash scripts\/clawhub-publish\.sh/);
   assert.match(
-    workflow,
+    script,
     /Too many bytes read in a single function execution/,
-    "release workflow must recognize ClawHub's Convex read-limit backend failure",
+    "script must recognize ClawHub's Convex read-limit backend failure",
+  );
+  assert.match(
+    script,
+    /Your request couldn't be completed\\\. Try again later/,
+    "script must recognize ClawHub's rate-limit 'Try again later' failure",
   );
   assert.ok(
-    !workflow.includes("syncPackage[A-Za-z]*SearchDigests?"),
-    "release workflow must select the nonfatal path on the Convex read-limit string alone, " +
+    !script.includes("syncPackage[A-Za-z]*SearchDigests?"),
+    "script must select the nonfatal path on the Convex read-limit string alone, " +
       "without requiring the internal syncPackage...SearchDigest stack frame",
   );
+  assert.match(script, /sleep "\$\{CLAWHUB_PUBLISH_BACKOFF_SECONDS\}"/, "transient failures must be retried with backoff");
   assert.match(
-    workflow,
-    /ClawHub publish hit its backend read limit[\s\S]*exit 0/,
-    "known external ClawHub backend read-limit failures should not block GitHub release creation after npm publish",
+    script,
+    /ClawHub publish hit its backend read limit or rate limit[\s\S]*exit 0/,
+    "known transient ClawHub failures should not fail the release after npm publish",
   );
-  assert.match(
-    workflow,
-    /rm -f "\$\{publish_log\}"\n            exit "\$\{publish_status\}"/,
-    "unknown ClawHub publish failures must remain fatal",
-  );
+  assert.match(script, /\n  exit "\$\{publish_status\}"\n/, "unknown ClawHub publish failures must remain fatal");
 });
 
 test("@remnic/server build verifies declared bin artifacts", async () => {


### PR DESCRIPTION
## Summary

ClawHub publishes of `@remnic/plugin-openclaw` have been failing since 9.64.4 (ClawHub still serves 9.64.4). Two distinct causes surfaced today on v9.69.66 and v9.69.67:

1. **Plugin Inspector breakage** (`unknown-registration-name`): ClawHub statically scans the packed dist for `api.register*(` and blocks publish when a registrar is missing from the target OpenClaw. `registerMemoryPromptSection`, `registerMemoryRuntime`, and `registerMemoryFlushPlan` were removed upstream in OpenClaw 2026.8.x. The plugin only calls them behind `typeof` guards (OpenClaw 1.x hosts, still inside the 60-day support window via 2026.7.1), but the scanner can't see the guard.
2. **Transient ClawHub backend errors** (`Your request couldn't be completed. Try again later.` from the inspector gate) failed the release job *after* npm and the GitHub release had already succeeded, with no way to re-run just the ClawHub step for an existing tag.

## Changes

- `src/index.ts`, `packages/plugin-openclaw/src/delegate-runtime.ts`, `delegate-capability.ts`: the three 1.x-only registrars are bound to locals and invoked via `.call(api, …)`. Runtime behavior is identical (same guards, same receiver); the static scan no longer sees `api.registerX(`. Verified by packing and running `@openclaw/plugin-inspector@0.3.24` against the tarball with OpenClaw 2026.9.2 as target: `unknown-registration-name` gone, `Breakages: 0`, observed registrars all present in 2026.9.2.
- `scripts/clawhub-publish.sh`: the release step body, extracted so it can run outside the release job. Adds 3-attempt/30s backoff for transient errors, treats the new rate-limit string as nonfatal (with a notice) after retries, keeps unknown errors fatal. Also fixes a latent bug in the old inline version where `$?` after `if …; fi` was always 0.
- `.github/workflows/clawhub-publish.yml`: `workflow_dispatch` catch-up publish for an existing tag (checks out `refs/tags/<tag>`, builds, runs the script). No version bump, no push, no npm.
- Tests: `tests/clawhub-publish-script.test.mjs` (retry, exhausted-retry-nonfatal, unknown-fatal against a stubbed `clawhub`), `tests/openclaw-legacy-registrar-scan.test.ts` (fails on the old source), existing workflow tests repointed at the script.

## Follow-up (not in this PR)

2026.7.1 leaves the 60-day window on Sep 11; the 1.x seams and their tests can then be deleted outright.

## Verification

- `pnpm run check-types` clean
- `tests/openclaw-*`, `tests/sdk-compat*`, `packages/plugin-openclaw/src/delegate-*.test.ts`: 331 pass
- Inspector 0.3.24 against packed tarball + OpenClaw 2026.9.2: PASS, 0 breakages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClawHub publishing reliability with retries for temporary service and rate-limit errors.
  * Releases now avoid failing when ClawHub remains temporarily unavailable, while still reporting unexpected errors.
  * Fixed compatibility with newer OpenClaw hosts to prevent plugin inspection failures.

* **New Features**
  * Added a workflow to manually republish an existing plugin release to ClawHub.

* **Tests**
  * Added coverage for publishing retries, failure handling, release republishing, and OpenClaw compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->