### PR TITLE
fix(support-passport): accept stable memory directories on win32 without a POSIX fd root

### DIFF
--- a/.changeset/3069-win32-private-file-pin.md
+++ b/.changeset/3069-win32-private-file-pin.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+Stability: stable
+---
+
+Fixed support-passport grant-store path safety on Windows: the no-follow ancestor check no longer rejects a legitimate stable memory directory with `support passport memory directory must be a stable directory`. Windows has no POSIX directory-fd root (`/proc/self/fd`, `/dev/fd`), so directory pinning there now degrades to the resolved stable path while the lstat-based no-follow ancestor walk, dev/ino stability asserts, and containment checks stay in force. POSIX platforms are unchanged and still pin through the descriptor root. Closes #3069.

--- a/packages/remnic-core/src/support-passport/grant-service.test.ts
+++ b/packages/remnic-core/src/support-passport/grant-service.test.ts
@@ -29,6 +29,7 @@ import {
   readPrivateFileNoFollow,
   removePrivateFilesNoFollow,
   requirePrivateFileDescriptorRoot,
+  withPrivateDirectoryNoFollow,
   writePrivateFileAtomicallyNoFollow,
 } from "./private-file.js";
 
@@ -2865,15 +2866,7 @@ test("the grant store rejects a symlinked grant directory", async () => {
   }
 });
 
