### PR TITLE
fix(server): lock top-level searchBackend/qmdEnabled as remnic.* aliases

### DIFF
--- a/.changeset/3096-toplevel-search-aliases.md
+++ b/.changeset/3096-toplevel-search-aliases.md
@@ -1,0 +1,7 @@
+---
+"@remnic/server": patch
+---
+
+Document and regression-test that standalone daemon config accepts top-level `searchBackend` / `qmdEnabled` as aliases of `remnic.*`, with the nested block winning on conflict.
+
+Stability: stable

--- a/docs/search-backends.md
+++ b/docs/search-backends.md
@@ -62,6 +62,10 @@ qmd update && qmd embed
 }
 ```
 
+Standalone daemon config accepts these keys at the top level **or** under a
+`remnic` (or legacy `engram`) block. Nested `remnic.searchBackend` /
+`remnic.qmdEnabled` win when both shapes are set.
+
 When QMD `2.5.3` is installed, Remnic uses the newer capability set when
 available: `qmd doctor` diagnostics, version-matched skill metadata, structured
 MCP `lex`/`vec`/`hyde` searches, candidate-limit forwarding, rerank toggles,

--- a/packages/remnic-server/src/config-toplevel-search.test.ts
+++ b/packages/remnic-server/src/config-toplevel-search.test.ts
@@ -14,18 +14,20 @@ async function writeConfig(content: string): Promise<{ filePath: string; cleanup
   return { filePath, cleanup: () => rm(dir, { recursive: true, force: true }) };
 }
 
-test("#3096 top-level-only qmdEnabled/searchBackend do not resolve to noop", async () => {
+test("#3096 top-level-only searchBackend/qmdEnabled aliases are not parseConfig defaults", async () => {
   const { filePath, cleanup } = await writeConfig(
     JSON.stringify({
-      qmdEnabled: true,
-      searchBackend: "qmd",
+      qmdEnabled: false,
+      searchBackend: "noop",
     }),
   );
   try {
     const loaded = loadConfigFile(filePath);
+    assert.equal(loaded.remnic.searchBackend, "noop");
+    assert.equal(loaded.remnic.qmdEnabled, false);
     const parsed = parseConfig(loaded.remnic);
-    assert.equal(parsed.searchBackend, "qmd");
-    assert.equal(parsed.qmdEnabled, true);
+    assert.equal(parsed.searchBackend, "noop");
+    assert.equal(parsed.qmdEnabled, false);
   } finally {
     await cleanup();
   }

--- a/packages/remnic-server/src/config-toplevel-search.test.ts
+++ b/packages/remnic-server/src/config-toplevel-search.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { parseConfig } from "@remnic/core";
+import { loadConfigFile } from "./index.js";
+
+async function writeConfig(content: string): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-toplevel-search-"));
+  const filePath = path.join(dir, "config.json");
+  await writeFile(filePath, content, "utf-8");
+  return { filePath, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+test("#3096 top-level-only qmdEnabled/searchBackend do not resolve to noop", async () => {
+  const { filePath, cleanup } = await writeConfig(
+    JSON.stringify({
+      qmdEnabled: true,
+      searchBackend: "qmd",
+    }),
+  );
+  try {
+    const loaded = loadConfigFile(filePath);
+    const parsed = parseConfig(loaded.remnic);
+    assert.equal(parsed.searchBackend, "qmd");
+    assert.equal(parsed.qmdEnabled, true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("#3096 nested remnic.searchBackend wins over a conflicting top-level key", async () => {
+  const { filePath, cleanup } = await writeConfig(
+    JSON.stringify({
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      remnic: { searchBackend: "noop", qmdEnabled: false },
+    }),
+  );
+  try {
+    const loaded = loadConfigFile(filePath);
+    const parsed = parseConfig(loaded.remnic);
+    assert.equal(parsed.searchBackend, "noop");
+    assert.equal(parsed.qmdEnabled, false);
+  } finally {
+    await cleanup();
+  }
+});


### PR DESCRIPTION
## What

Standalone daemon config already treats top-level `searchBackend` / `qmdEnabled` as aliases of `remnic.*`, with the nested block winning on conflict. This adds a regression so a top-level-only file cannot silently resolve to noop, and documents both shapes.

Fixes #3096