### PR TITLE
fix(core): score recognition hits on the retrieval 0-1 scale

### DIFF
--- a/.changeset/3117-recognition-hit-scores.md
+++ b/.changeset/3117-recognition-hit-scores.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Score recognition-tier hits on the retrieval 0-1 scale instead of raw rank offsets so merge order is not distorted (issue #3117).
+
+Stability: stable

--- a/packages/remnic-core/src/orchestration/recall-recognition-search.test.ts
+++ b/packages/remnic-core/src/orchestration/recall-recognition-search.test.ts
@@ -15,6 +15,7 @@ import test from "node:test";
 import { saveRecognitionIndex, type RecognitionIndex } from "../recall-recognition-tier.js";
 import {
   fetchQmdMemoryResultsWithRecognitionSwap,
+  recognitionHitScore,
   type RecognitionSearchDeps,
 } from "./recall-recognition-search.js";
 import type { QmdSearchResult } from "../types.js";
@@ -29,6 +30,13 @@ function indexOf(ids: string[]): RecognitionIndex {
     entries: ids.map((id) => ({ id, description: `trigger for ${id}` })),
   };
 }
+
+test("#3117 recognition hit scores stay on the retrieval 0-1 scale", () => {
+  assert.equal(recognitionHitScore(0), 1);
+  assert.ok(recognitionHitScore(1) < 1);
+  assert.ok(recognitionHitScore(1) > recognitionHitScore(2));
+  assert.ok(recognitionHitScore(99) > 0);
+});
 
 async function tmpDir(): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), "remnic-recognition-search-"));

--- a/packages/remnic-core/src/orchestration/recall-recognition-search.ts
+++ b/packages/remnic-core/src/orchestration/recall-recognition-search.ts
@@ -133,6 +133,10 @@ export async function fetchQmdMemoryResultsWithRecognitionSwap(
   );
 }
 
+export function recognitionHitScore(rankOffset: number): number {
+  return 1 / (1 + rankOffset);
+}
+
 async function hitsFromIds(
   namespace: string,
   storage: RecognitionStorage,
@@ -152,7 +156,7 @@ async function hitsFromIds(
       docid: `${namespace}:${rel}`,
       namespace,
       path: rel,
-      score: ids.length - offset,
+      score: recognitionHitScore(offset),
       snippet: descriptionById.get(id) ?? id,
     });
   }


### PR DESCRIPTION
$(cat <<'EOF'
Fixes #3117.

Recognition-tier hits used  as the score, so a 3-hit recognition batch scored 3/2/1 and dominated hybrid merge against 0-1 retrieval scores.

This PR scores hits as  so rank 0 is 1.0 and later ranks stay in (0, 1].

## Test
 — pass 1.

Stability: stable.
EOF
)