-test("private file operations select supported directory access strategies", () => {
-  assert.throws(
-    () =>
-      requirePrivateFileDescriptorRoot(
-        "win32",
-        "private file directory cannot be pinned",
-      ),
-    /private file directory cannot be pinned/,
-  );
+test("private file operations select supported directory access strategies", async () => {
   assert.equal(
     requirePrivateFileDescriptorRoot("linux", "unreachable"),
     "/proc/self/fd",
@@ -2882,6 +2875,28 @@ test("private file operations select supported directory access strategies", () 
     requirePrivateFileDescriptorRoot("darwin", "unreachable"),
     "/dev/fd",
   );
+  assert.throws(
+    () => requirePrivateFileDescriptorRoot("sunos", "unreachable"),
+    /unreachable/,
+  );
+
+  // win32 has no POSIX directory-fd root; pinning degrades to the resolved
+  // stable path while the no-follow ancestor walk and containment asserts stay.
+  const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-win32-"));
+  try {
+    const target = path.join(root, "state", "memory");
+    await mkdir(target, { recursive: true });
+    const pinned = await withPrivateDirectoryNoFollow(
+      root,
+      target,
+      "private file directory cannot be pinned",
+      async (pinnedDirectory) => pinnedDirectory,
+      "win32",
+    );
+    assert.equal(pinned, path.resolve(target));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("private directory creation syncs every verified parent entry", async () => {
@@ -3105,25 +3120,35 @@ test("the grant store rejects a symlink alias in the configured memory root", as
   }
 });
 
-test("Windows private-file operations fail before mutation", async () => {
+test("Windows private-file operations pin without a POSIX descriptor root", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "remnic-support-private-win32-"));
   try {
     const directory = path.join(root, "state", "support-passport", "grants");
-    const filePath = path.join(directory, "grant.json");
     const errorMessage = "private Windows file operation failed";
+    await ensurePrivateDirectoryNoFollow(root, directory, errorMessage, undefined, true, "win32");
+    assert.equal((await lstat(directory)).isDirectory(), true);
+
+    const liveParent = path.join(root, "live");
+    const parkedParent = path.join(root, "parked");
+    const outside = path.join(root, "outside");
+    await mkdir(liveParent);
+    await mkdir(path.join(outside, "memory"), { recursive: true });
+    await renameSync(liveParent, parkedParent);
+    await symlink(outside, liveParent, "dir");
+
     await assert.rejects(
-      ensurePrivateDirectoryNoFollow(root, directory, errorMessage, undefined, true, "win32"),
-      new RegExp(errorMessage)
-    );
-    assert.equal(
-      await lstat(directory).then(
-        () => true,
-        () => false
+      ensurePrivateDirectoryNoFollow(
+        root,
+        path.join(liveParent, "memory"),
+        errorMessage,
+        undefined,
+        true,
+        "win32",
       ),
-      false
+      new RegExp(errorMessage),
     );
     assert.equal(
-      await lstat(filePath).then(
+      await lstat(path.join(outside, "memory", "state")).then(
         () => true,
         () => false
       ),

--- a/packages/remnic-core/src/support-passport/private-file.test.ts
+++ b/packages/remnic-core/src/support-passport/private-file.test.ts
@@ -30,16 +30,21 @@ test("private append cannot escape its pinned directory", async (context) => {
   await assert.rejects(readFile(outsidePath, "utf8"), { code: "ENOENT" });
 });
 
-test("private append fails before mutation when descriptor pinning is unavailable", async (context) => {
+test("private append writes through a path-pinned directory on win32", async (context) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-private-append-win32-"));
   context.after(async () => await rm(root, { recursive: true, force: true }));
   const privateDirectory = path.join(root, "private");
+  await mkdir(privateDirectory);
   const auditPath = path.join(privateDirectory, "audit.jsonl");
-  await assert.rejects(
-    ensurePrivateDirectoryNoFollow(root, privateDirectory, "private path escaped", undefined, true, "win32"),
-    /private path escaped/
+  await appendPrivateFileNoFollow(
+    privateDirectory,
+    auditPath,
+    "private\n",
+    "private path escaped",
+    root,
+    "win32",
   );
-  await assert.rejects(readFile(auditPath, "utf8"), { code: "ENOENT" });
+  assert.equal(await readFile(auditPath, "utf8"), "private\n");
 });
 
 test("private append rejects a renamed target after opening it", async (context) => {

--- a/packages/remnic-core/src/support-passport/private-file.ts
+++ b/packages/remnic-core/src/support-passport/private-file.ts
@@ -104,6 +104,7 @@ export async function resolvePrivateDirectoryPath(
   errorMessage: string,
   platform: NodeJS.Platform = process.platform
 ): Promise<string> {
+  if (pinsDirectoriesByPath(platform)) return path.resolve(directory);
   const descriptorRoot = requirePrivateFileDescriptorRoot(platform, errorMessage);
   const pinnedPath = path.join(descriptorRoot, String(handle.fd));
   const metadata = await stat(pinnedPath);
@@ -125,6 +126,10 @@ export function requirePrivateFileDescriptorRoot(platform: NodeJS.Platform, erro
   throw new Error(errorMessage);
 }
 
+function pinsDirectoriesByPath(platform: NodeJS.Platform): boolean {
+  return platform === "win32";
+}
+
 async function openStableDirectoryFromRoot(
   trustedRoot: string,
   directory: string,
@@ -140,7 +145,7 @@ async function openStableDirectoryFromRoot(
   const root = path.resolve(trustedRoot);
   const target = path.resolve(directory);
   assertContainedPath(root, target, errorMessage);
-  requirePrivateFileDescriptorRoot(platform, errorMessage);
+  if (!pinsDirectoriesByPath(platform)) requirePrivateFileDescriptorRoot(platform, errorMessage);
   const relative = path.relative(root, target);
   const components = relative === "" ? [] : relative.split(path.sep);
   const handles: FileHandle[] = [];
@@ -149,7 +154,7 @@ async function openStableDirectoryFromRoot(
     let current = await openDirectoryNoFollow(root, errorMessage);
     handles.push(current.handle);
     for (const component of components) {
-      const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
+      const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage, platform);
       const child = await openDirectoryNoFollow(path.join(pinnedParent, component), errorMessage);
       handles.push(child.handle);
       assertStableDirectory(current.before, current.opened, await lstat(currentPath), errorMessage);
@@ -186,7 +191,7 @@ export async function ensurePrivateDirectoryNoFollow(
   const target = path.resolve(directory);
   assertContainedPath(root, target, errorMessage);
   const relative = path.relative(root, target);
-  requirePrivateFileDescriptorRoot(platform, errorMessage);
+  if (!pinsDirectoriesByPath(platform)) requirePrivateFileDescriptorRoot(platform, errorMessage);
   const components = relative === "" ? [] : relative.split(path.sep);
   const handles: FileHandle[] = [];
   let currentPath = root;
@@ -194,7 +199,7 @@ export async function ensurePrivateDirectoryNoFollow(
     let current = await openDirectoryNoFollow(root, errorMessage);
     handles.push(current.handle);
     for (const component of components) {
-      const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage);
+      const pinnedParent = await resolvePrivateDirectoryPath(currentPath, current.handle, current.opened, errorMessage, platform);
       const childPath = path.join(pinnedParent, component);
       let created = false;
       try {
@@ -393,10 +398,12 @@ export async function appendPrivateFileInPinnedDirectory(
   errorMessage: string,
   platform: NodeJS.Platform = process.platform
 ): Promise<void> {
-  const descriptorRoot = requirePrivateFileDescriptorRoot(platform, errorMessage);
   const resolvedDirectory = path.resolve(pinnedDirectory);
-  const descriptor = path.relative(descriptorRoot, resolvedDirectory);
-  if (!/^\d+$/.test(descriptor)) throw new Error(errorMessage);
+  if (!pinsDirectoriesByPath(platform)) {
+    const descriptorRoot = requirePrivateFileDescriptorRoot(platform, errorMessage);
+    const descriptor = path.relative(descriptorRoot, resolvedDirectory);
+    if (!/^\d+$/.test(descriptor)) throw new Error(errorMessage);
+  }
   const before = await stat(resolvedDirectory);
   if (!before.isDirectory()) throw new Error(errorMessage);
   let directoryHandle: FileHandle | undefined;


### PR DESCRIPTION
Fixes #3069

## Problem

`requirePrivateFileDescriptorRoot` rejected every win32 directory: Windows has no `/proc/self/fd` or `/dev/fd` namespace, so the no-follow ancestor check threw `support passport memory directory must be a stable directory` on a legitimate stable temp directory. Found by the windows-smoke subset (the `owner membership setup rejects a swapped memory-directory ancestor before mutation` test in `grant-store-path-safety.test.ts`), where the first, unswapped `listForOwner` call already failed.

## Fix

On win32, directory pinning degrades to the resolved stable path; the POSIX fd-root pin is skipped:

- `resolvePrivateDirectoryPath` returns the resolved directory instead of `<fd-root>/<fd>` on win32.
- The fd-root gates in `openStableDirectoryFromRoot` / `ensurePrivateDirectoryNoFollow` are skipped on win32; other unsupported platforms still fail fast.
- `appendPrivateFileInPinnedDirectory` skips the fd-descriptor prefix validation on win32 and keeps its stat/open/stability asserts.
- Internal pin-resolution calls now forward the caller's platform instead of defaulting to the host platform.

The lstat-based no-follow ancestor walk, dev/ino stability asserts, and containment checks are untouched on every platform. Linux, darwin, freebsd, and openbsd still pin through the descriptor root.

## Tests

- The strategy test no longer expects a throw on win32: pinning a real `mkdtemp` directory with `"win32"` succeeds and returns the resolved path; unknown platforms still throw; linux/darwin still map to their fd roots.
- `Windows private-file operations pin without a POSIX descriptor root`: win32-mode `ensurePrivateDirectoryNoFollow` creates the tree, and a symlinked ancestor component is still rejected before any mutation through it.
- `private append writes through a path-pinned directory on win32`: win32-mode append writes end to end.
- Discrimination verified: with the source fix stashed, the updated strategy test fails with `private file directory cannot be pinned` (1 fail / 77 pass); with the fix, both suites pass (78/78 and 5/5).
