### PR TITLE
fix(core): reject unknown searchBackend values including builtin

### DIFF
--- a/.changeset/3097-reject-builtin-search.md
+++ b/.changeset/3097-reject-builtin-search.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Reject unknown `searchBackend` values (including `"builtin"`) at config load instead of silently coercing them to `"qmd"`.
+
+Stability: stable

--- a/packages/remnic-core/src/config-search-backend.test.ts
+++ b/packages/remnic-core/src/config-search-backend.test.ts
@@ -10,6 +10,8 @@ test("#3097 parseSearchBackend rejects builtin and unknown values", () => {
   assert.equal(parseSearchBackend("noop"), "noop");
   assert.throws(() => parseSearchBackend("builtin"), /must be one of: qmd, remote, noop, lancedb, meilisearch, orama/);
   assert.throws(() => parseSearchBackend("jsno"), /must be one of:/);
+  assert.throws(() => parseSearchBackend(null), /must be one of:/);
+  assert.throws(() => parseSearchBackend(1n), /must be one of:/);
 });
 
 test("#3097 parseConfig rejects searchBackend=builtin instead of coercing", () => {

--- a/packages/remnic-core/src/config-search-backend.test.ts
+++ b/packages/remnic-core/src/config-search-backend.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { parseSearchBackend } from "./config-search-backend.js";
+
+test("#3097 parseSearchBackend rejects builtin and unknown values", () => {
+  assert.equal(parseSearchBackend(undefined), "qmd");
+  assert.equal(parseSearchBackend("qmd"), "qmd");
+  assert.equal(parseSearchBackend("noop"), "noop");
+  assert.throws(() => parseSearchBackend("builtin"), /must be one of: qmd, remote, noop, lancedb, meilisearch, orama/);
+  assert.throws(() => parseSearchBackend("jsno"), /must be one of:/);
+});
+
+test("#3097 parseConfig rejects searchBackend=builtin instead of coercing", () => {
+  assert.throws(() => parseConfig({ searchBackend: "builtin" }), /searchBackend must be one of/);
+  const ok = parseConfig({ searchBackend: "orama" });
+  assert.equal(ok.searchBackend, "orama");
+});

--- a/packages/remnic-core/src/config-search-backend.ts
+++ b/packages/remnic-core/src/config-search-backend.ts
@@ -1,0 +1,13 @@
+const SEARCH_BACKENDS = ["qmd", "remote", "noop", "lancedb", "meilisearch", "orama"] as const;
+
+export type SearchBackendName = (typeof SEARCH_BACKENDS)[number];
+
+export function parseSearchBackend(raw: unknown): SearchBackendName {
+  if (raw === undefined || raw === null) return "qmd";
+  if (typeof raw === "string" && (SEARCH_BACKENDS as readonly string[]).includes(raw)) {
+    return raw as SearchBackendName;
+  }
+  throw new Error(
+    `searchBackend must be one of: ${SEARCH_BACKENDS.join(", ")} (got ${JSON.stringify(raw)})`,
+  );
+}

--- a/packages/remnic-core/src/config-search-backend.ts
+++ b/packages/remnic-core/src/config-search-backend.ts
@@ -3,11 +3,15 @@ const SEARCH_BACKENDS = ["qmd", "remote", "noop", "lancedb", "meilisearch", "ora
 export type SearchBackendName = (typeof SEARCH_BACKENDS)[number];
 
 export function parseSearchBackend(raw: unknown): SearchBackendName {
-  if (raw === undefined || raw === null) return "qmd";
+  if (raw === undefined) return "qmd";
   if (typeof raw === "string" && (SEARCH_BACKENDS as readonly string[]).includes(raw)) {
     return raw as SearchBackendName;
   }
-  throw new Error(
-    `searchBackend must be one of: ${SEARCH_BACKENDS.join(", ")} (got ${JSON.stringify(raw)})`,
-  );
+  let shown: string;
+  try {
+    shown = JSON.stringify(raw) ?? String(raw);
+  } catch {
+    shown = Object.prototype.toString.call(raw);
+  }
+  throw new Error(`searchBackend must be one of: ${SEARCH_BACKENDS.join(", ")} (got ${shown})`);
 }

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -26,6 +26,7 @@ import type {
   TrustWeights,
 } from "./types.js";
 import { parseBackgroundGeneration } from "./background-generation-config.js";
+import { parseSearchBackend } from "./config-search-backend.js";
 import { parseLocalLlmConfig } from "./local-llm-config.js";
 import { parseConvergeConfig } from "./converge-config.js";
 import { parseExternalWikiRecallGuard } from "./external-wiki-guard.js";
@@ -3173,9 +3174,7 @@ export function parseConfig(
         : 500,
 
     // Search backend abstraction
-    searchBackend: (["qmd", "remote", "noop", "lancedb", "meilisearch", "orama"] as const).includes(cfg.searchBackend as any)
-      ? (cfg.searchBackend as "qmd" | "remote" | "noop" | "lancedb" | "meilisearch" | "orama")
-      : "qmd",
+    searchBackend: parseSearchBackend(cfg.searchBackend),
     remoteSearchBaseUrl: typeof cfg.remoteSearchBaseUrl === "string" ? cfg.remoteSearchBaseUrl : undefined,
     remoteSearchApiKey: typeof cfg.remoteSearchApiKey === "string" ? cfg.remoteSearchApiKey : undefined,
     remoteSearchTimeoutMs: typeof cfg.remoteSearchTimeoutMs === "number" ? cfg.remoteSearchTimeoutMs : 30_000,


### PR DESCRIPTION
## What

`searchBackend=\"builtin\"` is not a Remnic engine. parseConfig coerced unknown values to `qmd`, which hid misconfig. Unknown values (including builtin) now throw with the allowlist.

Fixes #3097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid search backend settings are now rejected during configuration loading instead of being silently converted to another backend.
  - The removed `builtin` search backend is no longer accepted.

- **Configuration**
  - Missing or null search backend settings default to `qmd`.
  - Supported backend values are validated consistently, with clear rejection of unknown values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->