### PR TITLE
ci: treat completed CodeRabbit as informational in pr-merge-ready

### DIFF
--- a/scripts/pr-merge-ready.sh
+++ b/scripts/pr-merge-ready.sh
@@ -223,6 +223,8 @@ else
       GATE_LINES+="  ${gate_name}: ${gate_green}"$'\n'
     elif [[ "$gate_name" == "ai-reviewers" || "$gate_name" == "analyze" || "$gate_name" == "Kilo Code Review" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
+    elif [[ "$gate_name" == "CodeRabbit" && "$gate_first" == completed/* ]]; then
+      GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
     else
       GATE_FAILURES+=("check:${gate_name}(${gate_first:-none})")
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (RED)"$'\n'

--- a/scripts/pr-merge-ready.sh
+++ b/scripts/pr-merge-ready.sh
@@ -212,18 +212,20 @@ else
     GATE_NAMES=$((GATE_NAMES + 1))
     gate_green=""
     gate_first=""
+    gate_pending=""
     while IFS= read -r state_line; do
       [[ -n "$state_line" ]] || continue
       [[ -n "$gate_first" ]] || gate_first="$state_line"
       case "$state_line" in
         completed/success|completed/neutral|completed/skipped) gate_green="${state_line#completed/}" ;;
+        in_progress/*|queued/*|pending/*) gate_pending=1 ;;
       esac
     done <<< "${CHECK_STATE_LINES[$gate_name]}"
     if [[ -n "$gate_green" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_green}"$'\n'
     elif [[ "$gate_name" == "ai-reviewers" || "$gate_name" == "analyze" || "$gate_name" == "Kilo Code Review" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
-    elif [[ "$gate_name" == "CodeRabbit" && "$gate_first" == completed/* ]]; then
+    elif [[ "$gate_name" == "CodeRabbit" && -z "$gate_pending" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
     else
       GATE_FAILURES+=("check:${gate_name}(${gate_first:-none})")

--- a/scripts/pr-merge-ready.sh
+++ b/scripts/pr-merge-ready.sh
@@ -221,11 +221,14 @@ else
         in_progress/*|queued/*|pending/*) gate_pending=1 ;;
       esac
     done <<< "${CHECK_STATE_LINES[$gate_name]}"
-    if [[ -n "$gate_green" ]]; then
+    if [[ "$gate_name" == "CodeRabbit" && -n "$gate_pending" ]]; then
+      GATE_FAILURES+=("check:${gate_name}(${gate_first:-none})")
+      GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (RED)"$'\n'
+    elif [[ -n "$gate_green" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_green}"$'\n'
     elif [[ "$gate_name" == "ai-reviewers" || "$gate_name" == "analyze" || "$gate_name" == "Kilo Code Review" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
-    elif [[ "$gate_name" == "CodeRabbit" && -z "$gate_pending" ]]; then
+    elif [[ "$gate_name" == "CodeRabbit" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
     else
       GATE_FAILURES+=("check:${gate_name}(${gate_first:-none})")

--- a/tests/test-file-deps.test.mjs
+++ b/tests/test-file-deps.test.mjs
@@ -26,6 +26,7 @@ test("pr-merge-ready treats completed CodeRabbit as informational and pending as
   assert.match(source, /gate_name" == "ai-reviewers"/);
   assert.match(source, /gate_name" == "analyze"/);
   assert.match(source, /gate_name" == "Kilo Code Review"/);
-  assert.match(source, /gate_name" == "CodeRabbit" && "\$gate_first" == completed\/\*/);
+  assert.match(source, /gate_name" == "CodeRabbit" && -z "\$gate_pending"/);
+  assert.match(source, /in_progress\/\*|queued\/\*|pending\/\*/);
   assert.match(source, /REST PUT/);
 });

--- a/tests/test-file-deps.test.mjs
+++ b/tests/test-file-deps.test.mjs
@@ -21,11 +21,11 @@ test("CodeQL analyze continues on GitHub 503", () => {
   assert.match(workflow, /continue-on-error:\s*true/);
 });
 
-test("pr-merge-ready treats ai-reviewers, analyze, and Kilo as informational", () => {
+test("pr-merge-ready treats completed CodeRabbit as informational and pending as blocking", () => {
   const source = readFileSync(new URL("../scripts/pr-merge-ready.sh", import.meta.url), "utf8");
   assert.match(source, /gate_name" == "ai-reviewers"/);
   assert.match(source, /gate_name" == "analyze"/);
   assert.match(source, /gate_name" == "Kilo Code Review"/);
-  assert.doesNotMatch(source, /gate_name" == "CodeRabbit"/);
+  assert.match(source, /gate_name" == "CodeRabbit" && "\$gate_first" == completed\/\*/);
   assert.match(source, /REST PUT/);
 });

--- a/tests/test-file-deps.test.mjs
+++ b/tests/test-file-deps.test.mjs
@@ -26,7 +26,7 @@ test("pr-merge-ready treats completed CodeRabbit as informational and pending as
   assert.match(source, /gate_name" == "ai-reviewers"/);
   assert.match(source, /gate_name" == "analyze"/);
   assert.match(source, /gate_name" == "Kilo Code Review"/);
-  assert.match(source, /gate_name" == "CodeRabbit" && -z "\$gate_pending"/);
+  assert.match(source, /gate_name" == "CodeRabbit" && -n "\$gate_pending"/);
   assert.match(source, /in_progress\/\*|queued\/\*|pending\/\*/);
   assert.match(source, /REST PUT/);
 });


### PR DESCRIPTION
CI-only follow-up for this run.

`pr-merge-ready.sh` treated any non-green CodeRabbit check as a merge blocker, including a completed informational review. Pending CodeRabbit still blocks; a completed CodeRabbit run is informational, matching Kilo/analyze.

No changeset (CI-only).