### PR TITLE
ci: raise windows-smoke timeout so Core unit tests can finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
   windows-smoke:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     defaults:
       run:
         # git-bash ships on the windows-latest image. Bash keeps `set -euo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,14 +418,14 @@ jobs:
       # `mktemp -d "$RUNNER_TEMP/..."` would silently run in the repo root.
       #
       # Ordered before the core suite on purpose: it is seconds of work, and the
-      # suite is the step that can exhaust the 25-minute budget.
+      # suite is the step that can exhaust the 45-minute budget.
       - name: CLI smoke
         run: node scripts/windows-cli-smoke.mjs
 
       # Runs the curated Windows-risk subset from scripts/windows-smoke-list.json
       # (native SQLite binding, path handling). The FULL @remnic/core suite no
-      # longer fits the free-tier 25-minute Windows runner cap, so a full run
-      # can never go green here; without this cap the job burns 25 minutes of
+      # longer fits the 45-minute Windows runner budget, so a full run
+      # can never go green here; without this cap the job burns 45 minutes of
       # allocation on every PR and always cancels. The full suite remains
       # runnable by hand: `node scripts/windows-test-runner.mjs` (no --smoke),
       # governed by scripts/windows-skip-list.json as before — a Windows

--- a/scripts/windows-smoke-list.json
+++ b/scripts/windows-smoke-list.json
@@ -1,5 +1,5 @@
 {
-  "note": "Curated subset for the PR windows-smoke job. The full @remnic/core suite (766 files) no longer fits the free-tier 25-minute Windows runner cap (issue #3034), so pull-request runs execute only the files below: the native SQLite binding and the path-handling surfaces most likely to break on Windows. The full suite remains available by running scripts/windows-test-runner.mjs without --smoke. Keep this list small enough to finish well inside the budget; add a file only when it guards a real Windows failure mode.",
+  "note": "Curated subset for the PR windows-smoke job. The full @remnic/core suite (766 files) no longer fits the 45-minute Windows runner budget (issue #3034/#3060), so pull-request runs execute only the files below: the native SQLite binding and the path-handling surfaces most likely to break on Windows. The full suite remains available by running scripts/windows-test-runner.mjs without --smoke. Keep this list small enough to finish well inside the budget; add a file only when it guards a real Windows failure mode.",
   "files": [
     "packages/remnic-core/src/runtime/better-sqlite.test.ts",
     "packages/remnic-core/src/native-binding-hint.test.ts",

--- a/tests/windows-test-runner.test.mjs
+++ b/tests/windows-test-runner.test.mjs
@@ -122,7 +122,12 @@ test("the skip report states its scope so smoke mode never claims full coverage"
 
 test("#3060 windows-smoke job timeout is above the 25-minute cancel cap", () => {
   const yaml = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
-  const match = /windows-smoke:[\s\S]*?timeout-minutes:\s*(\d+)/.exec(yaml);
-  assert.ok(match, "ci.yml must declare windows-smoke timeout-minutes");
+  const start = yaml.indexOf("\n  windows-smoke:");
+  assert.ok(start >= 0, "ci.yml must declare a windows-smoke job");
+  const rest = yaml.slice(start + 1);
+  const nextJob = rest.search(/\n  [A-Za-z][A-Za-z0-9_-]*:/);
+  const job = nextJob === -1 ? rest : rest.slice(0, nextJob);
+  const match = /timeout-minutes:\s*(\d+)/.exec(job);
+  assert.ok(match, "windows-smoke job must declare timeout-minutes");
   assert.ok(Number(match[1]) > 25, `windows-smoke timeout-minutes must be > 25, got ${match[1]}`);
 });

--- a/tests/windows-test-runner.test.mjs
+++ b/tests/windows-test-runner.test.mjs
@@ -120,7 +120,7 @@ test("the skip report states its scope so smoke mode never claims full coverage"
   assert.ok(scoped.includes(ENTRY.file), "scoped report must still name the skipped file");
 });
 
-test("#3060 windows-smoke job timeout is above the 25-minute cancel cap", () => {
+test("#3060 windows-smoke job timeout is at least 45 minutes", () => {
   const yaml = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
   const start = yaml.indexOf("\n  windows-smoke:");
   assert.ok(start >= 0, "ci.yml must declare a windows-smoke job");
@@ -129,5 +129,5 @@ test("#3060 windows-smoke job timeout is above the 25-minute cancel cap", () => 
   const job = nextJob === -1 ? rest : rest.slice(0, nextJob);
   const match = /timeout-minutes:\s*(\d+)/.exec(job);
   assert.ok(match, "windows-smoke job must declare timeout-minutes");
-  assert.ok(Number(match[1]) > 25, `windows-smoke timeout-minutes must be > 25, got ${match[1]}`);
+  assert.ok(Number(match[1]) >= 45, `windows-smoke timeout-minutes must be >= 45, got ${match[1]}`);
 });

--- a/tests/windows-test-runner.test.mjs
+++ b/tests/windows-test-runner.test.mjs
@@ -119,3 +119,10 @@ test("the skip report states its scope so smoke mode never claims full coverage"
   assert.match(scoped, /per scripts\/windows-skip-list\.json within the curated smoke subset:/);
   assert.ok(scoped.includes(ENTRY.file), "scoped report must still name the skipped file");
 });
+
+test("#3060 windows-smoke job timeout is above the 25-minute cancel cap", () => {
+  const yaml = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+  const match = /windows-smoke:[\s\S]*?timeout-minutes:\s*(\d+)/.exec(yaml);
+  assert.ok(match, "ci.yml must declare windows-smoke timeout-minutes");
+  assert.ok(Number(match[1]) > 25, `windows-smoke timeout-minutes must be > 25, got ${match[1]}`);
+});


### PR DESCRIPTION
## What

`windows-smoke` was cancelled at 25 minutes after CLI smoke, so Windows never reported a unit-test signal. Job timeout is now 45 minutes.

Fixes #3060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated coverage to verify that Windows smoke tests have a timeout of at least 45 minutes.

- **Chores**
  - Increased the Windows smoke test workflow timeout from 25 to 45 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->