### PR TITLE
ci: distinguish WAITING from BLOCKED in pr-merge-ready

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,7 +530,7 @@ Established from multi-issue batch runs. Each row documents a repeatable frictio
 | GraphQL rate limit exhausted by `gh issue edit` / `gh issue view --json` / `gh pr view --json` | Prefer REST: `gh api repos/.../issues/<n>`, `gh api repos/.../pulls/<n>/reviews`, `gh api repos/.../pulls/<n>/comments`. REST has a separate 5000-requests/hour budget |
 | `scripts/dev-worktree.sh` is a shell script | Invoke as `bash scripts/dev-worktree.sh`, never `node scripts/dev-worktree.sh` |
 | Sync daemon health probes hang against a local HTTP stub | The probe uses `Atomics.wait` on the calling thread. The stub must run on a worker; a main-thread `http.createServer` never accepts |
-| `pr-merge-ready --check` reports BLOCKED while shards are still running | Verdict is `WAITING` (exit 2) when remaining required checks are `in_progress`/`queued`/`pending`. `BLOCKED` is failed checks, unresolved threads, thread-read failures, or current-head `CHANGES_REQUESTED` |
+| `pr-merge-ready --check` reports BLOCKED while shards are still running | Verdict is `WAITING` (exit 3) when remaining required checks are `in_progress`/`queued`/`pending`. `BLOCKED` is failed checks, unresolved threads, thread-read failures, or current-head `CHANGES_REQUESTED` |
 
 
 ## Mechanical Stream Rules (`.omp/rules/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,6 +529,8 @@ Established from multi-issue batch runs. Each row documents a repeatable frictio
 | Background omp processes killed by shell job control | Use `setsid` + `disown` (or `nohup setsid`) to detach from the shell process group. Bare `&` does not survive the bash tool's job-reaping |
 | GraphQL rate limit exhausted by `gh issue edit` / `gh issue view --json` / `gh pr view --json` | Prefer REST: `gh api repos/.../issues/<n>`, `gh api repos/.../pulls/<n>/reviews`, `gh api repos/.../pulls/<n>/comments`. REST has a separate 5000-requests/hour budget |
 | `scripts/dev-worktree.sh` is a shell script | Invoke as `bash scripts/dev-worktree.sh`, never `node scripts/dev-worktree.sh` |
+| Sync daemon health probes hang against a local HTTP stub | The probe uses `Atomics.wait` on the calling thread. The stub must run on a worker; a main-thread `http.createServer` never accepts |
+| `pr-merge-ready --check` reports BLOCKED while shards are still running | Verdict is `WAITING` (exit 2) when remaining required checks are `in_progress`/`queued`/`pending`. `BLOCKED` is failed checks, unresolved threads, or current-head `CHANGES_REQUESTED` |
 
 
 ## Mechanical Stream Rules (`.omp/rules/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,7 +530,7 @@ Established from multi-issue batch runs. Each row documents a repeatable frictio
 | GraphQL rate limit exhausted by `gh issue edit` / `gh issue view --json` / `gh pr view --json` | Prefer REST: `gh api repos/.../issues/<n>`, `gh api repos/.../pulls/<n>/reviews`, `gh api repos/.../pulls/<n>/comments`. REST has a separate 5000-requests/hour budget |
 | `scripts/dev-worktree.sh` is a shell script | Invoke as `bash scripts/dev-worktree.sh`, never `node scripts/dev-worktree.sh` |
 | Sync daemon health probes hang against a local HTTP stub | The probe uses `Atomics.wait` on the calling thread. The stub must run on a worker; a main-thread `http.createServer` never accepts |
-| `pr-merge-ready --check` reports BLOCKED while shards are still running | Verdict is `WAITING` (exit 2) when remaining required checks are `in_progress`/`queued`/`pending`. `BLOCKED` is failed checks, unresolved threads, or current-head `CHANGES_REQUESTED` |
+| `pr-merge-ready --check` reports BLOCKED while shards are still running | Verdict is `WAITING` (exit 2) when remaining required checks are `in_progress`/`queued`/`pending`. `BLOCKED` is failed checks, unresolved threads, thread-read failures, or current-head `CHANGES_REQUESTED` |
 
 
 ## Mechanical Stream Rules (`.omp/rules/`)

