### PR TITLE
fix(core): time-bound briefing LLM follow-ups so MCP cannot stall (#3086)

### DIFF
--- a/.changeset/3086-briefing-followup-timeout.md
+++ b/.changeset/3086-briefing-followup-timeout.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Cap briefing LLM follow-up generation at 8s so a stalled local judge/gateway cannot block `remnic_briefing` past the MCP caller timeout (issue #3086). The briefing still returns windowed recall.
+
+Stability: stable

--- a/packages/remnic-core/src/briefing-followup-timeout.test.ts
+++ b/packages/remnic-core/src/briefing-followup-timeout.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { withBriefingFollowupTimeout } from "./briefing-followup-timeout.js";
+
+test("#3086 briefing follow-up timeout rejects so briefing can degrade", async () => {
+  await assert.rejects(
+    withBriefingFollowupTimeout(new Promise(() => {}), 20),
+    /briefing follow-up timeout/,
+  );
+});
+
+test("#3086 briefing follow-up timeout returns the work when it finishes", async () => {
+  assert.equal(await withBriefingFollowupTimeout(Promise.resolve("ok"), 50), "ok");
+});

--- a/packages/remnic-core/src/briefing-followup-timeout.ts
+++ b/packages/remnic-core/src/briefing-followup-timeout.ts
@@ -1,0 +1,14 @@
+export const BRIEFING_FOLLOWUP_TIMEOUT_MS = 8_000;
+
+export async function withBriefingFollowupTimeout<T>(
+  work: Promise<T>,
+  timeoutMs = BRIEFING_FOLLOWUP_TIMEOUT_MS,
+): Promise<T> {
+  const { promise: timeout, reject } = Promise.withResolvers<T>();
+  const timer = setTimeout(() => reject(new Error("briefing follow-up timeout")), timeoutMs);
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -19,6 +19,7 @@ import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { log } from "./logger.js";
+import { withBriefingFollowupTimeout } from "./briefing-followup-timeout.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import { drainPassiveCorrectionNotifications } from "./correction/passive-correction-notifications.js";
 import { excludeSupportPassportPrivateMemories } from "./support-passport/card-projection.js";
@@ -846,10 +847,6 @@ export async function buildBriefing(options: BuildBriefingOptions): Promise<Brie
 
   const activeThreads = buildActiveThreads(focusedMemories);
   const recentEntities = buildRecentEntities(allEntities, window, focus);
-  // TODO(#370): openCommitments only covers memories inside the lookback window.
-  // Still-open commitments (pending tag, commitment category) that pre-date the
-  // window are silently omitted. A separate query over allMemories filtered to
-  // open-status entries would surface these. Deferred to avoid scope creep here.
   const openCommitments = buildOpenCommitments(focusedMemories);
 
   const calendarLoadResult = options.calendarSource
@@ -882,11 +879,13 @@ export async function buildBriefing(options: BuildBriefingOptions): Promise<Brie
         model: options.model ?? BRIEFING_FOLLOWUP_DEFAULT_MODEL,
         baseURL: options.openaiBaseUrl,
       });
-      const generated = await generator({
-        sections: sectionsBase,
-        windowLabel: window.label,
-        maxFollowups,
-      });
+      const generated = await withBriefingFollowupTimeout(
+        generator({
+          sections: sectionsBase,
+          windowLabel: window.label,
+          maxFollowups,
+        }),
+      );
       followups = generated.slice(0, maxFollowups);
     } catch (err) {
       const errMsg = stringifyError(err);


### PR DESCRIPTION
## Summary
`remnic_briefing` no longer waits on a hung local-judge/gateway follow-up. Generation is capped at 8s and fails open; the windowed briefing still returns.

Fixes #3086

## Test plan
- `tsx --test --conditions=remnic-source packages/remnic-core/src/briefing-followup-timeout.test.ts`