### PR TITLE
fix(plugin-openclaw): uncredentialed liveness and observeTimeoutMs

### DIFF
--- a/.changeset/3077-liveness-observe-timeout.md
+++ b/.changeset/3077-liveness-observe-timeout.md
@@ -2,6 +2,6 @@
 "@remnic/plugin-openclaw": patch
 ---
 
-Liveness probes no longer send a bearer token, and detached observe uses `observeTimeoutMs` instead of half the flush budget (issue #3077).
+Liveness probes anonymously first (200 or 401/403 counts as live) and only send a bearer token if that request returns a non-auth HTTP error with time remaining. Detached observe uses `observeTimeoutMs` instead of half the flush budget (issue #3077).
 
 Stability: stable

--- a/.changeset/3077-liveness-observe-timeout.md
+++ b/.changeset/3077-liveness-observe-timeout.md
@@ -1,0 +1,7 @@
+---
+"@remnic/plugin-openclaw": patch
+---
+
+Liveness probes no longer send a bearer token, and detached observe uses `observeTimeoutMs` instead of half the flush budget (issue #3077).
+
+Stability: stable

--- a/packages/plugin-openclaw/src/bridge-auto-mode.test.ts
+++ b/packages/plugin-openclaw/src/bridge-auto-mode.test.ts
@@ -683,6 +683,19 @@ test("#3077 liveness probe does not send a bearer token", async () => {
   }
 });
 
+test("#3077 liveness treats an anonymous 401 as a live daemon", async () => {
+  const stub = await startHealthStub({ ok: true }, 200, 0, false, "daemon-token");
+  try {
+    assert.equal(
+      withDaemonEnv(stub.port, () => checkDaemonHealthSync("127.0.0.1", stub.port, 2_000)),
+      true,
+    );
+  } finally {
+    await stub.close();
+  }
+});
+
+
 
 test("host and port come from ONE config file, never spliced across two", async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), "remnic-split-config-"));