--- a/scripts/pr-merge-ready.sh
+++ b/scripts/pr-merge-ready.sh
@@ -192,6 +192,7 @@ if ! pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid,headRefN
 fi
 IFS=$'\t' read -r HEAD_SHA BRANCH PR_STATE MERGE_STATE <<< "$pr_meta"
 GATE_FAILURES=()
+GATE_WAITING=()
 GATE_LINES=""
 GATE_NAMES=0
 if ! check_runs_raw=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate --jq '.check_runs[] | [.name, (.status // "-"), (.conclusion // "-"), (.head_sha // "-")] | @tsv' 2>/dev/null); then
@@ -230,6 +231,9 @@ else
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
     elif [[ "$gate_name" == "CodeRabbit" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
+    elif [[ -n "$gate_pending" ]]; then
+      GATE_WAITING+=("check:${gate_name}(${gate_first:-none})")
+      GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (WAITING)"$'\n'
     else
       GATE_FAILURES+=("check:${gate_name}(${gate_first:-none})")
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (RED)"$'\n'
@@ -270,7 +274,9 @@ fi
 [[ "$PR_STATE" == "OPEN" ]] || GATE_FAILURES+=("state:${PR_STATE}")
 
 GATES_OK=true
-[[ ${#GATE_FAILURES[@]} -eq 0 && "$THREAD_UNRESOLVED" -eq 0 && "$THREADS_READ_FAILED" == false ]] || GATES_OK=false
+[[ ${#GATE_FAILURES[@]} -eq 0 && ${#GATE_WAITING[@]} -eq 0 && "$THREAD_UNRESOLVED" -eq 0 && "$THREADS_READ_FAILED" == false ]] || GATES_OK=false
+GATES_WAITING=false
+[[ ${#GATE_FAILURES[@]} -eq 0 && ${#GATE_WAITING[@]} -gt 0 && "$THREAD_UNRESOLVED" -eq 0 && "$THREADS_READ_FAILED" == false && "$CURRENT_HEAD_BLOCKING" -eq 0 ]] && GATES_WAITING=true
 
 printf '== pr-merge-ready #%s (%s) ==\n' "$PR_NUMBER" "$REPO"
 printf 'head:            %s\n' "$HEAD_SHA"
@@ -295,8 +301,16 @@ if [[ ${#GATE_FAILURES[@]} -gt 0 ]]; then
     printf '  - %s\n' "$failure"
   done
 fi
+if [[ ${#GATE_WAITING[@]} -gt 0 ]]; then
+  printf 'waiting:\n'
+  for waiting in "${GATE_WAITING[@]}"; do
+    printf '  - %s\n' "$waiting"
+  done
+fi
 if [[ "$GATES_OK" == true ]]; then
   printf 'verdict:         READY\n'
+elif [[ "$GATES_WAITING" == true ]]; then
+  printf 'verdict:         WAITING\n'
 else
   printf 'verdict:         BLOCKED\n'
 fi
@@ -313,6 +327,9 @@ if [[ "$DRY_RUN" == true ]]; then
   printf '  3. poll state until MERGED, then git push origin --delete %s\n' "$BRANCH"
   if [[ "$GATES_OK" == true ]]; then
     exit 0
+  fi
+  if [[ "$GATES_WAITING" == true ]]; then
+    exit 2
   fi
   exit 1
 fi

--- a/scripts/pr-merge-ready.sh
+++ b/scripts/pr-merge-ready.sh
@@ -20,7 +20,8 @@ set -euo pipefail
 #    auto-closes the PR (hit on #2434).
 #
 # `--check` prints the plan (evidence + intended actions) without acting.
-# Exit 0 on success, 1 when a gate or merge step blocks, 2 on usage errors.
+# Exit 0 on success, 1 when a gate or merge step blocks, 2 on usage errors,
+# 3 when `--check` is waiting on in-progress required checks.
 
 # Resolve the real gh binary when a tool-manager wrapper appears first on PATH.
 resolve_mise_gh() {
@@ -214,12 +215,14 @@ else
     gate_green=""
     gate_first=""
     gate_pending=""
+    gate_failed=""
     while IFS= read -r state_line; do
       [[ -n "$state_line" ]] || continue
       [[ -n "$gate_first" ]] || gate_first="$state_line"
       case "$state_line" in
         completed/success|completed/neutral|completed/skipped) gate_green="${state_line#completed/}" ;;
         in_progress/*|queued/*|pending/*) gate_pending=1 ;;
+        completed/failure|completed/cancelled|completed/timed_out|completed/action_required|completed/stale) gate_failed=1 ;;
       esac
     done <<< "${CHECK_STATE_LINES[$gate_name]}"
     if [[ "$gate_name" == "CodeRabbit" && -n "$gate_pending" ]]; then
@@ -231,6 +234,9 @@ else
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
     elif [[ "$gate_name" == "CodeRabbit" ]]; then
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (informational)"$'\n'
+    elif [[ -n "$gate_failed" ]]; then
+      GATE_FAILURES+=("check:${gate_name}(${gate_first:-none})")
+      GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (RED)"$'\n'
     elif [[ -n "$gate_pending" ]]; then
       GATE_WAITING+=("check:${gate_name}(${gate_first:-none})")
       GATE_LINES+="  ${gate_name}: ${gate_first:-unknown} (WAITING)"$'\n'
@@ -329,7 +335,7 @@ if [[ "$DRY_RUN" == true ]]; then
     exit 0
   fi
   if [[ "$GATES_WAITING" == true ]]; then
-    exit 2
+    exit 3
   fi
   exit 1
 fi

--- a/tests/pr-merge-ready.test.mjs
+++ b/tests/pr-merge-ready.test.mjs
@@ -326,11 +326,19 @@ test("treats a red ai-reviewers or analyze check as informational", async () => 
   });
 });
 
-test("blocks on a pending head check", async () => {
-  await withStubs("pending_check", async (env) => {
+test("waits on a pending head check without merging", async () => {
+  await withStubs("pending_check", async (env, { ghLog, gitLog }) => {
     const result = run(env, []);
     assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`);
-    assert.match(result.stdout, /ci: in_progress\/- \(RED\)/);
+    assert.match(result.stdout, /ci: in_progress\/- \(WAITING\)/);
+    assert.match(result.stdout, /verdict:\s+WAITING/);
+    assert.match(result.stderr, /gates not satisfied/);
+    assert.doesNotMatch(await readLog(ghLog), /merge:/);
+    assert.equal(await readLog(gitLog), "");
+
+    const check = run(env, ["--check"]);
+    assert.equal(check.status, 2, `${check.stderr}\n${check.stdout}`);
+    assert.match(check.stdout, /verdict:\s+WAITING/);
   });
 });
 

--- a/tests/pr-merge-ready.test.mjs
+++ b/tests/pr-merge-ready.test.mjs
@@ -337,7 +337,7 @@ test("waits on a pending head check without merging", async () => {
     assert.equal(await readLog(gitLog), "");
 
     const check = run(env, ["--check"]);
-    assert.equal(check.status, 2, `${check.stderr}\n${check.stdout}`);
+    assert.equal(check.status, 3, `${check.stderr}\n${check.stdout}`);
     assert.match(check.stdout, /verdict:\s+WAITING/);
   });
 });

--- a/tests/test-file-deps.test.mjs
+++ b/tests/test-file-deps.test.mjs
@@ -28,5 +28,7 @@ test("pr-merge-ready treats completed CodeRabbit as informational and pending as
   assert.match(source, /gate_name" == "Kilo Code Review"/);
   assert.match(source, /gate_name" == "CodeRabbit" && -n "\$gate_pending"/);
   assert.match(source, /in_progress\/\*|queued\/\*|pending\/\*/);
+  assert.match(source, /GATE_WAITING/);
+  assert.match(source, /verdict:         WAITING/);
   assert.match(source, /REST PUT/);
 });


### PR DESCRIPTION
Process follow-up from this maintenance loop.

Hits encoded:

1. `pr-merge-ready --check` treated in-progress test shards as RED/`BLOCKED`. They are now `WAITING` (exit 2).
2. A `waiting:` list names the still-running required checks.
3. Merge still refuses until those checks finish.
4. Sync daemon health probes use `Atomics.wait`; a main-thread HTTP stub never accepts (tooling table).
5. Pending CodeRabbit stays blocking; completed CodeRabbit stays informational (already on main).

No product issue. CI-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Merge-readiness checks now distinguish pending checks from failed checks.
  - Reports show `WAITING` while required checks are still running; `BLOCKED` remains for failures, unresolved threads, thread-read failures, or current-head change requests.
  - `--check` returns a distinct exit code for `WAITING`, without attempting a merge.

- **Documentation**
  - Clarified that local HTTP sync-daemon probes should run against a worker-thread stub server because probes block the calling thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->