### PR TITLE
fix(plugin-openclaw): skip foreign-corpus loopback on explicit delegate

### DIFF
--- a/.changeset/3077-delegate-foreign-corpus.md
+++ b/.changeset/3077-delegate-foreign-corpus.md
@@ -1,0 +1,7 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Explicit delegate preflight skips a same-host loopback daemon that serves a different memoryDir and dials the configured NIC instead (issue #3077).
+
+Stability: stable

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -2934,6 +2934,7 @@ test("#3077 explicit delegate skips loopback when it serves a foreign corpus", (
     .find((entry) => entry.family === "IPv4" && !entry.internal);
   if (local === undefined) return;
   const prior = { mode: process.env.REMNIC_BRIDGE_MODE, host: process.env.REMNIC_HOST, port: process.env.REMNIC_PORT };
+  const memoryDir = path.join(os.tmpdir(), "remnic-delegate-foreign-corpus");
   process.env.REMNIC_BRIDGE_MODE = "delegate";
   process.env.REMNIC_HOST = local.address;
   process.env.REMNIC_PORT = "4318";
@@ -2949,7 +2950,7 @@ test("#3077 explicit delegate skips loopback when it serves a foreign corpus", (
         allowPromptInjection: true,
         gateHeartbeatTurns: false,
         recallBudgetChars: 8_000,
-        memoryDir: path.join(os.tmpdir(), "remnic-delegate-foreign-corpus"),
+        memoryDir,
         sessionTogglesEnabled: false,
         respectBundledActiveMemoryToggle: false,
         cleanUserMessage: (text: string) => text,
@@ -2963,7 +2964,10 @@ test("#3077 explicit delegate skips loopback when it serves a foreign corpus", (
           probed.push(`health:${host}`);
           return true;
         },
-        checkCorpus: (host) => {
+        checkCorpus: (host, port, timeoutMs, dir) => {
+          assert.equal(port, 4318);
+          assert.ok(timeoutMs > 0 && timeoutMs <= 5_000);
+          assert.equal(dir, memoryDir);
           probed.push(`corpus:${host}`);
           return host !== "127.0.0.1";
         },

--- a/packages/plugin-openclaw/src/delegate-runtime.test.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.test.ts
@@ -2928,6 +2928,63 @@ test("explicit delegate preflight retries the configured interface address after
   }
 });
 
+test("#3077 explicit delegate skips loopback when it serves a foreign corpus", () => {
+  const local = Object.values(os.networkInterfaces())
+    .flatMap((entries) => entries ?? [])
+    .find((entry) => entry.family === "IPv4" && !entry.internal);
+  if (local === undefined) return;
+  const prior = { mode: process.env.REMNIC_BRIDGE_MODE, host: process.env.REMNIC_HOST, port: process.env.REMNIC_PORT };
+  process.env.REMNIC_BRIDGE_MODE = "delegate";
+  process.env.REMNIC_HOST = local.address;
+  process.env.REMNIC_PORT = "4318";
+  try {
+    const probed: string[] = [];
+    const handled = maybeRegisterDelegateRuntime(
+      recordingApi(),
+      {
+        serviceId: "openclaw-remnic",
+        configBridgeMode: "delegate",
+        bridgeHealthTimeoutMs: 5_000,
+        passive: false,
+        allowPromptInjection: true,
+        gateHeartbeatTurns: false,
+        recallBudgetChars: 8_000,
+        memoryDir: path.join(os.tmpdir(), "remnic-delegate-foreign-corpus"),
+        sessionTogglesEnabled: false,
+        respectBundledActiveMemoryToggle: false,
+        cleanUserMessage: (text: string) => text,
+        hookTimeoutMs: 5_000,
+        shouldSkipRecall: () => false,
+        flushOnResetEnabled: true,
+        capability: TEST_CAPABILITY,
+      },
+      {
+        checkHealth: (host) => {
+          probed.push(`health:${host}`);
+          return true;
+        },
+        checkCorpus: (host) => {
+          probed.push(`corpus:${host}`);
+          return host !== "127.0.0.1";
+        },
+        probeAuthorization: async () => ({ state: "authorized", tokenSource: "test" }) as never,
+      },
+    );
+    assert.equal(handled, true);
+    assert.deepEqual(probed, ["health:127.0.0.1", "corpus:127.0.0.1", `health:${local.address}`]);
+  } finally {
+    for (const [key, value] of [
+      ["REMNIC_BRIDGE_MODE", prior.mode],
+      ["REMNIC_HOST", prior.host],
+      ["REMNIC_PORT", prior.port],
+    ] as const) {
+      if (value === undefined) Reflect.deleteProperty(process.env, key);
+      else process.env[key] = value;
+    }
+  }
+});
+
+
 test("maybeRegisterDelegateRuntime deduplicates hook binding per api object", async () => {
   const stub = await startDaemonStub(() => ({ context: "ctx" }));
   try {

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -881,7 +881,7 @@ export interface MaybeRegisterDelegateDeps {
    * serves a different corpus than `memoryDir`. Tests omit this to keep the
    * liveness mock as the only network seam.
    */
-  checkCorpus?: (host: string, port: number, timeoutMs: number, memoryDir: string) => boolean;
+  checkCorpus?: (host: string, port: number, timeoutMs: number, memoryDir: string, configPath?: string) => boolean;
   probeAuthorization?: (
     target: DelegateDaemonTarget,
     namespace: string,
@@ -892,7 +892,17 @@ export interface MaybeRegisterDelegateDeps {
 export function maybeRegisterDelegateRuntime(
   api: DelegateHookApi,
   options: MaybeRegisterDelegateOptions,
-  deps: MaybeRegisterDelegateDeps = { checkHealth: checkDaemonHealthSync },
+  deps: MaybeRegisterDelegateDeps = {
+    checkHealth: checkDaemonHealthSync,
+    checkCorpus: (host, port, timeoutMs, memoryDir, configPath) => {
+      const probe = readDaemonMemoryDirSync(host, port, timeoutMs, configPath);
+      return (
+        probe.healthy === true &&
+        probe.memoryDir !== undefined &&
+        daemonServesCorpus(memoryDir, probe.memoryDir)
+      );
+    },
+  },
 ): boolean {
   // BEFORE any health-dependent resolution: if this service already has
   // delegate hooks on this api, they are still attached (OpenClaw exposes no
@@ -1007,22 +1017,15 @@ export function maybeRegisterDelegateRuntime(
     // a loopback that accepts and stalls must not let the fallback spend the
     // documented total again.
     const preflightDeadline = Date.now() + bridgeHealthTimeoutMs;
-    const corpusOk =
-      deps.checkCorpus ??
-      ((host, port, timeoutMs, memoryDir) => {
-        const probe = readDaemonMemoryDirSync(host, port, timeoutMs, bridge.daemonConfigPath);
-        return (
-          probe.healthy === true &&
-          probe.memoryDir !== undefined &&
-          daemonServesCorpus(memoryDir, probe.memoryDir)
-        );
-      });
     const healthyHost = hosts.find((host, index) => {
       const remaining = index === 0 ? bridgeHealthTimeoutMs : preflightDeadline - Date.now();
       if (!(remaining > 0 && deps.checkHealth(host, bridge.daemonPort, remaining))) return false;
-      if (index === 0 && hosts.length > 1) {
+      if (index === 0 && hosts.length > 1 && deps.checkCorpus !== undefined) {
         const corpusRemaining = preflightDeadline - Date.now();
-        if (corpusRemaining <= 0 || !corpusOk(host, bridge.daemonPort, corpusRemaining, options.memoryDir)) {
+        if (
+          corpusRemaining <= 0 ||
+          !deps.checkCorpus(host, bridge.daemonPort, corpusRemaining, options.memoryDir, bridge.daemonConfigPath)
+        ) {
           return false;
         }
       }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -60,10 +60,12 @@ import {
   checkDaemonHealthSync,
   daemonUrl,
   parseOpenClawBridgeConfig,
+  readDaemonMemoryDirSync,
   resolveBridgeMode,
   requestedDelegate,
   resolveRequestedBridgeMode,
 } from "./bridge.js";
+import { daemonServesCorpus } from "./memory-read-scope.js";
 import { REMNIC_OPENCLAW_LEGACY_PLUGIN_ID } from "./plugin-id.js";
 import {
   extractLastTurn,
@@ -874,7 +876,12 @@ const delegateAuthorizationPreflightServices = new WeakMap<object, Set<string>>(
 export interface MaybeRegisterDelegateDeps {
   /** Injectable liveness preflight — defaults to the bridge's worker-backed sync probe. */
   checkHealth: (host: string, port: number, timeoutMs: number) => boolean;
-  /** Injectable authorization preflight for standalone daemon compatibility. */
+  /**
+   * When loopback and a configured NIC both answer, reject the first host if it
+   * serves a different corpus than `memoryDir`. Tests omit this to keep the
+   * liveness mock as the only network seam.
+   */
+  checkCorpus?: (host: string, port: number, timeoutMs: number, memoryDir: string) => boolean;
   probeAuthorization?: (
     target: DelegateDaemonTarget,
     namespace: string,
@@ -885,7 +892,13 @@ export interface MaybeRegisterDelegateDeps {
 export function maybeRegisterDelegateRuntime(
   api: DelegateHookApi,
   options: MaybeRegisterDelegateOptions,
-  deps: MaybeRegisterDelegateDeps = { checkHealth: checkDaemonHealthSync },
+  deps: MaybeRegisterDelegateDeps = {
+    checkHealth: checkDaemonHealthSync,
+    checkCorpus: (host, port, timeoutMs, memoryDir) => {
+      const probe = readDaemonMemoryDirSync(host, port, timeoutMs);
+      return probe.memoryDir === undefined || daemonServesCorpus(memoryDir, probe.memoryDir);
+    },
+  },
 ): boolean {
   // BEFORE any health-dependent resolution: if this service already has
   // delegate hooks on this api, they are still attached (OpenClaw exposes no
@@ -1002,7 +1015,14 @@ export function maybeRegisterDelegateRuntime(
     const preflightDeadline = Date.now() + bridgeHealthTimeoutMs;
     const healthyHost = hosts.find((host, index) => {
       const remaining = index === 0 ? bridgeHealthTimeoutMs : preflightDeadline - Date.now();
-      return remaining > 0 && deps.checkHealth(host, bridge.daemonPort, remaining);
+      if (!(remaining > 0 && deps.checkHealth(host, bridge.daemonPort, remaining))) return false;
+      if (index === 0 && hosts.length > 1 && deps.checkCorpus !== undefined) {
+        const corpusRemaining = preflightDeadline - Date.now();
+        if (corpusRemaining > 0 && !deps.checkCorpus(host, bridge.daemonPort, corpusRemaining, options.memoryDir)) {
+          return false;
+        }
+      }
+      return true;
     });
     if (healthyHost !== undefined && healthyHost !== bridge.daemonHost) {
       log.info(

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -892,13 +892,7 @@ export interface MaybeRegisterDelegateDeps {
 export function maybeRegisterDelegateRuntime(
   api: DelegateHookApi,
   options: MaybeRegisterDelegateOptions,
-  deps: MaybeRegisterDelegateDeps = {
-    checkHealth: checkDaemonHealthSync,
-    checkCorpus: (host, port, timeoutMs, memoryDir) => {
-      const probe = readDaemonMemoryDirSync(host, port, timeoutMs);
-      return probe.memoryDir === undefined || daemonServesCorpus(memoryDir, probe.memoryDir);
-    },
-  },
+  deps: MaybeRegisterDelegateDeps = { checkHealth: checkDaemonHealthSync },
 ): boolean {
   // BEFORE any health-dependent resolution: if this service already has
   // delegate hooks on this api, they are still attached (OpenClaw exposes no
@@ -1013,12 +1007,22 @@ export function maybeRegisterDelegateRuntime(
     // a loopback that accepts and stalls must not let the fallback spend the
     // documented total again.
     const preflightDeadline = Date.now() + bridgeHealthTimeoutMs;
+    const corpusOk =
+      deps.checkCorpus ??
+      ((host, port, timeoutMs, memoryDir) => {
+        const probe = readDaemonMemoryDirSync(host, port, timeoutMs, bridge.daemonConfigPath);
+        return (
+          probe.healthy === true &&
+          probe.memoryDir !== undefined &&
+          daemonServesCorpus(memoryDir, probe.memoryDir)
+        );
+      });
     const healthyHost = hosts.find((host, index) => {
       const remaining = index === 0 ? bridgeHealthTimeoutMs : preflightDeadline - Date.now();
       if (!(remaining > 0 && deps.checkHealth(host, bridge.daemonPort, remaining))) return false;
-      if (index === 0 && hosts.length > 1 && deps.checkCorpus !== undefined) {
+      if (index === 0 && hosts.length > 1) {
         const corpusRemaining = preflightDeadline - Date.now();
-        if (corpusRemaining > 0 && !deps.checkCorpus(host, bridge.daemonPort, corpusRemaining, options.memoryDir)) {
+        if (corpusRemaining > 0 && !corpusOk(host, bridge.daemonPort, corpusRemaining, options.memoryDir)) {
           return false;
         }
       }

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -1022,7 +1022,7 @@ export function maybeRegisterDelegateRuntime(
       if (!(remaining > 0 && deps.checkHealth(host, bridge.daemonPort, remaining))) return false;
       if (index === 0 && hosts.length > 1) {
         const corpusRemaining = preflightDeadline - Date.now();
-        if (corpusRemaining > 0 && !corpusOk(host, bridge.daemonPort, corpusRemaining, options.memoryDir)) {
+        if (corpusRemaining <= 0 || !corpusOk(host, bridge.daemonPort, corpusRemaining, options.memoryDir)) {
           return false;
         }
       }


### PR DESCRIPTION
Part of #3077.

Explicit `delegate` preflight dials loopback before a same-host NIC address. If both listeners answer, liveness alone selected loopback even when it served a different `memoryDir`.

This PR rejects the loopback host when `checkCorpus` reports a foreign corpus and falls through to the configured address. Tests that omit `checkCorpus` keep the previous liveness-only seam.

Remaining #3077 items: observe-drain flush ordering, uncredentialed probe, detached observe bound.

## Test
`tsx --test --test-name-pattern "3077 explicit delegate" packages/plugin-openclaw/src/delegate-runtime.test.ts` — pass.

Stability: stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delegate connection checks to confirm that a healthy local daemon serves the configured memory corpus.
  * When a loopback daemon serves a different corpus, connections now fall back to the configured network address.
  * Delegate registration now avoids connecting to an incompatible local daemon.

* **Tests**
  * Added coverage verifying corpus validation, fallback behavior, host selection, and probe order during delegate registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->