### PR TITLE
fix(plugin-openclaw): drop OpenClaw 2.0-removed registrar from inspector expect

### DIFF
--- a/.changeset/3101-inspector-registrar.md
+++ b/.changeset/3101-inspector-registrar.md
@@ -1,0 +1,7 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Stop listing OpenClaw-2.0-removed `registerMemoryPromptSection` in the Plugin Inspector expected registrations so ClawHub publish is not blocked by unknown-registration-name.
+
+Stability: stable

--- a/packages/plugin-openclaw/plugin-inspector.config.json
+++ b/packages/plugin-openclaw/plugin-inspector.config.json
@@ -29,8 +29,7 @@
       ],
       "registrations": [
         "registerTool",
-        "registerService",
-        "registerMemoryPromptSection"
+        "registerService"
       ],
       "manifestContracts": [
         "tools"

--- a/tests/openclaw-legacy-registrar-scan.test.ts
+++ b/tests/openclaw-legacy-registrar-scan.test.ts
@@ -27,3 +27,23 @@ test("OpenClaw 1.x-only registrars are never called as api.registerX( (ClawHub i
     assert.equal(match, null, `${file}: '${match?.[0]}' would be flagged by ClawHub's unknown-registration-name check`);
   }
 });
+
+// ClawHub's publish gate fails any inspector-fixture registrar missing from
+// the target OpenClaw. `registerMemoryPromptSection` was removed in OpenClaw
+// 2.0 (2026.8.1), so listing it in plugin-inspector.config.json expected
+// registrations breaks every plugin-openclaw publish.
+const REMOVED_IN_OPENCLAW_2 = ["registerMemoryPromptSection"];
+
+test("inspector expected registrations list no registrar removed in OpenClaw 2.0", () => {
+  const file = "packages/plugin-openclaw/plugin-inspector.config.json";
+  const config = JSON.parse(readFileSync(file, "utf8")) as {
+    plugin?: { expect?: { registrations?: string[] } };
+  };
+  const names = config.plugin?.expect?.registrations ?? [];
+  const blocked = REMOVED_IN_OPENCLAW_2.filter((name) => names.includes(name));
+  assert.deepEqual(
+    blocked,
+    [],
+    `${file}: ${blocked.join(", ")} was removed in OpenClaw 2.0; listing it fails ClawHub's unknown-registration-name gate`,
+  );
+});


### PR DESCRIPTION
## What

Plugin Inspector `expected.registrations` no longer lists `registerMemoryPromptSection`. OpenClaw 2.0 removed that registrar, so ClawHub treated the inspector fixture as `unknown-registration-name` and blocked every `plugin-openclaw` publish since v9.69.67.

Runtime still feature-detects the 1.x seam. This only changes the inspector contract.

Fixes #3101