### PR TITLE
fix(bench): hash-bind online-adaptive contract generation

### DIFF
--- a/.changeset/3084-contract-generation.md
+++ b/.changeset/3084-contract-generation.md
@@ -1,0 +1,7 @@
+---
+"@remnic/bench": patch
+---
+
+Stability: stable
+
+Hash-bind online-adaptive metadata generation so stripping `attackerBaseUrl` and `unslicedPlannedRows` cannot skip resume-contract verification. Artifacts without `contractGeneration` stay on the closed legacy path.

--- a/packages/bench/src/security/injection-suite/online-adaptive-analysis.ts
+++ b/packages/bench/src/security/injection-suite/online-adaptive-analysis.ts
@@ -660,8 +660,12 @@ export async function analyzeInjectionSuiteOnlineAdaptiveRun(
   // generation (the frozen campaign set); they hashed a resolved attacker
   // URL they never persisted, so verification runs only when unsliced or
   // attackerBaseUrl is present.
+  const generationPresent = Object.hasOwn(metadata, "contractGeneration");
   const generationBound =
-    Number.isInteger(metadata.contractGeneration) && (metadata.contractGeneration ?? 0) >= 1;
+    generationPresent &&
+    Number.isInteger(metadata.contractGeneration) &&
+    (metadata.contractGeneration ?? 0) >= 1;
+  const generationInvalid = generationPresent && !generationBound;
   const newContract = metadata.attackerBaseUrl !== undefined;
   const digest = metadata.attackerModelDigest ?? "";
   const digestCandidates = digest === "unverified" ? [digest, ""] : [digest];
@@ -674,7 +678,8 @@ export async function analyzeInjectionSuiteOnlineAdaptiveRun(
   const limitedDesign = Number.isInteger(recordedLimit)
     && recordedLimit > 0
     && (unsliced === undefined || recordedLimit < unsliced)
-    || unslicedUnverifiable;
+    || unslicedUnverifiable
+    || generationInvalid;
   const incomplete =
     limitedDesign ||
     !corpusManifestPresent ||

--- a/packages/bench/src/security/injection-suite/online-adaptive-analysis.ts
+++ b/packages/bench/src/security/injection-suite/online-adaptive-analysis.ts
@@ -407,6 +407,8 @@ async function readCorpusManifest(runDir: string): Promise<{
 }
 
 export const INJECTION_SUITE_ONLINE_RESUME_CONTRACT = "h5-injection-suite-online-resume-v1";
+/** Hash-bound metadata generation. Absence is the closed legacy set (#3084). */
+export const INJECTION_SUITE_ONLINE_CONTRACT_GENERATION = 1;
 
 export function injectionSuiteResumeContractHashForOnline(metadata: {
   suiteVersion: string;
@@ -434,6 +436,7 @@ export function injectionSuiteResumeContractHashForOnline(metadata: {
   attackerModelDigest?: string;
   attackerPromptSha256?: string;
   attackerIterations?: number;
+  contractGeneration?: number;
 }): string {
   return createHash("sha256")
     .update(
@@ -469,6 +472,9 @@ export function injectionSuiteResumeContractHashForOnline(metadata: {
         attackerModelDigest: metadata.attackerModelDigest ?? "",
         attackerPromptSha256: metadata.attackerPromptSha256 ?? "",
         attackerIterations: metadata.attackerIterations ?? 0,
+        ...(metadata.contractGeneration === undefined
+          ? {}
+          : { contractGeneration: metadata.contractGeneration }),
       }),
     )
     .digest("hex");
@@ -646,28 +652,20 @@ export async function analyzeInjectionSuiteOnlineAdaptiveRun(
     && (metadata.unslicedPlannedRows ?? 0) > 0
     ? metadata.unslicedPlannedRows
     : undefined;
+  let unsliced = recordedUnsliced;
   // The value decides whether a limit truncated the design, so it is
   // tamper-evident: whenever it is recorded, the resume-contract hash must
-  // verify. A hand-edited count (stale, coerced, set equal to the limit, or
-  // paired with an edited `limit`/`null`) breaks the hash, and the run is
-  // then marked LIMITED rather than merely distrusted -- clearing the value
-  // alone would let a nulled `limit` read the run as complete (PR #3081 r3).
-  let unsliced = recordedUnsliced;
-  // The resume-contract hash is the arbiter. Runs on the NEW metadata
-  // contract (attackerBaseUrl persisted, which this code always writes) are
-  // verified UNCONDITIONALLY: every legitimate new state recomputes to its
-  // stored hash, so any mismatch -- an edited count, an edited or nulled
-  // limit, or the field deleted entirely -- marks the design LIMITED.
-  // LEGACY runs hashed a resolved attacker URL they never persisted, so
-  // their hash cannot be reconstructed; for them verification runs only
-  // when the unsliced field is present (superset of the pre-r8 behavior,
-  // and no frozen campaign run records a limit). Residual, documented: a
-  // new run stripped of attackerBaseUrl AND unsliced AND limit falls to the
-  // legacy path; closing that needs a contract version bump (post-cap r9).
+  // verify. Generation >= 1 (#3084) is hash-bound: every optional field
+  // participates and absence is verifiable. LEGACY artifacts have no
+  // generation (the frozen campaign set); they hashed a resolved attacker
+  // URL they never persisted, so verification runs only when unsliced or
+  // attackerBaseUrl is present.
+  const generationBound =
+    Number.isInteger(metadata.contractGeneration) && (metadata.contractGeneration ?? 0) >= 1;
   const newContract = metadata.attackerBaseUrl !== undefined;
   const digest = metadata.attackerModelDigest ?? "";
   const digestCandidates = digest === "unverified" ? [digest, ""] : [digest];
-  const mustVerify = newContract || unslicedPresent;
+  const mustVerify = generationBound || newContract || unslicedPresent;
   const resumeHashVerifies = !mustVerify || digestCandidates.some((candidate) =>
     injectionSuiteResumeContractHashForOnline({ ...metadata, attackerModelDigest: candidate })
       === metadata.resumeContractHash);

--- a/packages/bench/src/security/injection-suite/online-adaptive.test.ts
+++ b/packages/bench/src/security/injection-suite/online-adaptive.test.ts
@@ -29,6 +29,7 @@ import type {
 import {
   type OnlineAdaptiveCorpusLine,
   buildOnlineAdaptiveAttackerInput,
+  INJECTION_SUITE_ONLINE_CONTRACT_GENERATION,
   injectionSuiteResumeContractHashForOnline,
   onlineAdaptiveRejectionReason,
   onlineVariantFromBase,
@@ -1025,6 +1026,8 @@ async function writeOnlineFixture(
     unslicedPlannedRows?: number;
     /** Persisted attacker endpoint: opts the artifact into the new metadata contract (unconditional hash verification). */
     attackerBaseUrl?: string;
+    /** Hash-bound generation. Absence is the closed legacy set (#3084). */
+    contractGeneration?: number;
   } = {},
 ): Promise<void> {
   const design = {
@@ -1048,6 +1051,7 @@ async function writeOnlineFixture(
     limit: options.limit ?? null,
     ...(options.unslicedPlannedRows === undefined ? {} : { unslicedPlannedRows: options.unslicedPlannedRows }),
     ...(options.attackerBaseUrl === undefined ? {} : { attackerBaseUrl: options.attackerBaseUrl }),
+    ...(options.contractGeneration === undefined ? {} : { contractGeneration: options.contractGeneration }),
     expectedRows: planned.length,
     executor: "openai-compat",
     model: "fixture-defender",
@@ -1304,6 +1308,57 @@ test("a hand-edited unsliced count is distrusted via the resume-contract hash (P
     }
   } finally {
     await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("#3084 generation-bound full-strip stays limited; legacy stays estimable", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "online-generation-"));
+  try {
+    const planned = [
+      onlineIdentity("minja-1", 0),
+      onlineIdentity("minja-1", 1),
+      onlineIdentity("minja-1", 2),
+      onlineIdentity("minja-1", 3),
+    ];
+    await writeOnlineFixture(tmp, planned, {
+      corpusFor: planned.slice(1),
+      episodesFor: planned,
+      attackerIterations: 3,
+      limit: 4,
+      unslicedPlannedRows: 8,
+      attackerBaseUrl: "http://127.0.0.1:9",
+      contractGeneration: INJECTION_SUITE_ONLINE_CONTRACT_GENERATION,
+    });
+    const run = JSON.parse(await readFile(path.join(tmp, "run.json"), "utf8")) as Record<string, unknown>;
+    const { attackerBaseUrl: _url, unslicedPlannedRows: _rows, ...stripped } = run;
+    await writeFile(
+      path.join(tmp, "run.json"),
+      `${JSON.stringify({ ...stripped, limit: null })}\n`,
+      "utf8",
+    );
+    const generationBound = await analyzeInjectionSuiteOnlineAdaptiveRun(tmp);
+    assert.equal(generationBound.rowAccounting?.limitedDesign, true, "generation keeps verification after a full strip");
+    assert.equal(generationBound.decision.estimable, false);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+
+  const legacy = await mkdtemp(path.join(os.tmpdir(), "online-legacy-"));
+  try {
+    const planned = [
+      onlineIdentity("minja-1", 0),
+      onlineIdentity("minja-1", 1),
+    ];
+    await writeOnlineFixture(legacy, planned, {
+      corpusFor: planned.slice(1),
+      episodesFor: planned,
+      attackerIterations: 1,
+    });
+    const stats = await analyzeInjectionSuiteOnlineAdaptiveRun(legacy);
+    assert.equal(stats.rowAccounting?.limitedDesign, false, "a legacy artifact without generation stays estimable");
+    assert.equal(stats.decision.estimable, true);
+  } finally {
+    await rm(legacy, { recursive: true, force: true });
   }
 });
 

--- a/packages/bench/src/security/injection-suite/online-adaptive.test.ts
+++ b/packages/bench/src/security/injection-suite/online-adaptive.test.ts
@@ -1339,6 +1339,13 @@ test("#3084 generation-bound full-strip stays limited; legacy stays estimable", 
     const generationBound = await analyzeInjectionSuiteOnlineAdaptiveRun(tmp);
     assert.equal(generationBound.rowAccounting?.limitedDesign, true, "generation keeps verification after a full strip");
     assert.equal(generationBound.decision.estimable, false);
+    for (const bad of [0, 1.5, "1"]) {
+      const tampered = { ...stripped, limit: null, contractGeneration: bad };
+      tampered.resumeContractHash = injectionSuiteResumeContractHashForOnline(tampered as never);
+      await writeFile(path.join(tmp, "run.json"), `${JSON.stringify(tampered)}\n`, "utf8");
+      const invalid = await analyzeInjectionSuiteOnlineAdaptiveRun(tmp);
+      assert.equal(invalid.rowAccounting?.limitedDesign, true, `present invalid contractGeneration=${JSON.stringify(bad)} stays limited`);
+    }
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }

--- a/packages/bench/src/security/injection-suite/online-adaptive.test.ts
+++ b/packages/bench/src/security/injection-suite/online-adaptive.test.ts
@@ -1340,7 +1340,7 @@ test("#3084 generation-bound full-strip stays limited; legacy stays estimable", 
     assert.equal(generationBound.rowAccounting?.limitedDesign, true, "generation keeps verification after a full strip");
     assert.equal(generationBound.decision.estimable, false);
     for (const bad of [0, 1.5, "1"]) {
-      const tampered = { ...stripped, limit: null, contractGeneration: bad };
+      const tampered: Record<string, unknown> = { ...stripped, limit: null, contractGeneration: bad };
       tampered.resumeContractHash = injectionSuiteResumeContractHashForOnline(tampered as never);
       await writeFile(path.join(tmp, "run.json"), `${JSON.stringify(tampered)}\n`, "utf8");
       const invalid = await analyzeInjectionSuiteOnlineAdaptiveRun(tmp);

--- a/packages/bench/src/security/injection-suite/online-adaptive.ts
+++ b/packages/bench/src/security/injection-suite/online-adaptive.ts
@@ -82,15 +82,16 @@ import {
 } from "./types.js";
 import {
   corpusKey,
+  INJECTION_SUITE_ONLINE_CONTRACT_GENERATION,
   injectionSuiteResumeContractHashForOnline,
   ONLINE_ADAPTIVE_STAGE,
   readJsonlLines,
 } from "./online-adaptive-analysis.js";
-
 export { ONLINE_ADAPTIVE_STAGE };
 export {
   analyzeInjectionSuiteOnlineAdaptiveRows,
   analyzeInjectionSuiteOnlineAdaptiveRun,
+  INJECTION_SUITE_ONLINE_CONTRACT_GENERATION,
   injectionSuiteResumeContractHashForOnline,
 } from "./online-adaptive-analysis.js";
 export type {
@@ -722,6 +723,7 @@ export async function runInjectionSuiteOnlineAdaptive(
     attackerModelDigest: input.attackerModelDigest ?? "",
     attackerPromptSha256,
     attackerIterations: input.attackerIterations,
+    contractGeneration: INJECTION_SUITE_ONLINE_CONTRACT_GENERATION,
   });
 
   const existing = await readRunMetadata(input.outputDir);
@@ -776,6 +778,7 @@ export async function runInjectionSuiteOnlineAdaptive(
       // Persisted so the analyzer can recompute the resume hash exactly as
       // the runner did (PR #3081 r3); optional, so old runs are unaffected.
       ...(attacker.baseUrl ? { attackerBaseUrl: attacker.baseUrl } : {}),
+      contractGeneration: INJECTION_SUITE_ONLINE_CONTRACT_GENERATION,
       attackerModelDigest: input.attackerModelDigest ?? "unverified",
       attackerPromptSha256,
       attackerIterations: input.attackerIterations,

--- a/packages/bench/src/security/injection-suite/online-adaptive.ts
+++ b/packages/bench/src/security/injection-suite/online-adaptive.ts
@@ -733,9 +733,40 @@ export async function runInjectionSuiteOnlineAdaptive(
     );
   }
   if (existing && existing.resumeContractHash !== resumeContractHash) {
-    throw new Error(
-      "resume contract hash drifted; refusing to continue this run",
-    );
+    const legacyHash = Object.hasOwn(existing, "contractGeneration")
+      ? null
+      : injectionSuiteResumeContractHashForOnline({
+          suiteVersion: INJECTION_SUITE_VERSION,
+          modelProfileId: input.modelProfileId,
+          seeds,
+          variantsPerFamily: input.variantsPerFamily,
+          family: input.family ?? null,
+          limit: input.limit ?? null,
+          ...(input.limit === undefined ? {} : { unslicedPlannedRows }),
+          executor: defendedContract.executor,
+          model: defendedContract.model,
+          baseUrl: defendedContract.baseUrl,
+          requestTimeoutMs: defendedContract.requestTimeoutMs,
+          backend: defendedContract.backend,
+          stage: ONLINE_ADAPTIVE_STAGE,
+          runKind: input.runKind ?? "dev",
+          modelProfileHash: frozen.profile.modelProfileHash,
+          corpusManifestHash: frozen.corpusManifestHash,
+          expectedDesignHash: frozen.expectedDesignHash,
+          decisionRuleHash: frozen.decisionRuleHash,
+          gitSha: frozen.gitSha,
+          attackerExecutor: attacker.executor,
+          attackerModel: attacker.model,
+          attackerBaseUrl: attacker.baseUrl,
+          attackerModelDigest: input.attackerModelDigest ?? "",
+          attackerPromptSha256,
+          attackerIterations: input.attackerIterations,
+        });
+    if (legacyHash === null || existing.resumeContractHash !== legacyHash) {
+      throw new Error(
+        "resume contract hash drifted; refusing to continue this run",
+      );
+    }
   }
 
   await mkdir(input.outputDir, { recursive: true });

--- a/packages/bench/src/security/injection-suite/types.ts
+++ b/packages/bench/src/security/injection-suite/types.ts
@@ -202,6 +202,8 @@ export interface InjectionSuiteRunMetadata {
   unslicedPlannedRows?: number;
   /** Attacker endpoint, persisted for resume-hash recomputation (PR #3081 r3). */
   attackerBaseUrl?: string;
+  /** Hash-bound metadata generation. Absence is the closed legacy set (#3084). */
+  contractGeneration?: number;
   stage: InjectionSuiteStage;
   runKind: "dev" | "pilot" | "main";
   modelProfileHash: string;


### PR DESCRIPTION
Fixes #3084

Fold a hash-bound `contractGeneration` into the online-adaptive resume contract. Generation >= 1 makes verification mandatory even after `attackerBaseUrl` and `unslicedPlannedRows` are stripped. Artifacts with no generation stay on the closed legacy path.

Skipped: reconstructing the attacker URL from `model-profile.json` (defender endpoint only). Add when a persisted attacker URL exists on legacy artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added contract-generation metadata to online adaptive injection-suite runs.
  - Enhanced resume verification to validate artifacts tied to a contract generation.
  - Preserved compatibility for legacy artifacts without contract-generation metadata.

- **Bug Fixes**
  - Prevented stripped, generation-bound artifacts from incorrectly being treated as estimable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->