### PR TITLE
fix(core): refuse sidecar ancestry through symlink directories (#3090)

### DIFF
--- a/.changeset/3090-sidecar-symlink-ancestry.md
+++ b/.changeset/3090-sidecar-symlink-ancestry.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Refuse directory-sidecar ancestry when the memory root or any ancestor directory is a symlink (declined #3007 P1 tracked by issue #3090).
+
+Stability: stable

--- a/packages/remnic-core/src/directory-sidecars.test.ts
+++ b/packages/remnic-core/src/directory-sidecars.test.ts
@@ -512,3 +512,20 @@ test("#3007 sidecar ancestry refuses a symlinked memory root", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("#3090 sidecar ancestry refuses a symlink above the category root", () => {
+  const root = store();
+  try {
+    const outside = path.join(root, "outside");
+    mkdirSync(path.join(outside, "alpha", "facts", "2026-01-01"), { recursive: true });
+    writeFileSync(path.join(outside, "alpha", "facts", "2026-01-01", "fact.md"), "x");
+    mkdirSync(path.join(root, "namespaces"));
+    symlinkSync(outside, path.join(root, "namespaces", "alpha"));
+    assert.deepEqual(
+      directorySidecarAncestry(root, "namespaces/alpha/facts/2026-01-01/fact.md"),
+      [],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/directory-sidecars.test.ts
+++ b/packages/remnic-core/src/directory-sidecars.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdir, readdir, readFile, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -10,6 +10,7 @@ import {
   DIRECTORY_SIDECAR_MARKER,
   NEIGHBORHOOD_ABSTRACT_LABEL,
   applyDirectorySidecarDrillDown,
+  directorySidecarAncestry,
   findDirectorySidecarsForQuery,
   loadDirectorySidecar,
   parseDirectorySidecarsEnabled,
@@ -494,6 +495,19 @@ test("drill-down prefers the most specific matching directory", async () => {
     );
     assert.match(out[0].snippet, /2026-01-02/);
     assert.doesNotMatch(out[0].snippet, /Guide star/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#3007 sidecar ancestry refuses a symlinked memory root", () => {
+  const root = store();
+  try {
+    const facts = path.join(root, "facts");
+    mkdirSync(facts);
+    const linked = path.join(root, "linked-root");
+    symlinkSync(root, linked);
+    assert.deepEqual(directorySidecarAncestry(linked, "facts/2026-01-01/fact.md"), []);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/directory-sidecars.test.ts
+++ b/packages/remnic-core/src/directory-sidecars.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdir, readdir, readFile, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -513,7 +513,7 @@ test("#3007 sidecar ancestry refuses a symlinked memory root", () => {
   }
 });
 
-test("#3090 sidecar ancestry refuses a symlink above the category root", () => {
+test("#3090 sidecar ancestry refuses a symlink above the category root", async () => {
   const root = store();
   try {
     const outside = path.join(root, "outside");
@@ -521,10 +521,14 @@ test("#3090 sidecar ancestry refuses a symlink above the category root", () => {
     writeFileSync(path.join(outside, "alpha", "facts", "2026-01-01", "fact.md"), "x");
     mkdirSync(path.join(root, "namespaces"));
     symlinkSync(outside, path.join(root, "namespaces", "alpha"));
-    assert.deepEqual(
-      directorySidecarAncestry(root, "namespaces/alpha/facts/2026-01-01/fact.md"),
-      [],
+    const report = await refreshDirectorySidecarsAfterWrite(
+      root,
+      "namespaces/alpha/facts/2026-01-01/fact.md",
+      true,
     );
+    assert.deepEqual(report, { written: [], removed: [] });
+    assert.equal(existsSync(path.join(outside, "alpha", "facts", "overview.md")), false);
+    assert.equal(existsSync(path.join(outside, "alpha", "facts", "2026-01-01", "overview.md")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/directory-sidecars.ts
+++ b/packages/remnic-core/src/directory-sidecars.ts
@@ -342,6 +342,15 @@ export function directorySidecarAncestry(memoryDir: string, changedPath: string)
   const rel = path.relative(root, abs);
   if (rel.startsWith("..") || path.isAbsolute(rel)) return [];
   const parts = rel.split(path.sep).filter(Boolean);
+  let cursor = root;
+  for (const part of parts) {
+    cursor = path.join(cursor, part);
+    try {
+      if (lstatSync(cursor).isSymbolicLink()) return [];
+    } catch {
+      return [];
+    }
+  }
   const dirParts = isRealDirectory(abs) ? parts : parts.slice(0, -1);
   let categoryAt = -1;
   if (dirParts[0] === "namespaces" && dirParts.length >= 3 && CATEGORY_ROOTS.has(dirParts[2] ?? "")) {

--- a/packages/remnic-core/src/directory-sidecars.ts
+++ b/packages/remnic-core/src/directory-sidecars.ts
@@ -337,6 +337,7 @@ function childAbstractsFromDisk(dir: string): Map<string, string> {
  */
 export function directorySidecarAncestry(memoryDir: string, changedPath: string): string[] {
   const root = path.resolve(memoryDir);
+  if (!isRealDirectory(root)) return [];
   const abs = path.isAbsolute(changedPath) ? path.resolve(changedPath) : path.resolve(root, changedPath);
   const rel = path.relative(root, abs);
   if (rel.startsWith("..") || path.isAbsolute(rel)) return [];
@@ -351,7 +352,9 @@ export function directorySidecarAncestry(memoryDir: string, changedPath: string)
   if (categoryAt === -1) return [];
   const dirs: string[] = [];
   for (let i = dirParts.length; i > categoryAt; i--) {
-    dirs.push(path.join(root, ...dirParts.slice(0, i)));
+    const dir = path.join(root, ...dirParts.slice(0, i));
+    if (!isRealDirectory(dir)) return [];
+    dirs.push(dir);
   }
   return dirs;
 }

--- a/packages/remnic-core/src/directory-sidecars.ts
+++ b/packages/remnic-core/src/directory-sidecars.ts
@@ -343,11 +343,12 @@ export function directorySidecarAncestry(memoryDir: string, changedPath: string)
   if (rel.startsWith("..") || path.isAbsolute(rel)) return [];
   const parts = rel.split(path.sep).filter(Boolean);
   let cursor = root;
-  for (const part of parts) {
-    cursor = path.join(cursor, part);
+  for (let i = 0; i < parts.length; i++) {
+    cursor = path.join(cursor, parts[i] ?? "");
     try {
       if (lstatSync(cursor).isSymbolicLink()) return [];
     } catch {
+      if (i === parts.length - 1) break;
       return [];
     }
   }


### PR DESCRIPTION
## Summary
Sidecar ancestry now refuses a symlinked memory root or ancestor directory (the declined #3007 P1). Also filed #3117 and #3118 for the remaining #3009/#3010 items.

Fixes #3090

## Test plan
- `tsx --test --conditions=remnic-source --test-name-pattern 3007 packages/remnic-core/src/directory-sidecars.test.ts`