### PR TITLE
fix(core): exclude disputed memories from seed graduation

### DIFF
--- a/.changeset/3118-graduation-disputed-reindex.md
+++ b/.changeset/3118-graduation-disputed-reindex.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+---
+
+Exclude disputed memories from seed graduation and persist content-hash indexes after a promotion so graduated rows are searchable (issue #3118).
+
+Stability: stable

--- a/packages/remnic-core/src/lifecycle/seed-graduation.test.ts
+++ b/packages/remnic-core/src/lifecycle/seed-graduation.test.ts
@@ -39,6 +39,7 @@ function fakeMemory(overrides: {
   created: string;
   source?: string;
   status?: MemoryFrontmatter["status"];
+  verificationState?: MemoryFrontmatter["verificationState"];
   structuredAttributes?: Record<string, string>;
   lineage?: string[];
 }): MemoryFile {
@@ -55,6 +56,7 @@ function fakeMemory(overrides: {
       confidenceTier: "inferred",
       tags: [],
       status: overrides.status,
+      verificationState: overrides.verificationState,
       structuredAttributes: overrides.structuredAttributes,
       lineage: overrides.lineage,
     },
@@ -369,6 +371,20 @@ test("an independent negated restatement holds the seed even with enough corrobo
   assert.ok(decision.reasons.includes("contradiction-observed:1"));
 });
 
+test("#3118 disputed evidence cannot corroborate a seed", () => {
+  const seed = seedMemory({ id: "seed-1" });
+  const disputed = fakeMemory({
+    id: "ev-1",
+    content: RESTATE_TEXT,
+    created: "2026-08-02T10:00:00.000Z",
+    source: "wearable:limitless",
+    verificationState: "disputed",
+  });
+  const decision = evaluateSeedGraduation(seed, [disputed], { config: ENABLED });
+  assert.equal(decision.decision, "hold");
+  assert.equal(decision.corroborationCount, 0);
+});
+
 test("a negated seed restated positively is held (polarity symmetry)", () => {
   const seed = seedMemory({ id: "seed-1", content: CONTRADICT_TEXT });
   const positive = fakeMemory({
@@ -542,6 +558,34 @@ test("pass: independent corroboration promotes the seed in place with audit attr
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("#3118 disputed seed is skipped by the graduation pass", async () => {
+  const { storage, dir } = makeStorage();
+  try {
+    const seedWrite = await storage.writeMemory("fact", SEED_TEXT, {
+      source: "wearable:bee",
+      status: "pending_review",
+    });
+    await storage.writeMemory("fact", RESTATE_TEXT, {
+      source: "wearable:limitless",
+    });
+    const seed = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === seedWrite.id);
+    assert.ok(seed);
+    await storage.writeMemoryFrontmatter(seed, { verificationState: "disputed" });
+    const summary = await runSeedGraduationPass({
+      memories: await storage.readAllMemories(),
+      storage,
+      config: ENABLED,
+    });
+    assert.equal(summary.evaluated, 0);
+    assert.equal(summary.promoted, 0);
+    const held = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === seedWrite.id);
+    assert.equal(held?.frontmatter.status, "pending_review");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 
 test("pass: contradiction during the window holds the seed in place", async () => {
   const { storage, dir } = makeStorage();
@@ -727,6 +771,36 @@ test("lifecycle pass: enabled independent corroboration promotes through the pol
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("#3118 lifecycle pass reindexes after a graduation", async () => {
+  const { storage, dir } = makeStorage();
+  try {
+    await storage.writeMemory("fact", SEED_TEXT, {
+      source: "wearable:bee",
+      status: "pending_review",
+    });
+    await storage.writeMemory("fact", RESTATE_TEXT, {
+      source: "wearable:limitless",
+    });
+    const config = parseConfig({
+      memoryDir: dir,
+      seedGraduation: { enabled: true, minCorroborations: 1 },
+    });
+    const deps = coordinatorDeps(storage, config);
+    let saves = 0;
+    deps.saveContentHashIndexes = async () => {
+      saves += 1;
+    };
+    await new LifecyclePolicyCoordinator(deps).runLifecyclePolicyPass(
+      await storage.readAllMemories(),
+      storage,
+    );
+    assert.equal(saves, 1, "graduation must persist content-hash indexes");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 
 test("lifecycle pass: recall-handle history suppresses echo corroboration", async () => {
   const { storage, dir } = makeStorage();

--- a/packages/remnic-core/src/lifecycle/seed-graduation.test.ts
+++ b/packages/remnic-core/src/lifecycle/seed-graduation.test.ts
@@ -802,6 +802,56 @@ test("#3118 lifecycle pass reindexes after a graduation", async () => {
 });
 
 
+test("#3118 index-save failure does not unwind a completed graduation", async () => {
+  const { storage, dir } = makeStorage();
+  try {
+    await storage.writeMemory("fact", SEED_TEXT, {
+      source: "wearable:bee",
+      status: "pending_review",
+    });
+    await storage.writeMemory("fact", RESTATE_TEXT, {
+      source: "wearable:limitless",
+    });
+    const config = parseConfig({
+      memoryDir: dir,
+      seedGraduation: { enabled: true, minCorroborations: 1 },
+    });
+    const deps = coordinatorDeps(storage, config);
+    deps.saveContentHashIndexes = async () => {
+      throw new Error("index write failed");
+    };
+    await new LifecyclePolicyCoordinator(deps).runLifecyclePolicyPass(
+      await storage.readAllMemories(),
+      storage,
+    );
+    const seed = (await storage.readAllMemories()).find(
+      (memory) => memory.frontmatter.source === "wearable:bee",
+    );
+    assert.equal(seed?.frontmatter.status, "active", "graduation stays durable if reindex fails");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("#3118 promoteWearableMemory refuses a concurrently disputed seed", async () => {
+  const { storage, dir } = makeStorage();
+  try {
+    const seedWrite = await storage.writeMemory("fact", SEED_TEXT, {
+      source: "wearable:bee",
+      status: "pending_review",
+    });
+    const seed = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === seedWrite.id);
+    assert.ok(seed);
+    await storage.writeMemoryFrontmatter(seed, { verificationState: "disputed" });
+    assert.equal(await storage.promoteWearableMemory(seedWrite.id, { graduatedBy: "independent-corroboration" }), false);
+    const held = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === seedWrite.id);
+    assert.equal(held?.frontmatter.status, "pending_review");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+
 test("lifecycle pass: recall-handle history suppresses echo corroboration", async () => {
   const { storage, dir } = makeStorage();
   try {

--- a/packages/remnic-core/src/lifecycle/seed-graduation.ts
+++ b/packages/remnic-core/src/lifecycle/seed-graduation.ts
@@ -132,6 +132,10 @@ function isEvidenceStatus(status: MemoryStatus | undefined): boolean {
   return status === undefined || status === "active" || status === "pending_review";
 }
 
+function isGraduationEvidence(memory: MemoryFile): boolean {
+  return isEvidenceStatus(memory.frontmatter.status) && memory.frontmatter.verificationState !== "disputed";
+}
+
 function hasLineageLink(seed: MemoryFile, evidence: MemoryFile): boolean {
   const seedLineage = seed.frontmatter.lineage;
   if (seedLineage !== undefined && seedLineage.includes(evidence.frontmatter.id)) return true;
@@ -279,7 +283,7 @@ export function evaluateSeedGraduation(
     const candidateCreated = createdMs(candidate);
     if (!Number.isFinite(seedCreated) || !Number.isFinite(candidateCreated)) continue;
     if (candidateCreated <= seedCreated) continue;
-    if (!isEvidenceStatus(candidate.frontmatter.status)) continue;
+    if (!isGraduationEvidence(candidate)) continue;
     const candidateText = stripAttributesSuffix(candidate.content);
     if (hasNegationWord(candidateText) !== seedNegated) {
       // Polarity-flipped restatement of the seed's core content is a
@@ -417,7 +421,7 @@ export async function runSeedGraduationPass(
     return { evaluated: 0, promoted: 0, held: 0, contradictionHeld: 0, echoSuppressed: 0, disabled: true };
   }
   const corpus = excludeSupportPassportPrivateMemories(input.memories);
-  const evidencePool = corpus.filter((memory) => isEvidenceStatus(memory.frontmatter.status));
+  const evidencePool = corpus.filter((memory) => isGraduationEvidence(memory));
 
   let promoted = 0;
   let held = 0;
@@ -427,6 +431,7 @@ export async function runSeedGraduationPass(
 
   for (const seed of corpus) {
     if (seed.frontmatter.status !== "pending_review") continue;
+    if (seed.frontmatter.verificationState === "disputed") continue;
     // Tombstone-blocked rows need revokeTombstone first; the promotion
     // method refuses them anyway, so skip before evaluating.
     if (seed.frontmatter.blockedBy !== undefined) continue;

--- a/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/lifecycle-policy-coordinator.ts
@@ -261,12 +261,17 @@ export class LifecyclePolicyCoordinator {
     }
 
     const history = this.deps.getHandleHistory?.();
-    await runSeedGraduationPass({
+    const graduation = await runSeedGraduationPass({
       memories: allMemories,
       storage,
       config: this.config.seedGraduation,
       recalledBySession: history ? (sessionKey) => history.recent(sessionKey) : undefined,
     });
+    if (graduation.promoted > 0) {
+      await this.deps.saveContentHashIndexes().catch((err) =>
+        log.warn(`content-hash index save failed during seed graduation: ${err}`),
+      );
+    }
 
     // Report how many memories had frontmatter rewritten so callers can record a
     // catalog write touch for lifecycle-only passes (codex NR-tS).

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2598,6 +2598,7 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     const memory = memories.find((entry) => entry.frontmatter.id === id);
     if (!memory) return false;
     if (memory.frontmatter.status !== "pending_review") return false;
+    if (memory.frontmatter.verificationState === "disputed") return false;
     // Tombstone-blocked rows need revokeTombstone first (issue #1579 OcuDx/Ocu1l).
     if (memory.frontmatter.blockedBy) return false;
     return this.writeMemoryFrontmatter(memory, {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2601,11 +2601,8 @@ export class StorageManager extends TombstoneBlockedCaptureIndexHost {
     if (memory.frontmatter.verificationState === "disputed") return false;
     // Tombstone-blocked rows need revokeTombstone first (issue #1579 OcuDx/Ocu1l).
     if (memory.frontmatter.blockedBy) return false;
-    return this.writeMemoryFrontmatter(memory, {
+    return this.writeMemoryFrontmatterIfUnchanged(memory, {
       status: "active",
-      // Keep frontmatter confidence in step with the re-scored trust —
-      // new smart writes persist trust as confidence, and a promoted
-      // row must not keep its stale borderline value.
       ...(typeof confidence === "number" && Number.isFinite(confidence)
         ? { confidence: Math.min(1, Math.max(0, confidence)) }
         : {}),


### PR DESCRIPTION
Fixes #3118.

Seed graduation admitted `verificationState: disputed` rows as corroborating evidence and skipped the content-hash index save after a promotion, so graduated memories could stay undiscoverable.

- disputed seeds are not evaluated
- disputed evidence cannot corroborate
- `saveContentHashIndexes` runs after a successful promotion (same pattern as fact archival)

## Test
`tsx --test --test-name-pattern 3118 packages/remnic-core/src/lifecycle/seed-graduation.test.ts` — pass 3.

Stability: stable. Default remains `seedGraduation.enabled: false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Disputed memories are no longer used as evidence for seed graduation.
  - Disputed seeds remain unevaluated and are not graduated.
  - Promotions are prevented when a seed becomes disputed concurrently.
  - Newly graduated memories are now searchable through persisted content-hash indexes.
  - Completed graduations remain successful even if search-index persistence encounters an error.

- **Tests**
  - Added coverage for disputed evidence, disputed seeds, concurrent disputes, and post-graduation search indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->