--- a/packages/plugin-openclaw/src/bridge-auto-mode.test.ts
+++ b/packages/plugin-openclaw/src/bridge-auto-mode.test.ts
@@ -47,8 +47,6 @@ const server = http.createServer((req, res) => {
   // \`hang\`: accept the connection and never answer, so the probe must burn its
   // whole timeout - the only way to observe a shared preflight deadline.
   if (workerData.hang) return;
-  // \`requireToken\`: answer 401 for anything else, the way a daemon rejects a
-  // stale credential.
   if (workerData.requireToken) {
     const auth = req.headers.authorization;
     if (auth !== \`Bearer \${workerData.requireToken}\`) {
@@ -56,6 +54,11 @@ const server = http.createServer((req, res) => {
       res.end(JSON.stringify({ error: "unauthorized" }));
       return;
     }
+  }
+  if (workerData.rejectBearer && req.headers.authorization) {
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unauthorized" }));
+    return;
   }
   served += 1;
   // \`stallBody\`: send the headers and a partial body, then drop the socket.
@@ -95,6 +98,7 @@ async function startHealthStub(
   stallBody = false,
   listenHost?: string,
   delayMs = 0,
+  rejectBearer = false,
 ): Promise<HealthStub> {
   const worker = new Worker(
     new URL(`data:text/javascript,${encodeURIComponent(STUB_SOURCE)}`),
@@ -108,6 +112,7 @@ async function startHealthStub(
         stallBody,
         listenHost,
         delayMs,
+        rejectBearer,
         body: typeof body === "string" ? body : JSON.stringify(body),
       },
     } as ConstructorParameters<typeof Worker>[1] & { type: "module" },
@@ -661,6 +666,23 @@ test("a daemon that never opens its readiness gate stays unhealthy", async () =>
     await stub.close();
   }
 });
+
+test("#3077 liveness probe does not send a bearer token", async () => {
+  const stub = await startHealthStub({ ok: true }, 200, 0, false, undefined, false, undefined, 0, true);
+  const prior = process.env.REMNIC_AUTH_TOKEN;
+  process.env.REMNIC_AUTH_TOKEN = "should-not-be-sent";
+  try {
+    assert.equal(
+      withDaemonEnv(stub.port, () => checkDaemonHealthSync("127.0.0.1", stub.port, 2_000)),
+      true,
+    );
+  } finally {
+    if (prior === undefined) Reflect.deleteProperty(process.env, "REMNIC_AUTH_TOKEN");
+    else process.env.REMNIC_AUTH_TOKEN = prior;
+    await stub.close();
+  }
+});
+
 
 test("host and port come from ONE config file, never spliced across two", async () => {
   const home = await mkdtemp(path.join(os.tmpdir(), "remnic-split-config-"));

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -376,6 +376,7 @@ export function checkDaemonHealthSync(
   timeoutMs = DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
 ): boolean {
   assertProbeBudget(timeoutMs);
+  const deadline = Date.now() + timeoutMs;
   const anonymous = probeDaemonSync({
     host,
     port,
@@ -386,10 +387,12 @@ export function checkDaemonHealthSync(
   });
   if (anonymous.ok || anonymous.rejectedAuth === true) return true;
   if (anonymous.failure === "network") return false;
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return false;
   return probeDaemonSync({
     host,
     port,
-    timeoutMs,
+    timeoutMs: remaining,
     path: LIVENESS_PATH,
     fallbackPath: LEGACY_HEALTH_PATH,
   }).ok;

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -384,6 +384,7 @@ export function checkDaemonHealthSync(
     timeoutMs,
     path: LIVENESS_PATH,
     fallbackPath: LEGACY_HEALTH_PATH,
+    authToken: "",
   }).ok;
 }
 

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -375,16 +375,23 @@ export function checkDaemonHealthSync(
   port: number,
   timeoutMs = DEFAULT_DAEMON_HEALTH_TIMEOUT_MS,
 ): boolean {
-  // Same hazard as the capture probe: a non-finite budget reaches
-  // `Atomics.wait` as an unbounded wait on the caller's main thread.
   assertProbeBudget(timeoutMs);
-  return probeDaemonSync({
+  const anonymous = probeDaemonSync({
     host,
     port,
     timeoutMs,
     path: LIVENESS_PATH,
     fallbackPath: LEGACY_HEALTH_PATH,
     authToken: "",
+  });
+  if (anonymous.ok || anonymous.rejectedAuth === true) return true;
+  if (anonymous.failure === "network") return false;
+  return probeDaemonSync({
+    host,
+    port,
+    timeoutMs,
+    path: LIVENESS_PATH,
+    fallbackPath: LEGACY_HEALTH_PATH,
   }).ok;
 }
 

--- a/packages/plugin-openclaw/src/delegate-runtime.ts
+++ b/packages/plugin-openclaw/src/delegate-runtime.ts
@@ -499,13 +499,11 @@ export function registerDelegateRuntime(
     // connection and never answers would otherwise hold the host's agent_end
     // for the whole observe timeout on every turn; the turn capture is not
     // worth that, and its result feeds nothing the host waits for. Per-session
-    // chaining keeps turns in order and lets a flush wait behind them. That
-    // wait draws on the flush deadline, so an observe gets at most HALF of
-    // it: the drain can always outwait the observe (nothing lands after the
-    // session's final flush), and the flush keeps the other half for its own
-    // requests rather than inheriting a ~1ms remainder from a slow observe.
+    // chaining keeps turns in order and lets a flush wait behind them. The
+    // drain still uses half the flush budget; the observe POST itself uses
+    // `observeTimeoutMs` so a slow accept is not cut to the drain half.
     const observe = async (): Promise<void> => {
-      const observeDeadline = Date.now() + Math.min(options.observeTimeoutMs, options.flushTimeoutMs / 2);
+      const observeDeadline = Date.now() + Math.max(1, options.observeTimeoutMs);
       const observeRemaining = (): number => observeDeadline - Date.now();
       try {
         await postJson(


### PR DESCRIPTION
Part of #3077.

- Liveness (`checkDaemonHealthSync`) no longer sends a bearer token, so a loopback daemon that rejects the gateway token can still be classified as live vs down without a 401.
- Detached observe uses `observeTimeoutMs` instead of `min(observeTimeoutMs, flushTimeoutMs / 2)`. The flush drain still uses half the flush budget.

Observe-drain follow-up flush on timeout is already on main.

## Test
`tsx --test --test-name-pattern "3077 liveness" packages/plugin-openclaw/src/bridge-auto-mode.test.ts` — pass.

Stability: stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Liveness health checks now begin without authentication tokens and retry with configured credentials only when needed, improving compatibility with token-rejecting endpoints.
  * Detached observation requests now receive their full configured timeout instead of being limited by the flush timeout, reducing premature timeouts during slower daemon responses.
* **Documentation**
  * Updated release information to reflect these reliability and authentication behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->