### PR TITLE
fix(core): forward scope-profile write plan from observe to extraction

### DIFF
--- a/.changeset/3051-observe-autopromote.md
+++ b/.changeset/3051-observe-autopromote.md
@@ -1,0 +1,14 @@
+---
+"@remnic/core": patch
+---
+
+Stability: stable
+
+Fix autoPromote never firing for HTTP/MCP `observe` (issue #3051). The observe
+write surface resolved `scopeProfilePlan` but only forwarded
+`writeNamespaceOverride` and `principalOverride` to `ingestReplayBatch`, so
+`runExtraction` saw an explicit write namespace with no plan and every
+promotion gate returned false. Observe now forwards
+`scopeProfileWritePlan: scope.scopeProfilePlan` (mirroring force-flush), and
+`ingestReplayBatch` accepts and forwards it to `queueBufferedExtraction`.
+Namespaces-disabled single-store behavior is unchanged (plan omitted).

--- a/packages/remnic-core/src/access-observe-write-surface.ts
+++ b/packages/remnic-core/src/access-observe-write-surface.ts
@@ -864,14 +864,10 @@ export class AccessObserveWriteSurface {
         const principalOverride =
           typeof scope.principal === "string" && scope.principal.length > 0 ? scope.principal : undefined;
         // Fire-and-forget: queue extraction in the background so the HTTP
-        // response returns immediately. LCM archival (above) is also
-        // enqueue-only; extraction involves LLM calls that can take
-        // minutes under load and should not block the caller.
+        // response returns immediately; extraction LLM calls can take minutes.
         //
-        // Backpressure: the orchestrator's own extraction queue already
-        // limits concurrency (one extraction at a time per session via
-        // queueBufferedExtraction). Fire-and-forget here just decouples
-        // the HTTP response from the queue drain.
+        // Backpressure: the orchestrator's queue limits extraction concurrency
+        // (one per session); this just decouples the HTTP response from the drain.
         if (!observePreparation.isCancelled()) {
           try {
             const observeAbortController = new AbortController();
@@ -879,6 +875,7 @@ export class AccessObserveWriteSurface {
               archiveLcm: false,
               writeNamespaceOverride,
               principalOverride,
+              scopeProfileWritePlan: scope.scopeProfilePlan,
               abortSignal: observeAbortController.signal,
               ...(typeof request.authenticatedPrincipal === "string" && request.authenticatedPrincipal.trim().length > 0
                 ? { sessionOwnerPrincipal: request.authenticatedPrincipal.trim() }

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -37,6 +37,7 @@ import { PendingObserveExtractionTracker } from "./access-observe-helpers.js";
 
 import { tokenCapabilityStore } from "./access-token-capabilities.js";
 import { resolveAuthorizedNamespaceWritablePreflight } from "./access-namespace-preflight.js";
+import type { ResolvedScopeProfilePlan } from "./namespaces/scope-profiles.js";
 import { Orchestrator } from "./orchestrator.js";
 import type { StorageManager } from "./storage.js";
 import type { EngramAccessObserveRequest } from "./access-service.js";
@@ -67,6 +68,7 @@ interface ObserveProbe {
     sessionKeys: string[];
     writeNamespaceOverride?: string;
     principalOverride?: string;
+    scopeProfileWritePlan?: ResolvedScopeProfilePlan | null;
   }>;
   objectiveStateNamespaces: string[];
 }
@@ -125,12 +127,17 @@ function makeObserveProbe(overrides: Partial<PluginConfig> = {}): ObserveProbe {
     },
     ingestReplayBatch: async (
       turns: Array<{ sessionKey: string }>,
-      options: { writeNamespaceOverride?: string; principalOverride?: string } = {},
+      options: {
+        writeNamespaceOverride?: string;
+        principalOverride?: string;
+        scopeProfileWritePlan?: ResolvedScopeProfilePlan | null;
+      } = {},
     ) => {
       extractionCalls.push({
         sessionKeys: turns.map((t) => t.sessionKey),
         writeNamespaceOverride: options.writeNamespaceOverride,
         principalOverride: options.principalOverride,
+        scopeProfileWritePlan: options.scopeProfileWritePlan,
       });
     },
   } as unknown as Orchestrator;
@@ -1212,4 +1219,64 @@ test("#1501 memorySearch collection names stay constrained to active scope profi
     /collection is not namespace-scoped/,
   );
   assert.equal(searchedNamespaces, null);
+});
+
+test("#3051 observe forwards the resolved scope-profile write plan to extraction (autoPromote userGlobal)", async () => {
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      { name: "pi-observer", readPrincipals: ["pi-observer"], writePrincipals: ["pi-observer"] },
+      { name: "pi-observer-global", readPrincipals: ["pi-observer"], writePrincipals: ["pi-observer"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-observer:", principal: "pi-observer" }],
+    scopeProfiles: {
+      userGlobalProfile: {
+        readOrder: ["userGlobal"],
+        writeDefault: "userGlobal",
+        promotionTargets: ["userGlobal"],
+        userGlobal: { namespaceTemplate: "pi-observer-global" },
+        autoPromote: {
+          enabled: true,
+          targets: ["userGlobal"],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
+      },
+    },
+    defaultScopeProfile: "userGlobalProfile",
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({
+      sessionKey: "pi-observer:abc123",
+      authenticatedPrincipal: "pi-observer",
+    }),
+  );
+
+  assert.ok(probe.extractionCalls.length >= 1);
+  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, res.effectiveNamespace);
+  assert.ok(
+    probe.extractionCalls[0].scopeProfileWritePlan,
+    "namespaces ON + scope profile: ingestReplayBatch must receive the resolved plan, or autoPromote gates never fire",
+  );
+  assert.equal(probe.extractionCalls[0].scopeProfileWritePlan?.profileId, "userGlobalProfile");
+  assert.equal(probe.extractionCalls[0].scopeProfileWritePlan?.writeNamespace, res.effectiveNamespace);
+});
+
+test("#3051 observe omits the scope-profile write plan when namespaces are disabled", async () => {
+  const probe = makeObserveProbe({
+    namespacesEnabled: false,
+    namespacePolicies: [],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(observeRequest({}));
+
+  assert.ok(probe.extractionCalls.length >= 1);
+  assert.equal(
+    probe.extractionCalls[0].scopeProfileWritePlan,
+    undefined,
+    "single-store mode must not receive a scope-profile write plan",
+  );
 });

--- a/packages/remnic-core/src/orchestration/turn-ingestion.ts
+++ b/packages/remnic-core/src/orchestration/turn-ingestion.ts
@@ -238,6 +238,12 @@ export class TurnIngestionCoordinator {
        */
       principalOverride?: string;
       /**
+       * Forward the observe surface's resolved scope-profile write plan so
+       * autoPromote gates see a plan instead of treating "explicit write
+       * namespace, no plan" as non-promotable (#3051). Mirrors force-flush.
+       */
+      scopeProfileWritePlan?: ResolvedScopeProfilePlan | null;
+      /**
        * Persist the authenticated principal that owns the replay session.
        * Access observe supplies this from the transport auth boundary; replay
        * and import callers leave it unset.
@@ -335,6 +341,7 @@ export class TurnIngestionCoordinator {
               abortSignal: options.abortSignal,
               writeNamespaceOverride: options.writeNamespaceOverride,
               principalOverride: options.principalOverride,
+              scopeProfileWritePlan: options.scopeProfileWritePlan,
               onTaskSettled: (err) => (err ? reject(err) : resolve()),
             }).catch(reject);
           }),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2987,6 +2987,8 @@ export class Orchestrator {
        * `principalOverride` (issue #570 PR 4).
        */
       principalOverride?: string;
+      /** Forward the observe surface's resolved scope-profile write plan (#3051). */
+      scopeProfileWritePlan?: ResolvedScopeProfilePlan | null;
       /** Persist the authenticated session owner on buffered turns. */
       sessionOwnerPrincipal?: string;
     } = {},


### PR DESCRIPTION
Fixes #3051

## Reproducing config shape

A scope profile with `autoPromote.enabled: true` and `autoPromote.targets: ["userGlobal"]`, namespaces enabled, observe via HTTP/MCP. `resolveMemoryScopePlan` produced `scope.scopeProfilePlan`, but the observe write surface only forwarded `writeNamespaceOverride` + `principalOverride` into `ingestReplayBatch`. `runExtraction` then saw explicit write namespace + no plan, so `scopeProfileWritePlan = null` and every promotion gate returned false — silently.

## Change (two hops, mirroring force-flush)

1. `access-observe-write-surface.ts`: pass `scopeProfileWritePlan: scope.scopeProfilePlan` into `ingestReplayBatch`.
2. `orchestration/turn-ingestion.ts`: add the option to `ingestReplayBatch` and forward it at the `queueBufferedExtraction(..., "trigger_mode", ...)` call (plus the matching `Orchestrator.ingestReplayBatch` wrapper option type). `queueBufferedExtraction` already forwarded the plan to `runExtraction`.

## Tests

- Regression in `access-service-observe-scope.test.ts`: namespaces on + autoPromote userGlobal profile asserts the plan is forwarded to the extraction probe (verified to fail without the hops); namespaces-disabled case asserts the plan stays omitted.
- Changeset for `@remnic/core`, Stability: stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed HTTP/MCP `observe` auto-promotion when an explicit write namespace is used without a previously defined plan.
  - Ensured the resolved write plan is preserved during background extraction.
  - Kept existing behavior unchanged when namespaces are disabled.
  - This improves reliable promotion of observed data under supported namespace configurations.

- **Tests**
  - Added coverage for auto-promotion with namespaces enabled and for unchanged behavior when namespaces are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->