### PR TITLE
fix(core): drop deep-recall seed hits that fail memory resolution

### DIFF
--- a/.changeset/3087-deep-recall-seed-resolve-miss.md
+++ b/.changeset/3087-deep-recall-seed-resolve-miss.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Stability: stable
+
+Deep-recall seed search now drops a hit when its path fails to resolve to a stored memory instead of falling back to the search backend's bare docid. A docid can name a document in a foreign collection, so it must never enter the deep-recall working set as a resolved memory id. Index-unavailable failures still report `backend_unavailable` as before. Fixes #3087.

--- a/packages/remnic-core/src/deep-recall-seeds.test.ts
+++ b/packages/remnic-core/src/deep-recall-seeds.test.ts
@@ -51,3 +51,38 @@ test("seed search forwards the cancellation signal and the capped limit to the r
   assert.equal(captured?.execution?.signal, controller.signal, "the transport signal reaches the search router");
   assert.equal(resolverCalls, 2, "each returned hit is resolved per hit");
 });
+
+test("resolve-miss drops the hit instead of admitting the bare docid (issue #3087)", async () => {
+  const resolvedPaths: string[] = [];
+  const router: DeepRecallSeedRouter = {
+    async searchAcrossNamespaces() {
+      return [
+        { path: "entities/company-x.md", docid: "foreign-doc-42", score: 0.7 },
+        { path: "facts/2026-09-12/fact-good.md", docid: "doc-good", score: 0.6 },
+        { path: "", docid: "doc-nopath", score: 0.5 },
+      ];
+    },
+  };
+  const searchSeed = createDeepRecallSeedSearch({
+    namespace: "ns_3087",
+    storage: { dir: "/synthetic/ns_3087", readMemoryByPath: async () => null },
+    router,
+    resolver: {
+      async readQmdResultMemory(resultPath) {
+        resolvedPaths.push(resultPath);
+        return resultPath === "facts/2026-09-12/fact-good.md"
+          ? { frontmatter: { id: "fact-good-123" } }
+          : null;
+      },
+    },
+  });
+
+  const seeds = await searchSeed("company x", 3);
+
+  assert.deepEqual(
+    seeds,
+    [{ memoryId: "fact-good-123", score: 0.6 }],
+    "a hit the resolver cannot resolve is dropped, never admitted by its bare docid",
+  );
+  assert.ok(!resolvedPaths.includes(""), "an empty path is skipped before the resolver");
+});

--- a/packages/remnic-core/src/deep-recall-seeds.ts
+++ b/packages/remnic-core/src/deep-recall-seeds.ts
@@ -15,7 +15,9 @@
  * and the two forms it cannot decode (`qmd:///`, a leading `/`) are stripped
  * for one retry. A hit with no path is dropped: its namespace membership
  * cannot be verified, and a bare docid from a foreign collection must never
- * enter the working set as a resolved memory.
+ * enter the working set as a resolved memory. A hit with a path that still
+ * fails to resolve is dropped for the same reason: the resolver miss leaves
+ * the docid as the only identity, and a docid is not a memory id.
  *
  * An unavailable namespace backend (or a missing collection) contributes an
  * empty result set and reports itself only through `execution.onDegradation`,
@@ -127,9 +129,8 @@ export function createDeepRecallSeedSearch(deps: {
     const seeds: DeepRecallSeedHit[] = [];
     for (const hit of hits) {
       if (typeof hit.path !== "string" || hit.path.length === 0) continue;
-      const memoryId =
-        (await resolveSeedMemoryId(deps.resolver, deps.storage, deps.namespace, hit.path)) ?? hit.docid;
-      if (typeof memoryId !== "string" || memoryId.length === 0) continue;
+      const memoryId = await resolveSeedMemoryId(deps.resolver, deps.storage, deps.namespace, hit.path);
+      if (memoryId === null) continue;
       seeds.push({
         memoryId,
         score: typeof hit.score === "number" && Number.isFinite(hit.score) ? hit.score : 0,

--- a/packages/remnic-core/src/deep-recall-surface.test.ts
+++ b/packages/remnic-core/src/deep-recall-surface.test.ts
@@ -870,8 +870,8 @@ test("deep recall seeds resolve collection-qualified paths when namespaces are d
           path: rawPath,
           score: 0.5 + index / 10,
         })),
-        // A foreign-collection hit stays unresolvable: it keeps its docid and
-        // still seeds the working set, but never hydrates into the graph.
+        // A foreign-collection hit is unresolvable: skip it. Admitting the
+        // bare docid would violate the foreign-collection guard (#3087).
         { docid: "hash-doc-foreign", path: "foreign-coll/facts/2026-08-01/fact-1.md", score: 0.9 },
       ],
     };
@@ -885,15 +885,12 @@ test("deep recall seeds resolve collection-qualified paths when namespaces are d
 
     assert.deepEqual(
       seeds.map((seed) => seed.memoryId),
-      [
-        ...rawPaths.map(() => "mem-seed-1"),
-        "hash-doc-foreign",
-      ],
-      "every collection-qualified raw path form must resolve to the frontmatter id; only a foreign collection keeps its docid",
+      rawPaths.map(() => "mem-seed-1"),
+      "every collection-qualified raw path form must resolve to the frontmatter id; a foreign collection is dropped",
     );
     assert.deepEqual(
       seeds.map((seed) => seed.score),
-      [0.5, 0.6, 0.7, 0.8, 0.9],
+      [0.5, 0.6, 0.7, 0.8],
       "resolution must not disturb the hit scores",
     );
   } finally {


### PR DESCRIPTION
## Problem

Deep-recall seed search resolved each router hit to a stored memory id, but on a resolve miss it fell back to the search backend's bare `docid`:

```ts
const memoryId =
  (await resolveSeedMemoryId(...)) ?? hit.docid;
```

The module contract states a bare docid from a foreign collection must never enter the working set as a resolved memory. On a resolve miss the docid is the only remaining identity for the hit, and a docid is not a memory id — it can name a document in a foreign collection, so the fallback violated the guard exactly in the case it was supposed to protect.

## Fix

A resolve miss now skips the hit. `resolveSeedMemoryId` returning `null` (empty path was already skipped earlier, and a path that decodes but does not resolve now joins it) never admits `hit.docid`. Index-unavailable searches still throw the `backend_unavailable` seed failure unchanged.

## Test

New discriminating regression in `deep-recall-seeds.test.ts`: a hit with a non-empty path and a foreign-looking docid whose resolution returns `null` must not appear in the seeds, a resolvable hit must, and the empty-path hit must never reach the resolver. Verified red before the fix (the foreign docid leaked into the seed list) and green after.

## Gates

- `npm run test:file packages/remnic-core/src/deep-recall-seeds.test.ts` — 2/2 pass
- `check-types` (workspace) and `npx tsc --noEmit -p packages/remnic-core` — exit 0
- `npm run check:pre-push` — exit 0
- `npm run preflight:quick` — fails only at the baseline `plugin:inspect` fixture drift (fails identically at the base commit with no local changes; tracked in #3106). All steps after the failing inspector step were run individually and pass.
- Changeset for `@remnic/core` with `Stability: stable`.

Fixes #3087


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deep-recall searches now exclude results that cannot be resolved to a stored memory.
  * Results with missing or invalid paths are skipped instead of being admitted using an unrelated document ID.
  * Existing handling for unavailable search backends remains unchanged.

* **Documentation**
  * Clarified how deep-recall resolves and filters search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->